### PR TITLE
Migrate duroxide-pg-opt to microsoft org and pin duroxide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 
 # duroxide integration
-duroxide = "0.1.17"
-duroxide-pg-opt = { git = "https://github.com/Azure/duroxide-pg-opt.git", tag = "v0.1.15", package = "duroxide-pg-opt" }
+duroxide = "=0.1.17"
+duroxide-pg-opt = { git = "https://github.com/microsoft/duroxide-pg-opt.git", tag = "v0.1.15", package = "duroxide-pg-opt" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 
 # For ExecuteSQL activity (connecting back to PostgreSQL)


### PR DESCRIPTION
## Summary
- switch `duroxide-pg-opt` git source from Azure org to microsoft org
- pin `duroxide` to `=0.1.17` for compatibility with `duroxide-pg-opt` `v0.1.15`

## Validation
- `cargo clippy --features pg17 -- -D warnings`
