### PR TITLE
Refactor DSL to use nested JSON graph construction

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -138,6 +138,19 @@ Functions are persisted to disk. If PostgreSQL crashes:
 - In-progress steps resume from the last checkpoint
 - Pending steps execute when the server restarts
 
+### Graph Construction
+
+DSL functions build graph structures **in memory** without touching the database. Only when you call `df.start()` are the nodes written to the database:
+
+```sql
+-- This creates a JSON string representing the graph.
+SELECT 'SELECT 1' ~> 'SELECT 2';
+-- Returns: {"node_type":"THEN","left_node":{"node_type":"SQL","query":"SELECT 1"},"right_node":{"node_type":"SQL","query":"SELECT 2"}}
+
+-- Only df.start() writes to the database
+SELECT df.start('SELECT 1' ~> 'SELECT 2');
+```
+
 ---
 
 ## DSL Reference
@@ -1097,7 +1110,7 @@ SQL |=> 'step1': SELECT 1                    ✓ Completed
 **2. Dry-Run Preview** - Pass a DSL expression to visualize without executing:
 
 ```sql
-SELECT df.explain($$
+SELECT df.explain(
     'SELECT 1' |=> 'a'
     ~> 'SELECT 2' |=> 'b'
     ~> df.if(
@@ -1105,7 +1118,7 @@ SELECT df.explain($$
         'SELECT ''yes''',
         'SELECT ''no'''
     )
-$$);
+);
 ```
 
 Output shows the graph structure:
@@ -1133,7 +1146,7 @@ SQL |=> 'a': SELECT 1
 **ETL Pipeline with Parallel Validation:**
 
 ```sql
-SELECT df.explain($$
+SELECT df.explain(
     'SELECT * FROM staging WHERE status = ''pending'' LIMIT 1' |=> 'record'
     ~> df.if(
         'SELECT $record IS NOT NULL',
@@ -1150,7 +1163,7 @@ SELECT df.explain($$
             ),
         'SELECT ''no pending records'''
     )
-$$);
+);
 ```
 
 Output:
@@ -1177,7 +1190,7 @@ SQL |=> 'record': SELECT * FROM staging WHERE status = 'pending' LIMIT 1
 **Cron Job with Cleanup Loop:**
 
 ```sql
-SELECT df.explain($$
+SELECT df.explain(
     df.loop(
         df.wait_for_schedule('0 * * * *')
         ~> 'DELETE FROM logs WHERE created_at < now() - interval ''7 days''' |=> 'deleted'
@@ -1187,7 +1200,7 @@ SELECT df.explain($$
             'SELECT ''nothing to clean'''
         )
     )
-$$);
+);
 ```
 
 Output:
@@ -1207,7 +1220,7 @@ LOOP
 
 ```sql
 -- Visualize the daily-order-archive function before starting it
-SELECT df.explain($$
+SELECT df.explain(
     df.loop(
         df.wait_for_schedule('0 0 * * *')
         ~> 'SELECT COUNT(*) as cnt FROM playground.orders 
@@ -1224,7 +1237,7 @@ SELECT df.explain($$
              VALUES (''No orders to archive'')'
         )
     )
-$$);
+);
 ```
 
 Output:
@@ -1655,7 +1668,7 @@ SELECT df.signal('inst_id', 'approval', '{}');    -- send signal
 
 -- Visualize
 SELECT df.explain('instance_id');        -- live instance
-SELECT df.explain($$ 'a' ~> 'b' $$);     -- dry-run preview
+SELECT df.explain('a' ~> 'b');           -- dry-run preview
 
 -- Monitor
 SELECT * FROM df.list_instances();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,42 +186,47 @@ pub extern "C-unwind" fn _PG_init() {
 
 #### Durofut (Durable Future Reference)
 
-A `Durofut` represents a node in the function graph. It's serialized as JSON and passed between DSL functions.
+A `Durofut` represents an abstract function graph, sub-graph or leaf node. It's serialized as JSON and passed between DSL functions.
 
 ```rust
 // src/types.rs
 pub struct Durofut {
-    pub node_id: String,           // 8-char hex ID (e.g., "a1b2c3d4")
-    pub node_type: String,         // SQL, THEN, IF, JOIN, LOOP, etc.
-    pub left_node: Option<String>, // Left child node ID
-    pub right_node: Option<String>,// Right child node ID  
-    pub query: Option<String>,     // SQL query or config JSON
-    pub result_name: Option<String>, // Named result (from |=> operator)
+    pub node_type: String,                  // SQL, THEN, IF, JOIN, LOOP, etc.
+    pub left_node: Option<Box<Durofut>>,    // Embedded left child
+    pub right_node: Option<Box<Durofut>>,   // Embedded right child
+    pub query: Option<String>,              // SQL query or config JSON
+    pub result_name: Option<String>,        // Named result (from |=> operator)
 }
 ```
 
 When serialized to JSON:
 ```json
 {
-  "node_id": "a1b2c3d4",
-  "node_type": "SQL",
-  "query": "SELECT 1"
+  "node_type": "THEN",
+  "left_node": {
+    "node_type": "SQL",
+    "query": "SELECT 1"
+  },
+  "right_node": {
+    "node_type": "SQL",
+    "query": "SELECT 2"
+  }
 }
 ```
 
 #### FunctionNode (Database Representation)
 
-Nodes are persisted in `df.nodes`:
+`df.start(<function>)` adds a new row to `df.instances`, then iterates the nodes in the function graph bottom up, persisting each one to the `df.nodes` table along with the instance ID, a new ID for the node, and the IDs of its child nodes, if any.
 
 ```sql
 CREATE TABLE df.nodes (
     id VARCHAR(8) PRIMARY KEY,
-    instance_id VARCHAR(8),      -- Set by df.start() during linking
+    instance_id VARCHAR(8),      -- Set by df.start()
     node_type TEXT NOT NULL,     -- SQL, THEN, IF, JOIN, LOOP, etc.
     query TEXT,                  -- SQL query or config JSON
     result_name TEXT,            -- Named result for $variable substitution
-    left_node VARCHAR(8),        -- Left child
-    right_node VARCHAR(8),       -- Right child
+    left_node VARCHAR(8),        -- Left child ID
+    right_node VARCHAR(8),       -- Right child ID
     status TEXT DEFAULT 'pending',
     result JSONB,
     created_at TIMESTAMPTZ DEFAULT now()
@@ -230,7 +235,7 @@ CREATE TABLE df.nodes (
 
 ### DSL Functions
 
-Each DSL function (`df.sql`, `df.sleep`, `df.join`, etc.) creates a node and returns its JSON representation.
+Each DSL function (`df.sql`, `df.sleep`, `df.join`, etc.) creates a Durofut and returns its JSON representation. All graph construction is stateless.
 
 #### Example: `df.sql()`
 
@@ -238,16 +243,12 @@ Each DSL function (`df.sql`, `df.sleep`, `df.join`, etc.) creates a node and ret
 // src/dsl.rs
 #[pg_extern(schema = "df")]
 pub fn sql(query: &str) -> String {
-    let durofut = Durofut {
-        node_id: short_id(),              // Generate 8-char hex ID
+    Durofut {
         node_type: "SQL".to_string(),
-        left_node: None,
-        right_node: None,
-        query: Some(query.to_string()),   // Store the SQL query
-        result_name: None,
-    };
-    durofut.insert_node();                // INSERT INTO df.nodes
-    durofut.to_json()                     // Return JSON for chaining
+        query: Some(query.to_string()),
+        ..Default::default()
+    }
+    .to_json()
 }
 ```
 
@@ -259,16 +260,13 @@ pub fn then_fn(a: &str, b: &str) -> String {
     let a_fut = Durofut::ensure(a);       // Auto-wrap plain SQL if needed
     let b_fut = Durofut::ensure(b);
     
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "THEN".to_string(),
-        left_node: Some(a_fut.node_id),   // First step
-        right_node: Some(b_fut.node_id),  // Second step
-        query: None,
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        left_node: Some(Box::new(a_fut)),  // Embed first step
+        right_node: Some(Box::new(b_fut)), // Embed second step
+        ..Default::default()
+    }
+    .to_json()
 }
 ```
 
@@ -283,25 +281,20 @@ impl Durofut {
         if Self::is_durofut(s) {
             Self::from_json(s)           // Already a Durofut
         } else {
-            // Plain SQL string - create a SQL node
-            let fut = Durofut {
-                node_id: short_id(),
+            // Plain SQL string
+            Durofut {
                 node_type: "SQL".to_string(),
                 query: Some(s.to_string()),
                 ..Default::default()
-            };
-            fut.insert_node();
-            fut
+            }
         }
     }
     
     pub fn is_durofut(s: &str) -> bool {
-        // Check if valid JSON with 8-char hex node_id
-        if let Ok(fut) = serde_json::from_str::<Durofut>(s) {
-            fut.node_id.len() == 8 && fut.node_id.chars().all(|c| c.is_ascii_hexdigit())
-        } else {
-            false
-        }
+        // Check if valid JSON with a recognized node_type
+        serde_json::from_str::<Durofut>(s)
+            .map(|d| VALID_NODE_TYPES.contains(&d.node_type.as_str()))
+            .unwrap_or(false)
     }
 }
 ```
@@ -344,9 +337,9 @@ CREATE OPERATOR !> (FUNCTION = df.if_else_op, ...);
 CREATE OPERATOR @> (FUNCTION = df.loop_prefix_op, RIGHTARG = text);
 ```
 
-### Node Linking
+### Node Insertion
 
-When `df.start()` is called, it recursively links all nodes to the instance:
+When `df.start()` is called, it recursively inserts all nodes from the nested graph into the database:
 
 ```rust
 // src/dsl.rs - df.start()
@@ -354,42 +347,71 @@ pub fn start(fut: &str, label: Option<&str>) -> String {
     let durofut = Durofut::ensure(fut);
     let instance_id = short_id();
     
-    // Create instance record
-    Spi::run(&format!(
-        "INSERT INTO df.instances (id, label, root_node, status) 
-         VALUES ('{}', {}, '{}', 'pending')",
-        instance_id, label_sql, durofut.node_id
-    ));
-    
-    // Recursively link all nodes in the graph
-    fn link_nodes(node_id: &str, instance_id: &str, visited: &mut HashSet<String>) {
-        if visited.contains(node_id) { return; }
-        visited.insert(node_id.to_string());
+    // Recursively insert all nodes from the nested graph
+    // Note: No HashSet needed - nested graphs are trees, not DAGs
+    fn insert_nodes(node: &Durofut, instance_id: &str) -> String {
+        let node_id = short_id();  // Generate ID at insertion time
         
-        // Set instance_id on this node
-        Spi::run(&format!(
-            "UPDATE df.nodes SET instance_id = '{}' WHERE id = '{}'",
-            instance_id, node_id
-        ));
+        // Recursively insert children FIRST to get their IDs
+        let left_id = node.left_node.as_ref().map(|n| insert_nodes(n, instance_id));
+        let right_id = node.right_node.as_ref().map(|n| insert_nodes(n, instance_id));
         
-        // Get child nodes and recurse
-        let left = get_left_node(node_id);
-        let right = get_right_node(node_id);
-        let config = get_config(node_id);
-        
-        if let Some(l) = left { link_nodes(&l, instance_id, visited); }
-        if let Some(r) = right { link_nodes(&r, instance_id, visited); }
-        
-        // Handle extra nodes in config (e.g., condition_node, extra_nodes)
-        if let Some(cfg) = config {
-            if let Some(cond_id) = cfg["condition_node"].as_str() {
-                link_nodes(cond_id, instance_id, visited);
+        // Process config JSON to replace embedded Durofuts with IDs
+        // (for IF condition_node, LOOP condition_node, JOIN3 extra_nodes)
+        let query_escaped = if let Some(ref query_str) = node.query {
+            if let Ok(mut config) = serde_json::from_str::<serde_json::Value>(query_str) {
+                // For IF/LOOP nodes: replace condition_node Durofut with ID
+                if node.node_type == "IF" || node.node_type == "LOOP" {
+                    if let Some(cond_json) = config.get("condition_node") {
+                        if let Ok(cond_node) = serde_json::from_value::<Durofut>(cond_json.clone()) {
+                            let cond_id = insert_nodes(&cond_node, instance_id);
+                            config["condition_node"] = serde_json::json!(cond_id);
+                        }
+                    }
+                }
+                // For JOIN3 nodes: replace extra_nodes Durofuts with IDs
+                if node.node_type == "JOIN" {
+                    if let Some(extras) = config.get("extra_nodes").and_then(|e| e.as_array()) {
+                        let extra_ids: Vec<String> = extras.iter()
+                            .filter_map(|e| serde_json::from_value::<Durofut>(e.clone()).ok())
+                            .map(|n| insert_nodes(&n, instance_id))
+                            .collect();
+                        if !extra_ids.is_empty() {
+                            config["extra_nodes"] = serde_json::json!(extra_ids);
+                        }
+                    }
+                }
+                format!("'{}'", serde_json::to_string(&config).unwrap().replace('\'', "''"))
+            } else {
+                format!("'{}'", query_str.replace('\'', "''"))
             }
-            // ... handle extra_nodes for join3, etc.
-        }
+        } else {
+            "NULL".to_string()
+        };
+
+        // Insert this node with all fields
+        Spi::run(&format!(
+            "INSERT INTO df.nodes
+             (id, instance_id, node_type, query, result_name, left_node, right_node)
+             VALUES ('{}', '{}', '{}', {}, {}, {}, {})",
+            node_id, instance_id, node.node_type,
+            query_escaped,
+            escape_option(&node.result_name),
+            escape_option(&left_id),
+            escape_option(&right_id)
+        ));
+
+        node_id  // Return the generated ID
     }
     
-    link_nodes(&durofut.node_id, &instance_id, &mut HashSet::new());
+    let root_node_id = insert_nodes(&durofut, &instance_id);
+
+    // Create instance record with the root node ID
+    Spi::run(&format!(
+        "INSERT INTO df.instances (id, label, root_node, status)
+         VALUES ('{}', {}, '{}', 'pending')",
+        instance_id, label_sql, root_node_id
+    ));
     
     // Capture variables and enqueue to duroxide
     let vars = capture_vars();  // SELECT * FROM df.vars

--- a/docs/nested-graph-design.md
+++ b/docs/nested-graph-design.md
@@ -1,0 +1,369 @@
+# DSL Graph Construction Refactor: Nested JSON Design
+
+## Motivation
+
+The current DSL implementation inserts nodes into `df.nodes` during graph construction (e.g., inside `df.sql()`, `df.join()`, etc.). This creates several problems:
+
+1. **Premature database writes**: Graph construction performs I/O before `df.start()` is called
+2. **Orphaned nodes**: Errors during graph construction leave partial state in the database with no `instance_id`
+3. **No transaction management**: Nodes inserted before `df.start()` don't participate in transaction rollback
+4. **Complex explain mode**: Requires temporary tables and session variables to avoid polluting the database
+5. **No optimization opportunities**: Graph cannot be analyzed or transformed before execution
+6. **Accidental pollution**: Users experimenting with DSL expressions create database state
+
+### Example of Current Issues
+
+```sql
+-- Error creates orphaned node
+SELECT df.sql('SELECT 1') ~> df.sql('SYNTAX ERROR');
+-- First node inserted to df.nodes with no instance_id, never cleaned up
+
+-- Transaction rollback doesn't help
+BEGIN;
+SELECT df.sql('SELECT 1');
+ROLLBACK;
+-- Node still in df.nodes
+```
+
+## Design Approach: Nested JSON
+
+### Core Concept
+
+DSL functions return **self-contained JSON** that embeds the complete subtree, not just references to database-stored nodes. Graph construction becomes pure functional composition with no side effects.
+
+### Data Structure
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Durofut {
+    pub node_type: String,
+    pub query: Option<String>,
+    pub result_name: Option<String>,
+    // Children are embedded, not referenced by ID
+    // Node IDs are generated during df.start(), not during construction
+    pub left_node: Option<Box<Durofut>>,
+    pub right_node: Option<Box<Durofut>>,
+}
+```
+
+### Example Flow
+
+```sql
+-- df.sql() creates: {"node_type":"SQL","query":"SELECT 1",...}
+SELECT df.sql('SELECT 1');
+
+-- df.seq() embeds both children (no node IDs yet)
+SELECT df.sql('SELECT 1') ~> df.sql('SELECT 2');
+-- Returns:
+-- {
+--   "node_type":"THEN",
+--   "left_node": {"node_type":"SQL","query":"SELECT 1",...},
+--   "right_node": {"node_type":"SQL","query":"SELECT 2",...}
+-- }
+
+-- Node IDs are generated when df.start() inserts into df.nodes
+SELECT df.start(df.sql('SELECT 1') ~> df.sql('SELECT 2'));
+-- Now inserts all nodes with generated IDs and instance_id
+```
+
+### Benefits
+
+✅ **No database writes during construction** - Pure string manipulation
+✅ **Transaction-safe** - Only `df.start()` writes to the database
+✅ **No leaks on error** - Failed DSL calls leave no state
+✅ **Simple explain mode** - Just parse JSON and visualize
+✅ **Identical graphs produce identical JSON** - Enables caching and comparison
+✅ **Graph optimization** - Full graph available for analysis before execution
+✅ **User-friendly** - Can inspect intermediate graphs as JSON
+✅ **Stateless** - No TLS, no registry, no cleanup required
+
+### Trade-offs
+
+⚠️ **Larger JSON payloads** - Full tree instead of node IDs
+- Typical overhead: 200-500 bytes for common graphs vs. ~45 bytes + DB lookup
+- Still negligible for typical graphs (< 100 nodes)
+- Mitigated by only passing through function boundaries, not stored long-term
+
+## Discarded Approaches
+
+### 1. Thread-Local Storage (TLS)
+
+**Approach**: Store node arena in `thread_local!` registry, DSL functions return lightweight handles.
+
+**Why Rejected**:
+- PostgreSQL's `longjmp` error handling bypasses Rust destructors
+- TLS doesn't participate in subtransaction rollback
+- Memory leaks accumulate across queries in same session
+- Incompatible with parallel query execution
+- Background workers create separate TLS instances
+- Requires complex manual cleanup on every error path
+- Current database approach already has similar issues
+
+### 2. UUID-Keyed Global Registry
+
+**Approach**: `DashMap<Uuid, Arena<Node>>` with composite `GraphRef` type returned from SQL.
+
+**Why Rejected**:
+- Memory leaks when errors occur before `df.start()`
+- No automatic cleanup mechanism
+- Graph merging adds complexity (how to unify separate arenas?)
+- Requires PostgreSQL composite type overhead on every function call
+- Still needs manual cleanup strategy
+- More complex than nested JSON with no compelling benefit
+
+### 3. Use Temporary Tables for Graph Construction
+
+**Approach**: Create session-scoped temp tables for node storage during DSL construction, then copy to permanent tables in `df.start()`.
+
+```sql
+CREATE TEMP TABLE _dsl_nodes (LIKE df.nodes) ON COMMIT DROP;
+-- DSL functions insert to _dsl_nodes
+-- df.start() copies to df.nodes with instance_id
+```
+
+**Why Rejected**:
+- Still requires database I/O during graph construction (slower than in-memory)
+- Temp tables don't survive across function call boundaries reliably
+- `ON COMMIT DROP` semantics complicate multi-statement DSL composition
+- `ON COMMIT PRESERVE ROWS` leaks across queries in the same transaction
+- Adds complexity without solving the fundamental issue
+- Still need to handle cross-temp-table references for `Durofut.ensure()`
+- PostgreSQL temp table overhead for every DSL session
+- Nested JSON is simpler and faster
+
+## Implementation Plan
+
+### Phase 1: Update Type Definitions
+
+**File**: `src/types.rs`
+
+1. **Change `Durofut` structure**:
+   ```rust
+   pub struct Durofut {
+       pub node_type: String,
+       pub query: Option<String>,
+       pub result_name: Option<String>,
+       // Embed children directly, not by ID reference
+       // node_id is removed - IDs generated during df.start()
+       pub left_node: Option<Box<Durofut>>,
+       pub right_node: Option<Box<Durofut>>,
+   }
+   ```
+
+2. **Update serialization**:
+   - `to_json()` - already works with serde
+   - `from_json()` - already works with serde
+   - `is_durofut()` - simplified to just check deserialization
+   - `ensure()` - no node_id needed
+
+3. **Remove `insert_node()` method** - no longer needed in DSL functions
+
+4. **Remove `is_explain_mode()` function** - no longer needed
+
+5. **Update `ensure()` to not set node_id**:
+
+### Phase 2: Update DSL Functions
+
+**File**: [src/dsl.rs](../src/dsl.rs)
+
+All DSL functions updated to embed children as `Box<Durofut>` instead of storing ID references. No database writes during construction — just JSON composition.
+
+**Before** (old pattern — `join` as example):
+```rust
+let durofut = Durofut {
+    node_id: short_id(),
+    left_node: Some(a_fut.node_id),  // ID reference
+    right_node: Some(b_fut.node_id), // ID reference
+    ...
+};
+durofut.insert_node();  // Database write
+```
+
+**After** (new pattern):
+```rust
+let durofut = Durofut {
+    node_type: "JOIN".to_string(),
+    left_node: Some(Box::new(a_fut)),  // Embed child
+    right_node: Some(Box::new(b_fut)), // Embed child
+    ..Default::default()
+};
+durofut.to_json()  // No database write, no node_id
+```
+
+See [src/dsl.rs](../src/dsl.rs) for the full implementation.
+
+### Phase 3: Update `df.start()`
+
+**File**: [src/dsl.rs](../src/dsl.rs)
+
+`link_nodes()` replaced with `insert_nodes()` — a recursive function that:
+1. Generates node IDs via `short_id()` during insertion (post-order traversal)
+2. Inserts children before parents so their IDs are available
+3. Handles config-embedded children (IF condition, JOIN3 extras, LOOP condition) via `transform_config_children()`
+4. No `HashSet` needed — single tree traversal
+
+See `start()` → `insert_nodes()` in [src/dsl.rs](../src/dsl.rs) for the full implementation.
+
+### Phase 4: Update `df.explain()`
+
+**File**: [src/explain.rs](../src/explain.rs)
+
+Drastically simplified — no temp tables or database access needed for DSL expressions:
+
+1. `explain()` dispatches between instance IDs (8-char hex) and DSL expressions
+2. `explain_expression()` parses the nested JSON via `Durofut::ensure()`, then builds an in-memory node map with generated IDs (N1, N2, ...)
+3. `collect_nodes()` walks the tree recursively, handling config-embedded children via `transform_config_children()`
+4. Visualization uses the existing `build_tree_visualization()`
+
+**Removed**: `is_explain_mode()` checks, `df._explain_mode` session variable, `_durable_explain_nodes` temp table.
+
+See [src/explain.rs](../src/explain.rs) for the full implementation.
+
+### Phase 5: Test Updates
+
+#### Unit Tests
+
+**File**: `src/lib.rs` or test modules
+
+- Update any tests that inspect `df.nodes` before `df.start()`
+- Tests should now only verify JSON structure, not database state
+- Add tests for nested graph construction
+
+Example:
+```rust
+#[pg_test]
+fn test_nested_graph_construction() {
+    let result = Spi::get_one::<String>(
+        "SELECT df.sql('SELECT 1') ~> df.sql('SELECT 2')"
+    ).expect("query failed");
+
+    let graph: Durofut = serde_json::from_str(&result).expect("parse failed");
+    assert_eq!(graph.node_type, "THEN");
+    assert!(graph.left_node.is_some());
+    assert!(graph.right_node.is_some());
+}
+```
+
+#### E2E Tests
+
+**Directory**: `tests/e2e/sql/`
+
+Most E2E tests should work **without changes** because they:
+1. Build DSL expression
+2. Call `df.start()`
+3. Wait for completion
+4. Assert results
+
+**Tests that will need updates**:
+- `10_explain.sql` - Must change from `$$...$$` syntax to passing Durofut JSON or plain SQL directly to `df.explain()`
+- Any test that queries `df.nodes` before calling `df.start()`
+- Tests that verify node count or structure before execution
+
+**What to verify after changes**:
+- All existing E2E tests pass
+- Node insertion happens correctly in `df.start()`
+- `instance_id` is always set on all nodes
+- No orphaned nodes in `df.nodes` after errors
+
+### Phase 6: Documentation Updates
+
+#### USER_GUIDE.md
+
+Update sections on:
+- **Graph Construction**: Clarify that DSL functions don't write to database
+- **df.explain()**: Update to show it works on DSL expressions directly (no temp tables)
+- **Debugging**: Update guidance on inspecting graph JSON
+
+Example addition:
+```markdown
+### Understanding Graph Construction
+
+DSL functions build graph structures in memory without touching the database:
+
+```sql
+-- This creates JSON, not database records
+SELECT df.sql('SELECT 1') ~> df.sql('SELECT 2');
+
+-- Only df.start() writes to the database
+SELECT df.start(df.sql('SELECT 1') ~> df.sql('SELECT 2'));
+```
+
+You can inspect the graph structure by examining the JSON:
+```sql
+SELECT df.sql('SELECT 1') ~> df.sql('SELECT 2');
+-- Returns: {"node_type":"THEN",...}
+```
+```
+
+#### docs/ARCHITECTURE.md
+
+Update:
+- Data flow section to reflect new construction model
+- Remove mention of temp tables for explain mode
+- Add section on stateless DSL design
+
+#### README.md
+
+Update quick start examples if they reference graph construction details.
+
+## Implementation Checklist
+
+All items completed in commit `fdfbd44` and subsequent fixes:
+
+- [x] Update `Durofut` struct in `types.rs` to use `Box<Durofut>` for children
+- [x] Remove `insert_node()` method from `Durofut`
+- [x] Update `Durofut::ensure()` to not call `insert_node()`
+- [x] Remove `is_explain_mode()` function from `types.rs`
+- [x] Update all DSL functions in `dsl.rs` to embed children instead of storing IDs
+- [x] Remove `insert_node()` calls from all DSL functions
+- [x] Update `df.as_named()` to remove UPDATE query
+- [x] Replace `link_nodes()` with `insert_nodes()` in `df.start()`
+- [x] Add helper function for config node extraction (`for_each_config_child`, `transform_config_children`)
+- [x] Simplify `df.explain()` in `explain.rs` to parse nested JSON
+- [x] Remove temp table logic from `explain_expression()`
+- [x] Remove `df._explain_mode` session variable usage
+- [x] Update unit tests to verify JSON structure
+- [x] Run all E2E tests and fix any failures
+- [x] Update `USER_GUIDE.md` with new graph construction model
+- [x] Update `docs/ARCHITECTURE.md` with stateless design
+- [x] Update `README.md` if needed (checked — no stale references)
+- [x] Run `cargo fmt --all`
+- [x] Run `cargo clippy --features pg17` and fix warnings
+- [x] Run `./scripts/test-unit.sh`
+- [x] Run `./scripts/test-e2e-local.sh`
+
+## Migration Notes
+
+### Backward Compatibility
+
+**Breaking changes**:
+- Durofut JSON structure changes (children embedded vs. referenced)
+- Code relying on inspecting `df.nodes` before `df.start()` will break
+
+**Non-breaking**:
+- All SQL APIs remain the same (`df.sql()`, `df.start()`, etc.)
+- Existing workflows continue to work
+- Database schema unchanged
+
+### Rollout Strategy
+
+Completed — shipped in commit `fdfbd44` on branch `pinodeca/nested-graph` (PR #5).
+
+## Success Criteria
+
+✅ All unit tests pass
+✅ All E2E tests pass
+✅ No database writes during DSL construction
+✅ No orphaned nodes in `df.nodes`
+✅ `df.explain()` works on DSL expressions
+✅ No clippy warnings or format issues
+✅ Documentation updated and clear
+
+## Future Enhancements
+
+Once this is in place, we can:
+- **Graph optimization**: Dead code elimination, common subexpression elimination
+- **Validation**: Check for errors before execution (invalid SQL syntax, missing variables)
+- **Visualization**: Web UI for graph structure
+- **Compilation**: Pre-compile graphs to optimized execution plans
+- **Debugging**: Step through graph execution with breakpoints

--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -209,11 +209,11 @@ start_server() {
     fi
     
     # If server is running, we need to:
-    # 1. Drop duroxide schema (to clear any stale schema from previous duroxide-pg-opt version)
+    # 1. Drop extension + duroxide schema (to clear any stale schema from previous duroxide-pg-opt version)
     # 2. Restart server (so background worker reconnects with fresh cached plans)
     if "$PG_ISREADY" -h localhost -p $PG_PORT -U postgres &>/dev/null; then
-        # Drop schemas before restart (background worker will recreate on reconnect)
-        "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -c "DROP SCHEMA IF EXISTS duroxide CASCADE; DROP EXTENSION IF EXISTS pg_durable CASCADE;" >/dev/null 2>&1
+        # Drop extension (CASCADE also drops the owned duroxide schema)
+        "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -c "DROP EXTENSION IF EXISTS pg_durable CASCADE;" >/dev/null 2>&1
         echo -e "${YELLOW}Restarting PostgreSQL to reload extension...${NC}"
         stop_server
     fi
@@ -226,10 +226,13 @@ start_server() {
     if [ "$NO_PRELOAD" = true ]; then
         # Drop extension if it exists from a previous run (e.g., unit tests)
         # so the no-preload test can verify CREATE EXTENSION fails correctly
-        "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -c "DROP EXTENSION IF EXISTS pg_durable CASCADE; DROP SCHEMA IF EXISTS duroxide CASCADE;" >/dev/null 2>&1
+        "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -c "DROP EXTENSION IF EXISTS pg_durable CASCADE;" >/dev/null 2>&1
     else
-        # Create extension (duroxide schema will be created by background worker on first connect)
-        "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -c "CREATE EXTENSION IF NOT EXISTS pg_durable;" >/dev/null 2>&1
+        # Always drop and recreate extension to ensure PL/pgSQL functions from extension_sql!
+        # are up to date. Without this, a cached data directory (e.g. from CI) may have stale
+        # PL/pgSQL operator functions even though the Rust .so is updated by cargo pgrx install.
+        "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -c "DROP EXTENSION IF EXISTS pg_durable CASCADE;" >/dev/null 2>&1
+        "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -c "CREATE EXTENSION pg_durable;" >/dev/null 2>&1
     fi
 }
 

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -119,16 +119,12 @@ pub fn clearvars() -> String {
 /// Creates a SQL node in the function graph.
 #[pg_extern(schema = "df")]
 pub fn sql(query: &str) -> String {
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "SQL".to_string(),
-        left_node: None,
-        right_node: None,
         query: Some(query.to_string()),
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Creates a sequence node that executes two nodes in order.
@@ -139,16 +135,13 @@ pub fn then_fn(a: &str, b: &str) -> String {
     let a_fut = Durofut::ensure(a);
     let b_fut = Durofut::ensure(b);
 
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "THEN".to_string(),
-        left_node: Some(a_fut.node_id),
-        right_node: Some(b_fut.node_id),
-        query: None,
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        left_node: Some(Box::new(a_fut)),
+        right_node: Some(Box::new(b_fut)),
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Names a result for later reference.
@@ -160,13 +153,6 @@ pub fn as_named(fut: &str, name: &str) -> String {
     let mut durofut = Durofut::ensure(fut);
     durofut.result_name = Some(name.to_string());
 
-    let update_sql = format!(
-        "UPDATE df.nodes SET result_name = '{}' WHERE id = '{}'",
-        name.replace('\'', "''"),
-        durofut.node_id
-    );
-    let _ = Spi::run(&update_sql);
-
     durofut.to_json()
 }
 
@@ -176,16 +162,12 @@ pub fn sleep(seconds: i64) -> String {
     if seconds < 0 {
         pgrx::error!("Sleep duration must be non-negative");
     }
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "SLEEP".to_string(),
-        left_node: None,
-        right_node: None,
         query: Some(seconds.to_string()),
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Creates a wait-for-schedule node that waits until the next cron match.
@@ -214,16 +196,12 @@ pub fn wait_for_schedule(cron_expr: &str) -> String {
         "wait_seconds": duration_secs
     });
 
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "WAIT_SCHEDULE".to_string(),
-        left_node: None,
-        right_node: None,
         query: Some(config.to_string()),
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Creates a loop node.
@@ -246,26 +224,23 @@ pub fn wait_for_schedule(cron_expr: &str) -> String {
 pub fn loop_fn(body: &str, condition: default!(Option<&str>, "NULL")) -> String {
     let body_fut = Durofut::ensure(body);
 
-    let (right_node, query) = if let Some(cond) = condition {
+    let query = if let Some(cond) = condition {
         let cond_fut = Durofut::ensure(cond);
         let config = serde_json::json!({
-            "condition_node": cond_fut.node_id
+            "condition_node": cond_fut
         });
-        (Some(cond_fut.node_id), Some(config.to_string()))
+        Some(config.to_string())
     } else {
-        (None, None)
+        None
     };
 
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "LOOP".to_string(),
-        left_node: Some(body_fut.node_id),
-        right_node,
+        left_node: Some(Box::new(body_fut)),
         query,
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Creates a break node that exits the enclosing loop.
@@ -286,16 +261,12 @@ pub fn break_fn(value: default!(Option<&str>, "NULL")) -> String {
         "break_value": value
     });
 
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "BREAK".to_string(),
-        left_node: None,
-        right_node: None,
         query: Some(config.to_string()),
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Creates a conditional branch node.
@@ -307,19 +278,17 @@ pub fn if_fn(condition: &str, then_branch: &str, else_branch: &str) -> String {
     let else_fut = Durofut::ensure(else_branch);
 
     let config = serde_json::json!({
-        "condition_node": condition_fut.node_id
+        "condition_node": condition_fut
     });
 
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "IF".to_string(),
-        left_node: Some(then_fut.node_id),
-        right_node: Some(else_fut.node_id),
+        left_node: Some(Box::new(then_fut)),
+        right_node: Some(Box::new(else_fut)),
         query: Some(config.to_string()),
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Creates a parallel join node for 2 branches.
@@ -329,16 +298,13 @@ pub fn join(a: &str, b: &str) -> String {
     let a_fut = Durofut::ensure(a);
     let b_fut = Durofut::ensure(b);
 
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "JOIN".to_string(),
-        left_node: Some(a_fut.node_id),
-        right_node: Some(b_fut.node_id),
-        query: None,
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        left_node: Some(Box::new(a_fut)),
+        right_node: Some(Box::new(b_fut)),
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Creates a parallel join node for 3 branches.
@@ -350,19 +316,17 @@ pub fn join3(a: &str, b: &str, c: &str) -> String {
     let c_fut = Durofut::ensure(c);
 
     let config = serde_json::json!({
-        "extra_nodes": [c_fut.node_id]
+        "extra_nodes": [c_fut]
     });
 
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "JOIN".to_string(),
-        left_node: Some(a_fut.node_id),
-        right_node: Some(b_fut.node_id),
+        left_node: Some(Box::new(a_fut)),
+        right_node: Some(Box::new(b_fut)),
         query: Some(config.to_string()),
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Creates a race node - runs branches in parallel, first to complete wins.
@@ -372,16 +336,13 @@ pub fn race(a: &str, b: &str) -> String {
     let a_fut = Durofut::ensure(a);
     let b_fut = Durofut::ensure(b);
 
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "RACE".to_string(),
-        left_node: Some(a_fut.node_id),
-        right_node: Some(b_fut.node_id),
-        query: None,
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        left_node: Some(Box::new(a_fut)),
+        right_node: Some(Box::new(b_fut)),
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Creates an HTTP request node.
@@ -425,16 +386,12 @@ pub fn http(
         "timeout_seconds": timeout_seconds
     });
 
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "HTTP".to_string(),
-        left_node: None,
-        right_node: None,
         query: Some(config.to_string()),
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        ..Default::default()
+    }
+    .to_json()
 }
 
 // ============================================================================
@@ -471,16 +428,12 @@ pub fn wait_for_signal(name: &str, timeout_seconds: default!(Option<i32>, "NULL"
         "timeout_seconds": timeout_seconds
     });
 
-    let durofut = Durofut {
-        node_id: short_id(),
+    Durofut {
         node_type: "SIGNAL".to_string(),
-        left_node: None,
-        right_node: None,
         query: Some(config.to_string()),
-        result_name: None,
-    };
-    durofut.insert_node();
-    durofut.to_json()
+        ..Default::default()
+    }
+    .to_json()
 }
 
 /// Send a signal to a running durable function instance.
@@ -524,7 +477,15 @@ pub fn signal(instance_id: &str, signal_name: &str, signal_data: default!(&str, 
 /// Variables from df.vars are captured and passed to the orchestration.
 #[pg_extern(schema = "df")]
 pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
-    let durofut = Durofut::ensure(fut);
+    let durofut = match Durofut::ensure_strict(fut) {
+        Ok(d) => d,
+        Err(e) => pgrx::error!("Invalid durable function: {}", e),
+    };
+
+    // Validate the entire graph recursively before inserting
+    if let Err(e) = durofut.validate_recursive() {
+        pgrx::error!("Invalid durable function graph: {}", e);
+    }
     let instance_id = short_id();
 
     // Capture user identity for privilege isolation
@@ -538,11 +499,88 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
     let outer_oid_u32: u32 = outer_user_oid.into();
     let session_oid_u32: u32 = session_user_oid.into();
 
+    // Insert all nodes from the nested graph into df.nodes, returning root node ID
+    fn insert_nodes(
+        node: &Durofut,
+        instance_id: &str,
+        outer_user_oid: u32,
+        session_user_oid: u32,
+    ) -> String {
+        let node_id = short_id();
+
+        // Recursively insert children FIRST to get their IDs
+        let left_id = node
+            .left_node
+            .as_ref()
+            .map(|n| insert_nodes(n, instance_id, outer_user_oid, session_user_oid));
+        let right_id = node
+            .right_node
+            .as_ref()
+            .map(|n| insert_nodes(n, instance_id, outer_user_oid, session_user_oid));
+
+        // Process config JSON to recursively insert embedded nodes and get their IDs
+        let query_escaped = match node.transform_config_children(|child| {
+            Ok(insert_nodes(
+                child,
+                instance_id,
+                outer_user_oid,
+                session_user_oid,
+            ))
+        }) {
+            Ok(Some(updated_query)) => {
+                format!("'{}'", updated_query.replace('\'', "''"))
+            }
+            Ok(None) => "NULL".to_string(),
+            Err(e) => pgrx::error!("Invalid config in {} node: {}", node.node_type, e),
+        };
+
+        let result_name_escaped = node
+            .result_name
+            .as_ref()
+            .map(|n| format!("'{}'", n.replace('\'', "''")))
+            .unwrap_or_else(|| "NULL".to_string());
+
+        let left_node_escaped = left_id
+            .as_ref()
+            .map(|id| format!("'{id}'"))
+            .unwrap_or_else(|| "NULL".to_string());
+
+        let right_node_escaped = right_id
+            .as_ref()
+            .map(|id| format!("'{id}'"))
+            .unwrap_or_else(|| "NULL".to_string());
+
+        // Insert this node with the generated ID
+        let insert_sql = format!(
+            "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, login_role)
+             VALUES ('{}', '{}', '{}', {}, {}, {}, {}, {}::oid::regrole, {}::oid::regrole)",
+            node_id,
+            instance_id,
+            node.node_type.replace('\'', "''"),
+            query_escaped,
+            result_name_escaped,
+            left_node_escaped,
+            right_node_escaped,
+            outer_user_oid,
+            session_user_oid
+        );
+
+        if let Err(e) = Spi::run(&insert_sql) {
+            pgrx::error!("Failed to insert node {}: {:?}", node_id, e);
+        }
+
+        // Return the generated ID for parent to reference
+        node_id
+    }
+
+    let root_node_id = insert_nodes(&durofut, &instance_id, outer_oid_u32, session_oid_u32);
+
+    // Create instance record with root node ID
     let create_instance_sql = format!(
         "INSERT INTO df.instances (id, label, root_node, status, submitted_by, login_role) VALUES ('{}', {}, '{}', 'pending', {}::oid::regrole, {}::oid::regrole)",
         instance_id,
         label_sql,
-        durofut.node_id,
+        root_node_id,
         outer_oid_u32,
         session_oid_u32
     );
@@ -550,86 +588,6 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
     if let Err(e) = Spi::run(&create_instance_sql) {
         pgrx::error!("Failed to create instance: {:?}", e);
     }
-
-    // Link all nodes in the function graph to this instance and set identity
-    fn link_nodes(
-        node_id: &str,
-        instance_id: &str,
-        outer_user_oid: u32,
-        session_user_oid: u32,
-        visited: &mut std::collections::HashSet<String>,
-    ) {
-        if visited.contains(node_id) {
-            return;
-        }
-        visited.insert(node_id.to_string());
-
-        let update_sql = format!(
-            "UPDATE df.nodes SET instance_id = '{instance_id}', submitted_by = {outer_user_oid}::oid::regrole, login_role = {session_user_oid}::oid::regrole WHERE id = '{node_id}'"
-        );
-        let _ = Spi::run(&update_sql);
-
-        // Get child node IDs
-        let left: Option<String> = Spi::get_one(&format!(
-            "SELECT left_node FROM df.nodes WHERE id = '{node_id}'"
-        ))
-        .ok()
-        .flatten();
-
-        let right: Option<String> = Spi::get_one(&format!(
-            "SELECT right_node FROM df.nodes WHERE id = '{node_id}'"
-        ))
-        .ok()
-        .flatten();
-
-        let config: Option<String> = Spi::get_one(&format!(
-            "SELECT query FROM df.nodes WHERE id = '{node_id}'"
-        ))
-        .ok()
-        .flatten();
-
-        if let Some(l) = left {
-            link_nodes(&l, instance_id, outer_user_oid, session_user_oid, visited);
-        }
-        if let Some(r) = right {
-            link_nodes(&r, instance_id, outer_user_oid, session_user_oid, visited);
-        }
-        if let Some(config_str) = config {
-            if let Ok(cfg) = serde_json::from_str::<serde_json::Value>(&config_str) {
-                if let Some(cond_id) = cfg["condition_node"].as_str() {
-                    link_nodes(
-                        cond_id,
-                        instance_id,
-                        outer_user_oid,
-                        session_user_oid,
-                        visited,
-                    );
-                }
-                if let Some(extras) = cfg["extra_nodes"].as_array() {
-                    for extra in extras {
-                        if let Some(extra_id) = extra.as_str() {
-                            link_nodes(
-                                extra_id,
-                                instance_id,
-                                outer_user_oid,
-                                session_user_oid,
-                                visited,
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    let mut visited = std::collections::HashSet::new();
-    link_nodes(
-        &durofut.node_id,
-        &instance_id,
-        outer_oid_u32,
-        session_oid_u32,
-        &mut visited,
-    );
 
     // Capture vars from df.vars table
     let vars: std::collections::HashMap<String, String> = Spi::connect(|client| {

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -156,39 +156,74 @@ fn get_duroxide_instance_info(instance_id: &str) -> (String, Option<String>) {
     })
 }
 
+/// Check if input looks like a plain SQL statement (as opposed to a DSL expression).
+/// Returns true for inputs starting with SQL keywords like SELECT, INSERT, etc.
+fn looks_like_plain_sql(input: &str) -> bool {
+    let upper = input.trim_start().to_uppercase();
+    let sql_keywords = [
+        "SELECT ",
+        "INSERT ",
+        "UPDATE ",
+        "DELETE ",
+        "WITH ",
+        "CREATE ",
+        "ALTER ",
+        "DROP ",
+        "CALL ",
+        "DO ",
+        "TRUNCATE ",
+        "GRANT ",
+        "REVOKE ",
+        "EXPLAIN ",
+        "SELECT\n",
+        "INSERT\n",
+        "UPDATE\n",
+        "DELETE\n",
+        "WITH\n",
+    ];
+    sql_keywords.iter().any(|kw| upper.starts_with(kw))
+}
+
+/// Check if input looks like a DSL expression containing pg_durable operators or functions.
+/// DSL expressions contain operators like ~>, |=>, ?>, !>, @> or df.* function calls.
+fn looks_like_dsl_expression(input: &str) -> bool {
+    input.contains("~>")
+        || input.contains("|=>")
+        || input.contains("?>")
+        || input.contains("!>")
+        || input.contains("@>")
+        || input.contains("df.")
+}
+
 /// Explain a DSL expression without executing it
 fn explain_expression(expr: &str) -> String {
-    // 1. Create temp table for dry-run nodes
-    if let Err(e) = Spi::run(
-        r#"CREATE TEMP TABLE IF NOT EXISTS _durable_explain_nodes (
-            id VARCHAR(8) PRIMARY KEY,
-            instance_id VARCHAR(8),
-            node_type TEXT NOT NULL,
-            query TEXT,
-            result_name TEXT,
-            left_node VARCHAR(8),
-            right_node VARCHAR(8),
-            status TEXT DEFAULT 'pending',
-            result JSONB,
-            error TEXT,
-            created_at TIMESTAMPTZ DEFAULT now(),
-            updated_at TIMESTAMPTZ DEFAULT now()
-        )"#,
-    ) {
-        return format!("Failed to create temp table: {e:?}");
+    use crate::types::Durofut;
+
+    // First try to parse as Durofut JSON
+    if let Ok(root) = serde_json::from_str::<Durofut>(expr) {
+        // Build in-memory node map from nested structure with generated IDs
+        let mut nodes = HashMap::new();
+        let mut id_counter = 0;
+        let root_id = collect_nodes(&root, &mut nodes, &mut id_counter);
+        return build_tree_visualization(&root_id, &nodes, false);
     }
 
-    // Clear any previous dry-run nodes
-    let _ = Spi::run("TRUNCATE _durable_explain_nodes");
+    // If it looks like plain SQL (not a DSL expression), wrap it directly as a SQL node
+    // This prevents the "SELECT SELECT ..." problem when users pass plain SQL to explain
+    if looks_like_plain_sql(expr) && !looks_like_dsl_expression(expr) {
+        let sql_node = Durofut {
+            node_type: "SQL".to_string(),
+            query: Some(expr.to_string()),
+            ..Default::default()
+        };
+        let mut nodes = HashMap::new();
+        let mut id_counter = 0;
+        let root_id = collect_nodes(&sql_node, &mut nodes, &mut id_counter);
+        return build_tree_visualization(&root_id, &nodes, false);
+    }
 
-    // 2. Set explain mode flag
-    let _ = Spi::run("SET LOCAL df._explain_mode = 'true'");
-
-    // 3. Execute the expression to populate temp table
+    // DSL expression - evaluate it to build the graph
     let durofut_json: Result<Option<String>, _> = Spi::get_one(&format!("SELECT {expr}"));
-
-    // 4. Reset explain mode
-    let _ = Spi::run("RESET df._explain_mode");
 
     let root_json = match durofut_json {
         Ok(Some(json)) => json,
@@ -196,26 +231,67 @@ fn explain_expression(expr: &str) -> String {
         Err(e) => return format!("Failed to evaluate expression: {e:?}"),
     };
 
-    // Parse the root node ID from the Durofut JSON
-    let root_id = match serde_json::from_str::<serde_json::Value>(&root_json) {
-        Ok(v) => v["node_id"].as_str().unwrap_or("").to_string(),
-        Err(e) => return format!("Failed to parse result: {e:?}"),
+    // Parse the resulting JSON
+    let root = match serde_json::from_str::<Durofut>(&root_json) {
+        Ok(d) => d,
+        Err(e) => return format!("Failed to parse Durofut JSON: {e:?}"),
     };
 
-    if root_id.is_empty() {
-        return "Could not determine root node".to_string();
-    }
+    // Build in-memory node map from nested structure with generated IDs
+    let mut nodes = HashMap::new();
+    let mut id_counter = 0;
+    let root_id = collect_nodes(&root, &mut nodes, &mut id_counter);
 
-    // 5. Load nodes from temp table
-    let nodes = load_nodes_from_table("_durable_explain_nodes", None);
+    // Visualize (existing visualization code)
+    build_tree_visualization(&root_id, &nodes, false)
+}
 
-    // 6. Build visualization (without status markers for dry-run)
-    let result = build_tree_visualization(&root_id, &nodes, false);
+/// Collect all nodes from a nested Durofut structure into a flat HashMap
+/// Generates temporary IDs for visualization (e.g., "N1", "N2", ...)
+/// Returns the ID of the current node
+fn collect_nodes(
+    node: &crate::types::Durofut,
+    nodes: &mut HashMap<String, ExplainNode>,
+    id_counter: &mut i32,
+) -> String {
+    *id_counter += 1;
+    let node_id = format!("N{}", id_counter);
 
-    // 7. Cleanup temp table
-    let _ = Spi::run("DROP TABLE IF EXISTS _durable_explain_nodes");
+    // Recursively collect children first to get their IDs
+    let left_id = node
+        .left_node
+        .as_ref()
+        .map(|n| collect_nodes(n, nodes, id_counter));
+    let right_id = node
+        .right_node
+        .as_ref()
+        .map(|n| collect_nodes(n, nodes, id_counter));
 
-    result
+    // Process config JSON to collect embedded nodes and replace Durofuts with IDs
+    let updated_query =
+        match node.transform_config_children(|child| Ok(collect_nodes(child, nodes, id_counter))) {
+            Ok(q) => q,
+            Err(e) => {
+                // In explain context, report errors as part of the visualization rather than panicking
+                Some(format!("ERROR: {e}"))
+            }
+        };
+
+    nodes.insert(
+        node_id.clone(),
+        ExplainNode {
+            id: node_id.clone(),
+            node_type: node.node_type.clone(),
+            query: updated_query,
+            result_name: node.result_name.clone(),
+            left_node: left_id,
+            right_node: right_id,
+            status: None,
+            result: None,
+        },
+    );
+
+    node_id
 }
 
 /// Load nodes from a table into a HashMap

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,14 +296,30 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- Helper to ensure a value is a durofut (returns JSON string)
+-- Rejects JSON with unknown node_type values.
+-- NOTE: The valid node type list here must be kept in sync with
+-- VALID_NODE_TYPES in src/types.rs (the Rust constant is the canonical source).
 CREATE OR REPLACE FUNCTION df.ensure_durofut(val text) RETURNS text AS $$
+DECLARE
+    node_type_val text;
 BEGIN
     -- Try to parse as JSON to check if it's already a durofut
     BEGIN
-        IF (val::jsonb)->>'node_id' IS NOT NULL THEN
+        node_type_val := (val::jsonb)->>'node_type';
+        IF node_type_val IS NOT NULL THEN
+            -- Has a node_type - validate it
+            IF node_type_val NOT IN ('SQL', 'THEN', 'IF', 'JOIN', 'LOOP', 'BREAK', 'RACE', 'SLEEP', 'WAIT_SCHEDULE', 'HTTP', 'SIGNAL') THEN
+                RAISE EXCEPTION 'Unknown node_type ''%''. Valid types: SQL, THEN, IF, JOIN, LOOP, BREAK, RACE, SLEEP, WAIT_SCHEDULE, HTTP, SIGNAL', node_type_val;
+            END IF;
             RETURN val;
         END IF;
-    EXCEPTION WHEN OTHERS THEN
+    EXCEPTION WHEN invalid_text_representation THEN
+        -- Not valid JSON, treat as SQL
+        NULL;
+    WHEN raise_exception THEN
+        -- Re-raise our validation error
+        RAISE;
+    WHEN OTHERS THEN
         -- Not valid JSON, treat as SQL
         NULL;
     END;
@@ -500,7 +516,7 @@ mod tests {
         let json = crate::dsl::sql("SELECT 1");
         let fut = Durofut::from_json(&json);
         assert_eq!(fut.node_type, "SQL");
-        assert!(!fut.node_id.is_empty());
+        assert!(fut.query.is_some());
     }
 
     #[pg_test]
@@ -531,6 +547,28 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_sleep_node_is_recognized_as_durofut() {
+        // This test verifies that SLEEP nodes created by df.sleep() can be
+        // properly recognized and deserialized by Durofut::ensure()
+        let sleep_json = crate::dsl::sleep(1);
+
+        // Test that is_durofut recognizes it
+        assert!(
+            Durofut::is_durofut(&sleep_json),
+            "Durofut::is_durofut should recognize SLEEP node JSON: {}",
+            sleep_json
+        );
+
+        // Test that ensure doesn't wrap it in SQL
+        let ensured = Durofut::ensure(&sleep_json);
+        assert_eq!(
+            ensured.node_type, "SLEEP",
+            "Durofut::ensure should preserve SLEEP, not wrap as SQL"
+        );
+        assert_eq!(ensured.query, Some("1".to_string()));
+    }
+
+    #[pg_test]
     fn test_wait_for_schedule_valid_cron() {
         let json = crate::dsl::wait_for_schedule("*/5 * * * *");
         let fut = Durofut::from_json(&json);
@@ -554,9 +592,22 @@ mod tests {
         let json = crate::dsl::loop_fn(&body, Some(&condition));
         let fut = Durofut::from_json(&json);
         assert_eq!(fut.node_type, "LOOP");
-        assert!(fut.left_node.is_some()); // body
-        assert!(fut.right_node.is_some()); // condition
-        assert!(fut.query.is_some()); // has config with condition_node
+        assert!(fut.left_node.is_some(), "body should be set"); // body
+        assert!(
+            fut.right_node.is_none(),
+            "right_node should be None for LOOP"
+        ); // condition in config now
+        assert!(
+            fut.query.is_some(),
+            "should have config with condition_node"
+        ); // has config with condition_node
+
+        // Verify condition is embedded in config
+        let config: serde_json::Value = serde_json::from_str(fut.query.as_ref().unwrap()).unwrap();
+        assert!(
+            config.get("condition_node").is_some(),
+            "config should have condition_node"
+        );
     }
 
     #[pg_test]
@@ -590,6 +641,83 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_if_condition_embedded_in_config() {
+        // Verify that if_fn embeds condition as a nested Durofut in the config JSON,
+        // not as a string ID reference.
+        let condition = crate::dsl::sql("SELECT count(*) > 0 FROM tasks");
+        let then_branch = crate::dsl::sql("SELECT 'yes'");
+        let else_branch = crate::dsl::sql("SELECT 'no'");
+        let json = crate::dsl::if_fn(&condition, &then_branch, &else_branch);
+        let fut = Durofut::from_json(&json);
+
+        assert_eq!(fut.node_type, "IF");
+        assert!(fut.left_node.is_some(), "then branch should be left_node");
+        assert!(fut.right_node.is_some(), "else branch should be right_node");
+
+        // Parse the config to verify condition_node structure
+        let config: serde_json::Value = serde_json::from_str(fut.query.as_ref().unwrap()).unwrap();
+        let cond_node = config
+            .get("condition_node")
+            .expect("config should have condition_node");
+
+        // condition_node must be a nested Durofut object, not a string ID
+        assert!(
+            cond_node.is_object(),
+            "condition_node should be an object, not a string"
+        );
+        assert_eq!(cond_node["node_type"], "SQL");
+        assert_eq!(cond_node["query"], "SELECT count(*) > 0 FROM tasks");
+
+        // Verify it round-trips through validation
+        assert!(
+            fut.validate_recursive().is_ok(),
+            "IF with embedded condition should pass validation"
+        );
+    }
+
+    #[pg_test]
+    fn test_join3_extra_nodes_embedded_in_config() {
+        // Verify that join3 embeds the third branch as a nested Durofut in extra_nodes,
+        // not as a string ID reference.
+        let a = crate::dsl::sql("SELECT 1");
+        let b = crate::dsl::sql("SELECT 2");
+        let c = crate::dsl::sql("SELECT 3");
+        let json = crate::dsl::join3(&a, &b, &c);
+        let fut = Durofut::from_json(&json);
+
+        assert_eq!(fut.node_type, "JOIN");
+        assert!(fut.left_node.is_some(), "first branch should be left_node");
+        assert!(
+            fut.right_node.is_some(),
+            "second branch should be right_node"
+        );
+
+        // Parse the config to verify extra_nodes structure
+        let config: serde_json::Value = serde_json::from_str(fut.query.as_ref().unwrap()).unwrap();
+        let extras = config
+            .get("extra_nodes")
+            .and_then(|e| e.as_array())
+            .expect("config should have extra_nodes array");
+
+        assert_eq!(extras.len(), 1, "join3 should have exactly 1 extra node");
+
+        // extra_nodes[0] must be a nested Durofut object, not a string ID
+        let extra = &extras[0];
+        assert!(
+            extra.is_object(),
+            "extra_nodes entry should be an object, not a string"
+        );
+        assert_eq!(extra["node_type"], "SQL");
+        assert_eq!(extra["query"], "SELECT 3");
+
+        // Verify it round-trips through validation
+        assert!(
+            fut.validate_recursive().is_ok(),
+            "JOIN3 with embedded extra_nodes should pass validation"
+        );
+    }
+
+    #[pg_test]
     fn test_join_creates_join_node() {
         let a = crate::dsl::sql("SELECT 1");
         let b = crate::dsl::sql("SELECT 2");
@@ -607,7 +735,7 @@ mod tests {
         let json = crate::dsl::http("https://example.com/api", "GET", None, None, 30);
         let fut = Durofut::from_json(&json);
         assert_eq!(fut.node_type, "HTTP");
-        assert!(!fut.node_id.is_empty());
+        assert!(fut.query.is_some());
     }
 
     #[pg_test]
@@ -718,7 +846,7 @@ mod tests {
         let json = crate::dsl::wait_for_signal("approval", None);
         let fut = Durofut::from_json(&json);
         assert_eq!(fut.node_type, "SIGNAL");
-        assert!(!fut.node_id.is_empty());
+        assert!(fut.query.is_some());
 
         let config: serde_json::Value = serde_json::from_str(fut.query.as_ref().unwrap()).unwrap();
         assert_eq!(config["signal_name"], "approval");
@@ -842,10 +970,12 @@ mod tests {
 
     #[pg_test]
     fn test_multiple_starts_different_ids() {
+        // The same graph JSON can be reused with df.start() multiple times,
+        // each producing a distinct instance with its own node IDs.
         let fut = crate::dsl::sql("SELECT 1");
         let id1 = crate::dsl::start(&fut, None);
         let id2 = crate::dsl::start(&fut, None);
-        assert_ne!(id1, id2);
+        assert_ne!(id1, id2, "Each start should create a new instance");
     }
 
     #[pg_test]
@@ -1572,6 +1702,213 @@ mod tests {
             pg_status,
             Some("completed".to_string()),
             "Expected 'completed' in PostgreSQL table, got {pg_status:?}"
+        );
+    }
+
+    // ========================================================================
+    // Negative-path tests: validation, malformed config, ensure_strict
+    // ========================================================================
+
+    #[pg_test]
+    fn test_validate_rejects_malformed_condition_node_object() {
+        // A condition_node that is a JSON object but not a valid Durofut
+        // should be rejected by validate_recursive
+        let durofut = Durofut {
+            node_type: "IF".to_string(),
+            left_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 'then'".to_string()),
+                ..Default::default()
+            })),
+            right_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 'else'".to_string()),
+                ..Default::default()
+            })),
+            query: Some(r#"{"condition_node": {"foo": "bar"}}"#.to_string()),
+            ..Default::default()
+        };
+        let result = durofut.validate_recursive();
+        assert!(
+            result.is_err(),
+            "Should reject malformed condition_node object"
+        );
+        assert!(
+            result.unwrap_err().contains("condition_node"),
+            "Error should mention condition_node"
+        );
+    }
+
+    #[pg_test]
+    fn test_validate_rejects_condition_node_number() {
+        // condition_node as a number should be rejected
+        let durofut = Durofut {
+            node_type: "LOOP".to_string(),
+            left_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 1".to_string()),
+                ..Default::default()
+            })),
+            query: Some(r#"{"condition_node": 42}"#.to_string()),
+            ..Default::default()
+        };
+        let result = durofut.validate_recursive();
+        assert!(result.is_err(), "Should reject numeric condition_node");
+    }
+
+    #[pg_test]
+    fn test_validate_rejects_condition_node_string_id() {
+        // condition_node as a string ID (old format) should be rejected
+        let durofut = Durofut {
+            node_type: "IF".to_string(),
+            left_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 'then'".to_string()),
+                ..Default::default()
+            })),
+            right_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 'else'".to_string()),
+                ..Default::default()
+            })),
+            query: Some(r#"{"condition_node": "a1b2c3d4"}"#.to_string()),
+            ..Default::default()
+        };
+        let result = durofut.validate_recursive();
+        assert!(result.is_err(), "Should reject string ID condition_node");
+    }
+
+    #[pg_test]
+    fn test_validate_rejects_deeply_nested_invalid_node_type() {
+        // Valid outer graph but a deeply nested node has an invalid type
+        let inner_bad = Durofut {
+            node_type: "BOGUS".to_string(),
+            query: Some("SELECT 1".to_string()),
+            ..Default::default()
+        };
+        let middle = Durofut {
+            node_type: "THEN".to_string(),
+            left_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 1".to_string()),
+                ..Default::default()
+            })),
+            right_node: Some(Box::new(inner_bad)),
+            ..Default::default()
+        };
+        let root = Durofut {
+            node_type: "THEN".to_string(),
+            left_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 0".to_string()),
+                ..Default::default()
+            })),
+            right_node: Some(Box::new(middle)),
+            ..Default::default()
+        };
+        let result = root.validate_recursive();
+        assert!(
+            result.is_err(),
+            "Should catch invalid node_type deep in the tree"
+        );
+        assert!(
+            result.unwrap_err().contains("BOGUS"),
+            "Error should mention the invalid type"
+        );
+    }
+
+    #[pg_test]
+    fn test_validate_rejects_malformed_extra_nodes() {
+        // An extra_nodes entry that is not a valid Durofut
+        let durofut = Durofut {
+            node_type: "JOIN".to_string(),
+            left_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 1".to_string()),
+                ..Default::default()
+            })),
+            right_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 2".to_string()),
+                ..Default::default()
+            })),
+            query: Some(r#"{"extra_nodes": [{"not": "a durofut"}]}"#.to_string()),
+            ..Default::default()
+        };
+        let result = durofut.validate_recursive();
+        assert!(result.is_err(), "Should reject malformed extra_nodes entry");
+        assert!(
+            result.unwrap_err().contains("extra_nodes[0]"),
+            "Error should identify the index"
+        );
+    }
+
+    #[pg_test]
+    fn test_ensure_strict_malformed_structure_valid_type() {
+        // JSON with valid node_type but invalid structure (left_node as string)
+        let input = r#"{"node_type": "THEN", "left_node": "not-an-object"}"#;
+        let result = Durofut::ensure_strict(input);
+        assert!(result.is_err(), "Should reject malformed Durofut structure");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Malformed"),
+            "Error should say 'Malformed', got: {err}"
+        );
+        assert!(
+            !err.contains("Unknown node_type"),
+            "Error should NOT say 'Unknown node_type' for valid type, got: {err}"
+        );
+    }
+
+    #[pg_test]
+    fn test_ensure_strict_unknown_node_type() {
+        // JSON with truly unknown node_type
+        let input = r#"{"node_type": "BOGUS"}"#;
+        let result = Durofut::ensure_strict(input);
+        assert!(result.is_err(), "Should reject unknown node_type");
+        assert!(
+            result.unwrap_err().contains("Unknown node_type"),
+            "Error should say 'Unknown node_type'"
+        );
+    }
+
+    #[pg_test]
+    fn test_ensure_strict_plain_sql() {
+        // Non-JSON string should be treated as SQL
+        let result = Durofut::ensure_strict("SELECT 1");
+        assert!(result.is_ok());
+        let d = result.unwrap();
+        assert_eq!(d.node_type, "SQL");
+        assert_eq!(d.query, Some("SELECT 1".to_string()));
+    }
+
+    #[pg_test]
+    fn test_validate_accepts_valid_condition_node() {
+        // A properly formed IF node with embedded Durofut condition should pass
+        let condition = Durofut {
+            node_type: "SQL".to_string(),
+            query: Some("SELECT true".to_string()),
+            ..Default::default()
+        };
+        let config = serde_json::json!({ "condition_node": condition });
+        let durofut = Durofut {
+            node_type: "IF".to_string(),
+            left_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 'then'".to_string()),
+                ..Default::default()
+            })),
+            right_node: Some(Box::new(Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT 'else'".to_string()),
+                ..Default::default()
+            })),
+            query: Some(config.to_string()),
+            ..Default::default()
+        };
+        assert!(
+            durofut.validate_recursive().is_ok(),
+            "Valid IF graph should pass validation"
         );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,9 @@
 //! Core types and configuration for pg_durable
 
+use pgrx::pg_extern;
+
 use chrono::{DateTime, Utc};
 use cron::Schedule as CronSchedule;
-use pgrx::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::ffi::CString;
 use std::str::FromStr;
@@ -385,15 +386,31 @@ fn default_http_timeout() -> u64 {
 // Durofut Type - Represents a function node reference
 // ============================================================================
 
+/// Valid node types for Durofut nodes.
+pub const VALID_NODE_TYPES: &[&str] = &[
+    "SQL",
+    "THEN",
+    "IF",
+    "JOIN",
+    "LOOP",
+    "BREAK",
+    "RACE",
+    "SLEEP",
+    "WAIT_SCHEDULE",
+    "HTTP",
+    "SIGNAL",
+];
+
 /// The Durofut type represents a "durable future" - a reference to a node in the function graph.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Children are embedded as nested structures, not stored as ID references.
+/// Node IDs are generated during insertion into df.nodes, not during graph construction.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Durofut {
-    pub node_id: String,
     pub node_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub left_node: Option<String>,
+    pub left_node: Option<Box<Durofut>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub right_node: Option<String>,
+    pub right_node: Option<Box<Durofut>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -409,92 +426,211 @@ impl Durofut {
         serde_json::from_str(s).expect("failed to deserialize Durofut")
     }
 
-    /// Check if a string is a valid Durofut JSON
-    /// Returns true if it's valid JSON with a node_id field that looks like our format
+    /// Check if a string is a valid Durofut JSON with a recognized node_type
     pub fn is_durofut(s: &str) -> bool {
-        if let Ok(fut) = serde_json::from_str::<Durofut>(s) {
-            // Check if node_id is 8 hex characters (our format)
-            fut.node_id.len() == 8 && fut.node_id.chars().all(|c| c.is_ascii_hexdigit())
-        } else {
-            false
-        }
+        serde_json::from_str::<Durofut>(s)
+            .map(|d| VALID_NODE_TYPES.contains(&d.node_type.as_str()))
+            .unwrap_or(false)
     }
 
-    /// Ensure a string is a Durofut - if it's already one, parse it; if not, treat as SQL and create a node
+    /// Ensure a string is a Durofut - if it's already one, parse it; if not, treat as SQL and create a node.
+    /// Uses a single deserialization attempt to avoid redundant parsing.
     pub fn ensure(s: &str) -> Self {
-        if Self::is_durofut(s) {
-            Self::from_json(s)
-        } else {
-            // It's a plain SQL string - create a SQL node for it
-            let fut = Durofut {
-                node_id: short_id(),
+        match serde_json::from_str::<Durofut>(s) {
+            Ok(d) if VALID_NODE_TYPES.contains(&d.node_type.as_str()) => d,
+            _ => Durofut {
                 node_type: "SQL".to_string(),
-                left_node: None,
-                right_node: None,
                 query: Some(s.to_string()),
-                result_name: None,
-            };
-            fut.insert_node();
-            fut
+                ..Default::default()
+            },
         }
     }
 
-    /// Insert this node into the appropriate table (df.nodes or temp table in explain mode)
-    pub fn insert_node(&self) {
-        let query_escaped = self
-            .query
-            .as_ref()
-            .map(|q| q.replace('\'', "''"))
-            .map(|q| format!("'{q}'"))
-            .unwrap_or_else(|| "NULL".to_string());
+    /// Strict version of ensure - rejects JSON with unknown node_type instead of wrapping as SQL.
+    /// Used by df.start() and other entrypoints where invalid node types should be caught early.
+    pub fn ensure_strict(s: &str) -> Result<Self, String> {
+        match serde_json::from_str::<Durofut>(s) {
+            Ok(d) => {
+                if VALID_NODE_TYPES.contains(&d.node_type.as_str()) {
+                    Ok(d)
+                } else {
+                    Err(format!(
+                        "Unknown node_type '{}'. Valid types: {}",
+                        d.node_type,
+                        VALID_NODE_TYPES.join(", ")
+                    ))
+                }
+            }
+            Err(serde_err) => {
+                // Not valid Durofut JSON - try to parse as generic JSON to check for node_type
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(s) {
+                    if let Some(nt) = val.get("node_type").and_then(|v| v.as_str()) {
+                        if VALID_NODE_TYPES.contains(&nt) {
+                            // Valid node_type but malformed structure
+                            return Err(format!(
+                                "Malformed Durofut JSON with node_type '{}': {}",
+                                nt, serde_err
+                            ));
+                        }
+                        return Err(format!(
+                            "Unknown node_type '{}'. Valid types: {}",
+                            nt,
+                            VALID_NODE_TYPES.join(", ")
+                        ));
+                    }
+                }
+                // Not JSON at all or no node_type field - treat as SQL
+                Ok(Durofut {
+                    node_type: "SQL".to_string(),
+                    query: Some(s.to_string()),
+                    ..Default::default()
+                })
+            }
+        }
+    }
 
-        let result_name_escaped = self
-            .result_name
-            .as_ref()
-            .map(|n| format!("'{}'", n.replace('\'', "''")))
-            .unwrap_or_else(|| "NULL".to_string());
+    /// Validate a Durofut node and all its children have valid node_types.
+    /// Used during insertion in df.start() to catch invalid nested nodes.
+    pub fn validate_recursive(&self) -> Result<(), String> {
+        if !VALID_NODE_TYPES.contains(&self.node_type.as_str()) {
+            return Err(format!(
+                "Unknown node_type '{}'. Valid types: {}",
+                self.node_type,
+                VALID_NODE_TYPES.join(", ")
+            ));
+        }
+        if let Some(ref left) = self.left_node {
+            left.validate_recursive()?;
+        }
+        if let Some(ref right) = self.right_node {
+            right.validate_recursive()?;
+        }
+        // Validate config-embedded nodes (condition_node, extra_nodes)
+        self.for_each_config_child(|child| child.validate_recursive())?;
+        Ok(())
+    }
 
-        let left_node = self
-            .left_node
-            .as_ref()
-            .map(|id| format!("'{id}'"))
-            .unwrap_or_else(|| "NULL".to_string());
-
-        let right_node = self
-            .right_node
-            .as_ref()
-            .map(|id| format!("'{id}'"))
-            .unwrap_or_else(|| "NULL".to_string());
-
-        // Check if we're in explain mode - use temp table if so
-        let target_table = if is_explain_mode() {
-            "_durable_explain_nodes"
-        } else {
-            "df.nodes"
+    /// Extract config-embedded Durofut children from the `query` JSON field and apply
+    /// a callback to each. This is the single source of truth for walking `condition_node`
+    /// (in IF/LOOP nodes) and `extra_nodes` (in JOIN nodes).
+    ///
+    /// The callback receives each embedded child and returns `Result<(), String>`.
+    /// Parsing failures are always treated as errors — a `condition_node` or `extra_nodes`
+    /// entry that cannot be deserialized as a valid Durofut is rejected.
+    pub fn for_each_config_child<F>(&self, mut f: F) -> Result<(), String>
+    where
+        F: FnMut(&Durofut) -> Result<(), String>,
+    {
+        let query_str = match self.query.as_ref() {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+        let config = match serde_json::from_str::<serde_json::Value>(query_str) {
+            Ok(c) => c,
+            Err(_) => return Ok(()), // not JSON config, nothing to walk
         };
 
-        let sql = format!(
-            r#"INSERT INTO {} (id, node_type, query, result_name, left_node, right_node)
-               VALUES ('{}', '{}', {}, {}, {}, {})"#,
-            target_table,
-            self.node_id,
-            self.node_type,
-            query_escaped,
-            result_name_escaped,
-            left_node,
-            right_node
-        );
+        // IF/LOOP nodes: condition_node
+        if self.node_type == "IF" || self.node_type == "LOOP" {
+            if let Some(cond) = config.get("condition_node") {
+                let cond_node = serde_json::from_value::<Durofut>(cond.clone()).map_err(|e| {
+                    format!(
+                        "condition_node in {} must be a valid Durofut object, got {}: {}",
+                        self.node_type,
+                        summarize_json_type(cond),
+                        e
+                    )
+                })?;
+                f(&cond_node)?;
+            }
+        }
 
-        Spi::run(&sql).expect("failed to insert node");
+        // JOIN nodes: extra_nodes array
+        if self.node_type == "JOIN" {
+            if let Some(extras) = config.get("extra_nodes").and_then(|e| e.as_array()) {
+                for (i, extra) in extras.iter().enumerate() {
+                    let extra_node =
+                        serde_json::from_value::<Durofut>(extra.clone()).map_err(|e| {
+                            format!(
+                                "extra_nodes[{}] in {} must be a valid Durofut object: {}",
+                                i, self.node_type, e
+                            )
+                        })?;
+                    f(&extra_node)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Transform config-embedded Durofut children into string IDs via a callback,
+    /// returning the updated query JSON string. Used by `insert_nodes` and `collect_nodes`
+    /// to replace nested Durofut objects with generated node IDs.
+    ///
+    /// The callback receives each embedded child and returns the generated ID string.
+    /// Parsing failures are always treated as errors.
+    pub fn transform_config_children<F>(&self, mut f: F) -> Result<Option<String>, String>
+    where
+        F: FnMut(&Durofut) -> Result<String, String>,
+    {
+        let query_str = match self.query.as_ref() {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        let mut config = match serde_json::from_str::<serde_json::Value>(query_str) {
+            Ok(c) => c,
+            Err(_) => return Ok(Some(query_str.clone())), // not JSON, pass through as-is
+        };
+
+        // IF/LOOP nodes: condition_node
+        if self.node_type == "IF" || self.node_type == "LOOP" {
+            if let Some(cond) = config.get("condition_node") {
+                let cond_node = serde_json::from_value::<Durofut>(cond.clone()).map_err(|e| {
+                    format!(
+                        "condition_node in {} must be a valid Durofut object, got {}: {}",
+                        self.node_type,
+                        summarize_json_type(cond),
+                        e
+                    )
+                })?;
+                let cond_id = f(&cond_node)?;
+                config["condition_node"] = serde_json::json!(cond_id);
+            }
+        }
+
+        // JOIN nodes: extra_nodes array
+        if self.node_type == "JOIN" {
+            if let Some(extras) = config.get("extra_nodes").and_then(|e| e.as_array()) {
+                let mut extra_ids: Vec<String> = Vec::new();
+                for (i, extra) in extras.iter().enumerate() {
+                    let extra_node =
+                        serde_json::from_value::<Durofut>(extra.clone()).map_err(|e| {
+                            format!(
+                                "extra_nodes[{}] in {} must be a valid Durofut object: {}",
+                                i, self.node_type, e
+                            )
+                        })?;
+                    extra_ids.push(f(&extra_node)?);
+                }
+                if !extra_ids.is_empty() {
+                    config["extra_nodes"] = serde_json::json!(extra_ids);
+                }
+            }
+        }
+
+        Ok(Some(serde_json::to_string(&config).unwrap()))
     }
 }
 
-/// Check if we're in explain mode (for dry-run graph visualization)
-pub fn is_explain_mode() -> bool {
-    Spi::get_one::<bool>(
-        "SELECT COALESCE(current_setting('df._explain_mode', true), 'false') = 'true'",
-    )
-    .ok()
-    .flatten()
-    .unwrap_or(false)
+/// Helper to describe a JSON value type for error messages
+fn summarize_json_type(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "a boolean",
+        serde_json::Value::Number(_) => "a number",
+        serde_json::Value::String(_) => "a string",
+        serde_json::Value::Array(_) => "an array",
+        serde_json::Value::Object(_) => "an object",
+    }
 }

--- a/tests/e2e/sql/30_graph_reuse.sql
+++ b/tests/e2e/sql/30_graph_reuse.sql
@@ -1,0 +1,126 @@
+-- Test: Graph Reuse with Identical Durofut JSON
+-- Verifies that:
+-- 1. A graph can be stored and called with df.start() later
+-- 2. Two identical DSL expressions produce identical Durofut JSON
+-- 3. Graphs can be reused multiple times
+
+-- Setup: Create test table
+DROP TABLE IF EXISTS test_graph_reuse;
+CREATE TABLE test_graph_reuse (
+    id SERIAL PRIMARY KEY,
+    value INT
+);
+
+-- Test 1: Store a graph and start it later
+-- Build a graph and store it in a variable
+CREATE TEMP TABLE _stored_graph AS
+SELECT 'SELECT 1' ~> 'INSERT INTO test_graph_reuse (value) VALUES (1)' AS graph_json;
+
+-- Start the graph from the stored value (first execution)
+CREATE TEMP TABLE _test1_instance1 AS
+SELECT df.start((SELECT graph_json FROM _stored_graph), 'test-reuse-1') AS instance_id;
+
+-- Wait for first execution
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test1_instance1;
+
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'cancelled') OR attempts > 300;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED: First execution status = %', status;
+    END IF;
+
+    RAISE NOTICE 'First execution completed';
+END $$;
+
+-- Start the same graph again (second execution)
+CREATE TEMP TABLE _test1_instance2 AS
+SELECT df.start((SELECT graph_json FROM _stored_graph), 'test-reuse-2') AS instance_id;
+
+-- Wait for second execution
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test1_instance2;
+
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'cancelled') OR attempts > 300;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED: Second execution status = %', status;
+    END IF;
+
+    RAISE NOTICE 'Second execution completed';
+END $$;
+
+-- Verify both executions worked
+DO $$
+BEGIN
+    IF (SELECT COUNT(*) FROM test_graph_reuse) != 2 THEN
+        RAISE EXCEPTION 'TEST FAILED: Expected 2 rows, got %', (SELECT COUNT(*) FROM test_graph_reuse);
+    END IF;
+
+    RAISE NOTICE 'Test 1 PASSED: Graph stored and reused successfully';
+END $$;
+
+DROP TABLE _stored_graph;
+DROP TABLE _test1_instance1;
+DROP TABLE _test1_instance2;
+
+-- Test 2: Verify identical DSL expressions produce identical JSON
+-- Two identical graphs should have identical Durofut JSON representation
+DO $$
+DECLARE
+    graph1 TEXT;
+    graph2 TEXT;
+BEGIN
+    -- Build two identical graphs separately
+    SELECT 'SELECT 2' ~> 'SELECT 3' INTO graph1;
+    SELECT 'SELECT 2' ~> 'SELECT 3' INTO graph2;
+
+    -- The JSON representations should be identical
+    IF graph1 IS DISTINCT FROM graph2 THEN
+        RAISE EXCEPTION 'TEST FAILED: Identical DSL expressions produced different JSON. Graph 1: %, Graph 2: %', graph1, graph2;
+    END IF;
+
+    RAISE NOTICE 'Test 2 PASSED: Identical DSL expressions produce identical Durofut JSON';
+END $$;
+
+-- Test 3: Different graphs should have different JSON
+DO $$
+DECLARE
+    graph1 TEXT;
+    graph2 TEXT;
+BEGIN
+    -- Build two different graphs
+    SELECT 'SELECT 4' ~> 'SELECT 5' INTO graph1;
+    SELECT 'SELECT 6' ~> 'SELECT 7' INTO graph2;
+
+    -- JSON representations should be different
+    IF graph1 = graph2 THEN
+        RAISE EXCEPTION 'TEST FAILED: Different graphs produced identical JSON: %', graph1;
+    END IF;
+
+    RAISE NOTICE 'Test 3 PASSED: Different graphs produce different Durofut JSON';
+END $$;
+
+-- Cleanup
+DROP TABLE test_graph_reuse;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/31_explain_plain_sql.sql
+++ b/tests/e2e/sql/31_explain_plain_sql.sql
@@ -1,0 +1,21 @@
+-- Test: Explain on plain SQL input (auto-wrap)
+-- Expected: df.explain('SELECT 1') produces a SQL node visualization
+
+DO $body$
+DECLARE
+    explain_output TEXT;
+BEGIN
+    SELECT df.explain('SELECT 1') INTO explain_output;
+
+    IF explain_output IS NULL OR explain_output = '' THEN
+        RAISE EXCEPTION 'TEST FAILED: explain returned empty output';
+    END IF;
+
+    IF explain_output NOT LIKE '%SQL:%' OR explain_output NOT LIKE '%SELECT 1%' THEN
+        RAISE EXCEPTION 'TEST FAILED: explain should show SQL: SELECT 1, got: %', explain_output;
+    END IF;
+
+    RAISE NOTICE 'TEST PASSED: explain plain SQL';
+END $body$;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/32_invalid_node_type.sql
+++ b/tests/e2e/sql/32_invalid_node_type.sql
@@ -1,0 +1,25 @@
+-- Test: Reject invalid Durofut JSON node_type
+-- Expected: df.start('{"node_type":"NOT_A_NODE"}') raises an error
+
+DO $body$
+BEGIN
+    BEGIN
+        PERFORM df.start('{"node_type":"NOT_A_NODE"}');
+        RAISE EXCEPTION 'TEST FAILED: df.start should have rejected invalid node_type';
+    EXCEPTION WHEN OTHERS THEN
+        -- ok
+        RAISE NOTICE 'Caught expected error: %', SQLERRM;
+    END;
+
+    BEGIN
+        PERFORM df.explain('{"node_type":"NOT_A_NODE"}');
+        -- explain returns a string; it should contain our error text, not crash.
+        -- If it returned empty, that would be suspicious.
+    EXCEPTION WHEN OTHERS THEN
+        RAISE EXCEPTION 'TEST FAILED: df.explain should not raise on invalid node_type';
+    END;
+
+    RAISE NOTICE 'TEST PASSED: invalid node_type handling';
+END $body$;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/33_malformed_condition_node.sql
+++ b/tests/e2e/sql/33_malformed_condition_node.sql
@@ -1,0 +1,76 @@
+-- Test: Reject malformed condition_node in IF/LOOP nodes
+-- Verifies that hand-crafted JSON with invalid condition_node is caught
+
+-- Test 1: condition_node as a non-Durofut object should be rejected by df.start()
+DO $body$
+BEGIN
+    BEGIN
+        PERFORM df.start('{
+            "node_type": "IF",
+            "left_node": {"node_type": "SQL", "query": "SELECT 1"},
+            "right_node": {"node_type": "SQL", "query": "SELECT 2"},
+            "query": "{\"condition_node\": {\"foo\": \"bar\"}}"
+        }');
+        RAISE EXCEPTION 'TEST FAILED: df.start should have rejected malformed condition_node';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM LIKE '%condition_node%' THEN
+            RAISE NOTICE 'Test 1 PASSED: Caught malformed condition_node object: %', SQLERRM;
+        ELSE
+            RAISE EXCEPTION 'TEST FAILED: Wrong error for malformed condition_node: %', SQLERRM;
+        END IF;
+    END;
+END $body$;
+
+-- Test 2: condition_node as a string ID (old format) should be rejected
+DO $body$
+BEGIN
+    BEGIN
+        PERFORM df.start('{
+            "node_type": "LOOP",
+            "left_node": {"node_type": "SQL", "query": "SELECT 1"},
+            "query": "{\"condition_node\": \"a1b2c3d4\"}"
+        }');
+        RAISE EXCEPTION 'TEST FAILED: df.start should have rejected string condition_node';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM LIKE '%condition_node%' THEN
+            RAISE NOTICE 'Test 2 PASSED: Caught string condition_node: %', SQLERRM;
+        ELSE
+            RAISE EXCEPTION 'TEST FAILED: Wrong error for string condition_node: %', SQLERRM;
+        END IF;
+    END;
+END $body$;
+
+-- Test 3: condition_node as a number should be rejected
+DO $body$
+BEGIN
+    BEGIN
+        PERFORM df.start('{
+            "node_type": "IF",
+            "left_node": {"node_type": "SQL", "query": "SELECT 1"},
+            "right_node": {"node_type": "SQL", "query": "SELECT 2"},
+            "query": "{\"condition_node\": 42}"
+        }');
+        RAISE EXCEPTION 'TEST FAILED: df.start should have rejected numeric condition_node';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM LIKE '%condition_node%' THEN
+            RAISE NOTICE 'Test 3 PASSED: Caught numeric condition_node: %', SQLERRM;
+        ELSE
+            RAISE EXCEPTION 'TEST FAILED: Wrong error for numeric condition_node: %', SQLERRM;
+        END IF;
+    END;
+END $body$;
+
+-- Test 4: Valid condition_node (produced by DSL) should work fine
+DO $body$
+DECLARE
+    graph TEXT;
+BEGIN
+    SELECT df.if('SELECT true', 'SELECT 1', 'SELECT 2') INTO graph;
+    -- Just verify it parses — don't start it (would need worker)
+    IF graph IS NULL THEN
+        RAISE EXCEPTION 'TEST FAILED: df.if should return non-null graph';
+    END IF;
+    RAISE NOTICE 'Test 4 PASSED: Valid IF graph produced: %', left(graph, 80);
+END $body$;
+
+SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## Summary

Refactors the DSL graph construction to use **nested JSON** instead of inserting nodes into `df.nodes` during construction. DSL functions now return self-contained JSON that embeds the complete subtree. Node IDs are only generated when `df.start()` is called, which is the single point where database writes occur.

## Motivation

The previous implementation inserted nodes into `df.nodes` during graph construction (inside `df.sql()`, `df.join()`, etc.), causing several problems:

1. **Premature database writes** — Graph construction performed I/O before `df.start()` was called
2. **Orphaned nodes** — Errors during graph construction left partial state in the database with no `instance_id`
3. **No transaction management** — Nodes inserted before `df.start()` did not participate in transaction rollback
4. **Complex explain mode** — Required temporary tables and session variables to avoid polluting the database

## Design

DSL functions now return **self-contained JSON** with embedded children instead of database-stored node ID references:

```sql
-- df.sql() creates: {"node_type":"SQL","query":"SELECT 1",...}
-- Chaining embeds children directly (no node IDs yet):
SELECT df.sql('SELECT 1') ~> df.sql('SELECT 2');
-- Returns:
-- {
--   "node_type":"THEN",
--   "left_node": {"node_type":"SQL","query":"SELECT 1",...},
--   "right_node": {"node_type":"SQL","query":"SELECT 2",...}
-- }

-- Node IDs are generated only when df.start() inserts into df.nodes
SELECT df.start(df.sql('SELECT 1') ~> df.sql('SELECT 2'));
```

## Key Changes

### `src/types.rs`
- `Durofut` struct now uses `Option<Box<Durofut>>` for `left_node` and `right_node` (embedded children instead of ID references)
- Removed `node_id` field — IDs are generated during `df.start()`
- Removed `insert_node()` method — no database writes during construction
- Removed `is_explain_mode()` — no longer needed
- `ensure()` simplified — no node insertion

### `src/dsl.rs`
- All DSL functions (`sql`, `seq`, `join`, `race`, `if_fn`, `loop_fn`, `sleep`, `http`, etc.) updated to embed children directly
- Removed all `insert_node()` calls from DSL functions
- `df.start()` now contains `insert_nodes()` which recursively traverses the nested graph, generates node IDs, and inserts all nodes in a single pass
- `df.as_named()` no longer writes to database

### `src/explain.rs`
- Drastically simplified — parses nested JSON directly instead of using temp tables
- Removed `_explain_mode` session variable and temp table logic
- `explain_expression()` generates temporary IDs (N1, N2, ...) for visualization
- `explain_instance()` unchanged (reads from `df.nodes` for running instances)
- Now supports explaining plain SQL strings (auto-wrapped with `df.sql()`)

### `src/types.rs` — Strict validation
- `node_type` validation added with strict allowlist
- Config-embedded nodes (IF condition, LOOP condition, JOIN3 extras) now validated during `insert_nodes()`

## Benefits

- **No database writes during construction** — Pure string/JSON manipulation
- **Transaction-safe** — Only `df.start()` writes to the database
- **No orphaned nodes** — Failed DSL calls leave no state
- **Simple explain mode** — Just parse JSON and visualize, no temp tables
- **Stateless** — No TLS, no registry, no cleanup required

## Testing

- All existing E2E tests pass without modification
- Unit tests updated to verify JSON structure
- `cargo clippy` and `cargo fmt` clean

See [docs/nested-graph-design.md](docs/nested-graph-design.md) for full design document including discarded alternatives.