### PR TITLE
Add Copilot setup workflow so coding agent can access duroxide-pg-opt private repo

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,49 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 59
+    environment: copilot
+
+    # Least privilege; checkout needs contents:read.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      # Strongly recommended for private git deps + auth in CI-like envs
+      - name: Configure Cargo to use git CLI
+        run: |
+          mkdir -p ~/.cargo
+          cat >> ~/.cargo/config.toml << 'EOF'
+          [net]
+          git-fetch-with-cli = true
+          EOF
+
+      # Provide non-interactive auth for *all* https://github.com/* git fetches
+      # using an environment secret in the `copilot` environment.
+      - name: Configure git auth for private GitHub deps (PAT)
+        run: |
+          test -n "${{ secrets.DUROXIDE_PG_OPT_TOKEN }}"
+          git config --global --add url."https://x-access-token:${{ secrets.DUROXIDE_PG_OPT_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global --add url."https://x-access-token:${{ secrets.DUROXIDE_PG_OPT_TOKEN }}@github.com/".insteadOf "https://api.github.com/"
+
+      # Warm the Cargo git/db caches so later `cargo update/test` is fast and reliable.
+      - name: Prefetch Rust dependencies (including private git deps)
+        run: |
+          cargo fetch


### PR DESCRIPTION
## Summary
- add a new workflow at .github/workflows/copilot-setup-steps.yml
- trigger on workflow_dispatch, pushes to this workflow file, and pull requests touching this workflow file
- install a stable Rust toolchain and configure Cargo to use the git CLI for dependency fetches
- configure Git URL rewrite auth using DUROXIDE_PG_OPT_TOKEN from the copilot environment for GitHub-hosted private dependencies
- prefetch Rust dependencies with cargo fetch to warm caches and validate auth setup

## Why
- provide a focused, reproducible setup workflow for Copilot and CI-like runs that need access to private git dependencies

## Validation
- workflow run now reaches and completes cargo fetch with authenticated access