### PR TITLE
Add setup-git-credentials Copilot skill

### DIFF
--- a/.github/skills/setup-git-credentials/SKILL.md
+++ b/.github/skills/setup-git-credentials/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: setup-git-credentials
+description: Set up and verify HTTPS GitHub credential access for microsoft/duroxide-pg-opt using ~/.git-credentials and credential.helper=store. Use this when git ls-remote or cargo git fetch fails with 401/403 for the private dependency.
+---
+
+Use this skill when a user needs to configure GitHub access to `microsoft/duroxide-pg-opt` with HTTPS credentials in `~/.git-credentials`, or when credential-helper precedence is causing auth failures.
+
+## Goal
+
+Ensure Git uses `~/.git-credentials` for `github.com` and verify access with:
+
+- `git credential fill` (effective credential)
+- `git ls-remote https://github.com/microsoft/duroxide-pg-opt` (real access)
+
+## Inputs to collect
+
+- GitHub username (for credential URL)
+- GitHub PAT with repository read access to `microsoft/duroxide-pg-opt`
+
+If the token is unavailable, stop and ask the user to provide it securely.
+
+## Procedure
+
+1. Write `~/.git-credentials` with mode `600`:
+
+   ```bash
+   umask 077
+   printf 'https://<username>:<token>@github.com\n' > ~/.git-credentials
+   chmod 600 ~/.git-credentials
+   ```
+
+2. Configure helper precedence so `store` wins even when system helpers exist (for example Codespaces helpers):
+
+   ```bash
+   git config --global --unset-all credential.helper || true
+   git config --global --add credential.helper ''
+   git config --global --add credential.helper store
+   ```
+
+3. Verify helper chain and effective credential (redact password in output):
+
+   ```bash
+   git config --show-origin --get-all credential.helper
+   printf 'protocol=https\nhost=github.com\n\n' | git credential fill \
+     | sed -E 's/(password=).+$/\1***REDACTED***/'
+   ```
+
+   Expected: `username=<provided-username>`.
+
+4. Verify remote access:
+
+   ```bash
+   git ls-remote https://github.com/microsoft/duroxide-pg-opt | head -n 5
+   ```
+
+   Expected: refs are returned.
+
+## Troubleshooting
+
+- If `username=PersonalAccessToken` appears in `git credential fill`, a higher-priority helper is still active. Re-apply step 2.
+- If `ls-remote` returns 403, verify token scope/permissions and organization SSO authorization for the token.
+- If `ls-remote` returns 401, token is invalid/expired or malformed in `~/.git-credentials`.
+- If `~/.git-credentials` has multiple `github.com` lines, keep only the intended one.
+
+## Optional automation
+
+Use the included script:
+
+```bash
+.github/skills/setup-git-credentials/setup_and_test.sh <github-username> <github-token>
+```
+
+The script configures credentials, enforces helper precedence, and runs verification checks.
+
+## Safety rules
+
+- Never print raw PATs in logs or responses.
+- Redact tokens from all command output.
+- Do not commit credentials or write them into repository files.

--- a/.github/skills/setup-git-credentials/setup_and_test.sh
+++ b/.github/skills/setup-git-credentials/setup_and_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "Usage: $0 <github-username> <github-token> [repo-url]" >&2
+  echo "Default repo-url: https://github.com/microsoft/duroxide-pg-opt" >&2
+  exit 1
+fi
+
+github_username="$1"
+github_token="$2"
+repo_url="${3:-https://github.com/microsoft/duroxide-pg-opt}"
+credentials_file="${HOME}/.git-credentials"
+
+if [[ -z "$github_username" || -z "$github_token" ]]; then
+  echo "Username and token must be non-empty." >&2
+  exit 1
+fi
+
+echo "Writing ${credentials_file} with restricted permissions..."
+umask 077
+printf 'https://%s:%s@github.com\n' "$github_username" "$github_token" > "$credentials_file"
+chmod 600 "$credentials_file"
+
+echo "Configuring git credential helper precedence (global): clear inherited helpers, then use store..."
+git config --global --unset-all credential.helper || true
+git config --global --add credential.helper ''
+git config --global --add credential.helper store
+
+echo ""
+echo "Credential helpers in effect:"
+git config --show-origin --get-all credential.helper
+
+echo ""
+echo "Resolved credential for github.com (password redacted):"
+printf 'protocol=https\nhost=github.com\n\n' | git credential fill \
+  | sed -E 's/(password=).+$/\1***REDACTED***/'
+
+echo ""
+echo "Testing remote access: ${repo_url}"
+git ls-remote "$repo_url" | head -n 5
+
+echo ""
+echo "Success: credential helper is configured and remote is accessible."


### PR DESCRIPTION
## Summary
- add project skill at .github/skills/setup-git-credentials/SKILL.md
- add helper script to set up ~/.git-credentials and helper precedence
- include verification steps for git credential fill and ls-remote access to microsoft/duroxide-pg-opt