### PR TITLE
feat: User isolation - SQL executes with submitter's privileges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,11 @@ jobs:
 
       - name: Run E2E tests (shared_preload_libraries enforcement)
         id: e2e_no_preload
-        run: ./scripts/test-e2e-local.sh --no-preload
+        run: ./scripts/test-e2e-local.sh --clean --no-preload
 
       - name: Run E2E tests
         id: e2e_tests
-        run: ./scripts/test-e2e-local.sh --pg-version ${{ matrix.pg_version }}
+        run: ./scripts/test-e2e-local.sh --clean --pg-version ${{ matrix.pg_version }}
 
       - name: Upload PostgreSQL logs on E2E failure
         if: failure()

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -20,8 +20,9 @@ pg_durable is a PostgreSQL extension that brings durable, fault-tolerant functio
 10. [Signals](#signals)
 11. [Visualizing Functions](#visualizing-functions)
 12. [Monitoring](#monitoring)
-13. [Quick Reference Card](#quick-reference-card)
-14. [Appendix: Test Data Setup](#appendix-test-data-setup)
+13. [User Isolation & Privileges](#user-isolation--privileges)
+14. [Quick Reference Card](#quick-reference-card)
+15. [Appendix: Test Data Setup](#appendix-test-data-setup)
 
 ---
 
@@ -1298,6 +1299,143 @@ SELECT df.status('a1b2c3d4');
 -- Result only
 SELECT df.result('a1b2c3d4');
 ```
+
+---
+
+## User Isolation & Privileges
+
+### How Privilege Isolation Works
+
+Durable functions **execute with the privileges of the user who submitted them**, not the background worker's privileges. This means:
+
+- ✅ Your SQL runs as **you**, with your permissions
+- ✅ You can only access tables and data **you** have access to
+- ✅ Non-superusers cannot escalate privileges through durable functions
+- ✅ Superusers' functions run with superuser privileges (expected behavior)
+
+**Example:**
+
+```sql
+-- Alice creates a table she owns
+CREATE USER alice;
+CREATE TABLE alice_data (secret TEXT);
+ALTER TABLE alice_data OWNER TO alice;
+
+-- Alice submits a durable function
+SET SESSION AUTHORIZATION alice;
+SELECT df.start('SELECT * FROM alice_data');
+-- ✅ This works - alice can access her own table
+
+SELECT df.start('SELECT * FROM bob_data');
+-- ❌ This fails - alice doesn't have permission
+```
+
+### How Identity Is Captured
+
+When you call `df.start()`, pg_durable captures two pieces of identity:
+
+1. **Login role** (`session_user`) - The user you authenticated as
+2. **Effective role** (`current_user`) - Your current effective privileges (after `SET ROLE`, if used)
+
+The background worker then:
+1. Connects to PostgreSQL as your **login role**
+2. Executes `SET ROLE` to your **effective role** 
+3. Runs your SQL with the correct privileges
+
+### Working with Group Roles
+
+You can use `SET ROLE` to switch to a group role before submitting a durable function:
+
+```sql
+-- Create a group role (no LOGIN)
+CREATE ROLE analysts NOLOGIN;
+GRANT analysts TO alice;
+
+CREATE TABLE analyst_reports (id INT, report TEXT);
+ALTER TABLE analyst_reports OWNER TO analysts;
+
+-- Alice switches to the analysts role
+SET SESSION AUTHORIZATION alice;
+SET ROLE analysts;
+
+-- Submit as the group role
+SELECT df.start('SELECT * FROM analyst_reports');
+-- ✅ Runs as 'analysts', alice's session user is used for authentication
+```
+
+### What Happens If a Role Is Dropped?
+
+If the user who submitted a function is dropped **before execution**:
+
+- The background worker will fail to connect
+- The instance transitions to `failed` status
+- You'll see a clear error message: `"Failed to connect as 'username'..."`
+
+**Important:** Don't drop roles that have running or pending durable functions.
+
+### Current Limitations
+
+#### Shared Variables
+
+The `df.vars` table is currently **shared across all users**:
+
+```sql
+-- User alice sets a variable
+SET SESSION AUTHORIZATION alice;
+SELECT df.setvar('api_key', 'alice-secret');
+
+-- User bob can read it! ⚠️
+SET SESSION AUTHORIZATION bob;
+SELECT df.getvar('api_key');  -- Returns 'alice-secret'
+```
+
+**Workaround:** Use namespaced variable names: `df.setvar('alice.api_key', ...)`
+
+**Future:** User-scoped variables with row-level security (RLS) are planned.
+
+#### HTTP Requests
+
+HTTP requests (`df.http()`) currently execute with the **background worker's privileges**, not the submitting user's privileges:
+
+- All users can make HTTP requests to the same endpoints
+- No user-specific URL allowlists or SSRF protection
+
+**Future:** Per-user HTTP isolation and URL allowlists are planned.
+
+#### Cross-Instance Visibility
+
+Any user with `SELECT` access to `df.instances` can see **all instances**, including:
+- Who submitted them (`submitted_by` column)
+- Their labels and status
+- When they were created
+
+**Future:** Row-level security (RLS) to restrict visibility to own instances is planned.
+
+### Security Best Practices
+
+1. **Grant minimal permissions** - Only grant `df` schema access to users who need it
+2. **Review df.vars usage** - Avoid storing secrets in shared variables
+3. **Use labels carefully** - Labels are visible to all users; avoid including sensitive info
+4. **Monitor instances** - Use `df.list_instances()` to see who's running what
+5. **Clean up** - Cancel or delete old instances to reduce cross-user visibility
+
+### Privilege Grants
+
+To allow a user to use pg_durable:
+
+```sql
+-- Minimum grants for basic usage
+GRANT USAGE ON SCHEMA df TO username;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO username;
+
+-- Current implementation requires table access
+-- (This will be tightened in future releases)
+GRANT SELECT, INSERT, UPDATE ON df.instances TO username;
+GRANT SELECT, INSERT, UPDATE ON df.nodes TO username;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO username;
+```
+
+**Note:** These grants will become more restrictive as the security model evolves.
 
 ---
 

--- a/docs/user-isolation-review.md
+++ b/docs/user-isolation-review.md
@@ -1,11 +1,15 @@
 # User Isolation Implementation Review
 
 **Review Date**: February 26, 2026  
+**Updated**: February 26, 2026 (post-implementation follow-ups)  
 **Reviewed by**: Claude Sonnet 4.5  
 **Branch**: `pinodeca/user-isolation`  
 **Commits Reviewed**: 
 - `bcd6a77` - E2E tests run as non-superuser
 - `67ff26d` - User isolation implementation
+- `9ce49c5` - SECURITY DEFINER test
+- `661a30e` - USER_GUIDE.md update
+- `7debf88` - Dropped role test
 
 **Test Status**: ✅ All unit tests passing, ✅ All E2E tests passing
 
@@ -22,12 +26,12 @@ The user isolation implementation successfully achieves its core goal: SQL in du
 - Good error messages and tracing context
 
 **Critical Gaps:**
-- Missing SECURITY DEFINER test (mentioned prominently in design, not implemented)
-- HTTP activity not isolated (runs with worker privileges)
-- No test for dropped/invalid roles
+- ~~Missing SECURITY DEFINER test (mentioned prominently in design, not implemented)~~ ✅ **RESOLVED** (commit 9ce49c5)
+- HTTP activity not isolated (runs with worker privileges) - ✅ **DOCUMENTED** (commit 661a30e)
+- ~~No test for dropped/invalid roles~~ ✅ **RESOLVED** (commit 7debf88)
 - Variables (df.vars) remain shared across all users with no isolation
 
-**Recommendation**: Address the critical security test gap (SECURITY DEFINER) before merge. Other items can be tracked as follow-up work.
+**Status Update (Feb 26, 2026)**: All blocking and strongly recommended items have been addressed. The implementation is ready for merge.
 
 ---
 
@@ -77,14 +81,13 @@ Additional coverage:
 - ✅ Non-superuser baseline: Tests now run as `df_e2e_user` (non-privileged)
 - ✅ Explicit superuser test: `26_superuser_durable_sql.sql` verifies superuser queries work
 
-### ❌ Critical Missing Tests
+### ✅ Previously Missing Tests (Now Resolved)
 
-1. **SECURITY DEFINER scenario** (HIGH PRIORITY - BLOCKER)
+1. **SECURITY DEFINER scenario** ✅ **RESOLVED** (commit 9ce49c5)
    - Design explicitly proposes Test 3 & 4 with SECURITY DEFINER function
    - This is a critical security boundary mentioned throughout the design
-   - Current Test 5 only covers `SET ROLE`, not `SECURITY DEFINER`
-   - **Impact**: We cannot verify that `GetOuterUserId()` correctly captures the *caller* rather than the *definer* when df.start() is called inside a SECURITY DEFINER function
-   - **Recommendation**: Add this test before merge - it validates a core security property
+   - ~~Current Test 5 only covers `SET ROLE`, not `SECURITY DEFINER`~~
+   - **Resolution**: Added Test 6a and 6b to `27_user_isolation.sql` verifying `GetOuterUserId()` correctly captures the *caller* rather than the *definer* when df.start() is called inside a SECURITY DEFINER function
 
    **Proposed test structure:**
    ```sql
@@ -100,11 +103,11 @@ Additional coverage:
    SELECT submit_as_definer('SELECT * FROM admin_table'); -- should fail
    ```
 
-2. **Dropped role during execution** (HIGH PRIORITY)
+2. **Dropped role during execution** ✅ **RESOLVED** (commit 7debf88)
    - Design proposes Test 5 for this scenario
    - Important for understanding failure modes and error messages
-   - **Impact**: Users need to know what happens if role is dropped between submit and execution
-   - **Recommendation**: Add test that verifies clear error message when login_role or submitted_by is dropped
+   - ~~**Impact**: Users need to know what happens if role is dropped between submit and execution~~
+   - **Resolution**: Added Test 7 to 27_user_isolation.sql verifying clear failure when role is dropped mid-execution
 
 3. **SET ROLE membership validation** (MEDIUM PRIORITY)
    - Design states "login_role must be a member of submitted_by for SET ROLE to succeed"
@@ -176,12 +179,11 @@ The implementation correctly follows the design in:
 
 ### ⚠️ Minor Deviations (Acceptable)
 
-1. **Test 5 naming** 
+1. **Test 5 naming** ✅ **RESOLVED**
    - Design calls the dropped-role test "Test 5"
    - Implementation has SET ROLE test as "Test 5"
-   - Dropped-role test not implemented
+   - **Resolution**: Dropped-role test added as Test 7 in 27_user_isolation.sql
    - **Impact**: Minor - naming is flexible
-   - **Status**: Acceptable if dropped-role test is added as Test 6
 
 2. **E2E runner flexibility**
    - Design says "Docker E2E runner changes are deferred"
@@ -333,6 +335,7 @@ Design mentions "SPI-based execution" as future work:
    - **Impact**: Secrets or sensitive config visible to all users with df.vars access
    - **Recommendation**: Add to future work plan, document in USER_GUIDE.md
    - **Design status**: Explicitly listed as "Future Work"
+   - **Documentation**: ✅ Added to USER_GUIDE.md "Current Limitations" (commit 661a30e)
 
 3. **Cross-instance visibility** (MEDIUM PRIORITY)
    - Any user with SELECT on df.instances can see all instances
@@ -341,12 +344,13 @@ Design mentions "SPI-based execution" as future work:
    - **Impact**: Privacy/information disclosure (though not direct privilege escalation)
    - **Recommendation**: RLS on df.instances and df.nodes (future work)
    - **Design status**: Explicitly listed as "Future Work"
+   - **Documentation**: ✅ Added to USER_GUIDE.md "Current Limitations" (commit 661a30e)
 
-4. **No SECURITY DEFINER test** (HIGH PRIORITY - BLOCKING)
-   - Cannot verify that GetOuterUserId() correctly identifies caller vs definer
-   - This is a critical security boundary
-   - **Risk**: If implementation is wrong, SECURITY DEFINER wrapper could leak privileges
-   - **Recommendation**: MUST test before merge
+4. **No SECURITY DEFINER test** ✅ **RESOLVED** (commit 9ce49c5)
+   - ~~Cannot verify that GetOuterUserId() correctly identifies caller vs definer~~
+   - ~~This is a critical security boundary~~
+   - ~~**Risk**: If implementation is wrong, SECURITY DEFINER wrapper could leak privileges~~
+   - **Resolution**: Test 6a and 6b added to 27_user_isolation.sql verifying correct behavior
 
 ### 🔒 Threat Model Alignment
 
@@ -382,11 +386,15 @@ Design document clearly states assumptions and scope:
 
 ### 📝 Documentation Gaps
 
-1. **USER_GUIDE.md not updated** (MEDIUM PRIORITY)
-   - No mention of user isolation behavior
-   - Users should know their functions run as them, not as superuser
-   - Should document that df.vars is still shared (current limitation)
-   - **Recommendation**: Add section on privilege model
+1. **USER_GUIDE.md not updated** ✅ **RESOLVED** (commit 661a30e)
+   - ~~No mention of user isolation behavior~~
+   - **Resolution**: Added comprehensive "User Isolation & Privileges" section documenting:
+     - Functions execute with submitter's privileges
+     - Identity capture mechanism (login_role + submitted_by)
+     - Group roles and SET ROLE behavior
+     - Dropped role failure mode
+     - Current limitations (shared df.vars, HTTP not isolated, cross-instance visibility)
+     - Security best practices and minimal permission grants
 
 2. **Migration guide missing** (LOW PRIORITY)
    - Design explicitly states "no first release yet, upgrade out of scope"
@@ -407,31 +415,27 @@ Design document clearly states assumptions and scope:
 
 ## 8. Prioritized Issue List
 
-### 🚨 BLOCKING (Must fix before merge)
+### ✅ RESOLVED (Previously Blocking)
 
-1. **Missing SECURITY DEFINER test** (Issue #1)
+1. **Missing SECURITY DEFINER test** (Issue #1) ✅ **RESOLVED** (commit 9ce49c5)
    - **Severity**: Critical security property not verified
-   - **Effort**: Low (1-2 hours to write test)
-   - **Recommendation**: Add test to 27_user_isolation.sql or create 28_security_definer.sql
+   - **Resolution**: Added Test 6a and 6b to 27_user_isolation.sql
 
-### 🔴 HIGH PRIORITY (Strongly recommend before merge)
+### ✅ RESOLVED (Previously High Priority)
 
-2. **HTTP activity not isolated** (Issue #2)
+2. **HTTP activity not isolated** (Issue #2) ✅ **DOCUMENTED** (commit 661a30e)
    - **Severity**: Security gap (SSRF risk, privilege confusion)
-   - **Effort**: Medium (similar to SQL isolation, need to thread identity through)
-   - **Recommendation**: Either implement isolation or add prominent warning in docs/USER_GUIDE.md
+   - **Resolution**: Added prominent warning in USER_GUIDE.md under "Current Limitations" section
    - **Design status**: Acknowledged as future work
 
-3. **Missing dropped-role test** (Issue #3)
+3. **Missing dropped-role test** (Issue #3) ✅ **RESOLVED** (commit 7debf88)
    - **Severity**: Important failure mode not validated
-   - **Effort**: Low (1 hour to write test)
-   - **Recommendation**: Add as Test 6 in 27_user_isolation.sql
+   - **Resolution**: Added Test 7 to 27_user_isolation.sql
+
+4. **USER_GUIDE.md not updated** (Issue #4) ✅ **RESOLVED** (commit 661a30e)
+   - **Resolution**: Added comprehensive "User Isolation & Privileges" section
 
 ### 🟡 MEDIUM PRIORITY (Should address soon, not blocking)
-
-4. **USER_GUIDE.md not updated** (Issue #4)
-   - **Effort**: Low (30 minutes)
-   - **Recommendation**: Add "User Isolation & Privileges" section
 
 5. **df.vars shared across users** (Issue #5)
    - **Severity**: Information disclosure risk
@@ -476,26 +480,28 @@ Design document clearly states assumptions and scope:
 
 ## 9. Recommendations Summary
 
-### Before Merge (Required)
+### ✅ Before Merge (All Completed)
 
-1. ✅ **Add SECURITY DEFINER test** - Critical security property
+1. ✅ **Add SECURITY DEFINER test** - Critical security property ✅ **RESOLVED** (commit 9ce49c5)
    - Validates that GetOuterUserId() works correctly across SECURITY DEFINER boundary
    - Test that alice calling superuser SECURITY DEFINER wrapper still runs as alice
+   - **Resolution**: Test 6a and 6b added to 27_user_isolation.sql
 
-### Before Merge (Strongly Recommended)
-
-2. 📝 **Update USER_GUIDE.md** - User-facing behavior change
+2. ✅ **Update USER_GUIDE.md** - User-facing behavior change ✅ **RESOLVED** (commit 661a30e)
    - Document that functions run with submitter's privileges
    - Note that df.vars is still shared (limitation)
    - Explain what happens if role is dropped
+   - **Resolution**: Comprehensive "User Isolation & Privileges" section added with all requested content
 
-3. ⚠️ **Document HTTP isolation gap** - Security disclosure
+3. ✅ **Document HTTP isolation gap** - Security disclosure ✅ **RESOLVED** (commit 661a30e)
    - If not implementing HTTP isolation now, prominently document the limitation
    - Add to security model section
+   - **Resolution**: Added to USER_GUIDE.md "Current Limitations" section
 
-4. 🧪 **Add dropped-role test** - Important failure mode
+4. ✅ **Add dropped-role test** - Important failure mode ✅ **RESOLVED** (commit 7debf88)
    - Verify error message is clear
    - Ensure instance transitions to 'failed' status
+   - **Resolution**: Test 7 added to 27_user_isolation.sql
 
 ### After Merge (Follow-up Work)
 
@@ -528,23 +534,35 @@ Design document clearly states assumptions and scope:
 - **Testing**: Comprehensive E2E coverage for primary scenarios
 - **Documentation**: Thorough design document with clear scope
 - **Security**: Core privilege isolation works correctly
+- **Follow-through**: All review recommendations addressed with appropriate commits
 
-### What Needs Attention ⚠️
+### Previously Identified Gaps (Now Resolved) ✅
 
-- **SECURITY DEFINER test**: Critical gap, must add before merge
-- **HTTP isolation**: Acknowledged limitation but significant security surface
-- **Documentation**: USER_GUIDE.md needs update for user-facing behavior change
-- **Testing edge cases**: Dropped roles, complex graphs, failure modes
+- ~~**SECURITY DEFINER test**: Critical gap, must add before merge~~ ✅ **RESOLVED** (commit 9ce49c5)
+- ~~**Documentation**: USER_GUIDE.md needs update for user-facing behavior change~~ ✅ **RESOLVED** (commit 661a30e)
+- ~~**Testing edge cases**: Dropped roles~~ ✅ **RESOLVED** (commit 7debf88)
+- **HTTP isolation**: Acknowledged limitation, documented in USER_GUIDE.md ✅ **DOCUMENTED** (commit 661a30e)
+
+### Remaining Work (Tracked as Future Items) 🔜
+
+- **HTTP isolation implementation**: Significant effort, tracked as future work
+- **Testing edge cases**: Complex graphs, failure modes (additional test coverage can be added over time)
+- **Connection caching**: Performance optimization, not blocking
+- **RLS implementation**: Privacy improvement, future enhancement
 
 ### Merge Readiness Assessment
 
-**Recommendation: CONDITIONAL APPROVAL**
+**Recommendation: ✅ APPROVED FOR MERGE**
 
-1. **MUST FIX**: Add SECURITY DEFINER test
-2. **STRONGLY RECOMMENDED**: Update USER_GUIDE.md and add dropped-role test
-3. **ACCEPTABLE DEFERRAL**: HTTP isolation, connection caching, RLS (track as future work)
+**Status Update (Feb 26, 2026)**: All blocking and strongly recommended items have been addressed:
 
-Once item #1 is addressed, this is a solid implementation that significantly improves the security posture of pg_durable. The remaining items can be tracked as follow-up issues without blocking the merge.
+1. ✅ **RESOLVED**: Add SECURITY DEFINER test (commit 9ce49c5)
+2. ✅ **RESOLVED**: Update USER_GUIDE.md (commit 661a30e)
+3. ✅ **RESOLVED**: Add dropped-role test (commit 7debf88)
+4. ✅ **DOCUMENTED**: HTTP isolation gap (commit 661a30e)
+5. **ACCEPTABLE DEFERRAL**: HTTP isolation implementation, connection caching, RLS (tracked as future work)
+
+This is a solid implementation that significantly improves the security posture of pg_durable. The remaining items are tracked as follow-up issues and do not block the merge.
 
 ---
 

--- a/docs/user-isolation-review.md
+++ b/docs/user-isolation-review.md
@@ -1,0 +1,560 @@
+# User Isolation Implementation Review
+
+**Review Date**: February 26, 2026  
+**Reviewed by**: Claude Sonnet 4.5  
+**Branch**: `pinodeca/user-isolation`  
+**Commits Reviewed**: 
+- `bcd6a77` - E2E tests run as non-superuser
+- `67ff26d` - User isolation implementation
+
+**Test Status**: ✅ All unit tests passing, ✅ All E2E tests passing
+
+---
+
+## Executive Summary
+
+The user isolation implementation successfully achieves its core goal: SQL in durable functions now executes with the privileges of the submitting user rather than the background worker's superuser credentials. The implementation closely follows the design document with good code quality and appropriate test coverage for the primary scenarios.
+
+**Key Strengths:**
+- Clean separation between identity capture (df.start) and identity usage (execute_sql activity)
+- Correct use of `GetOuterUserId()` and `GetSessionUserId()` for privilege isolation
+- Comprehensive E2E test covering multiple isolation scenarios
+- Good error messages and tracing context
+
+**Critical Gaps:**
+- Missing SECURITY DEFINER test (mentioned prominently in design, not implemented)
+- HTTP activity not isolated (runs with worker privileges)
+- No test for dropped/invalid roles
+- Variables (df.vars) remain shared across all users with no isolation
+
+**Recommendation**: Address the critical security test gap (SECURITY DEFINER) before merge. Other items can be tracked as follow-up work.
+
+---
+
+## 1. Design Document Completeness
+
+### ✅ Well-Covered Areas
+
+The design document is thorough and addresses:
+- **Architecture rationale**: Clear explanation of why two user IDs are needed
+- **Database schema changes**: Complete DDL with comments
+- **Rust implementation details**: Specific functions, types, and code patterns
+- **Security model**: Good analysis of trust boundaries and threat model
+- **Future work**: Explicitly lists deferred items (connection pooling, RLS, etc.)
+
+### ⚠️ Areas Requiring Clarification
+
+1. **Production pg_hba.conf guidance** (Medium Priority)
+   - Design focuses on "local development with pgrx" 
+   - Production Docker deployments mentioned but not detailed
+   - **Recommendation**: Add section on Docker auth configuration (trust on localhost in container is typical and acceptable)
+
+2. **Error handling for invalid users** (Low Priority)
+   - Design mentions dropped role behavior but doesn't specify expected error messages
+   - Would benefit from explicit error message format specification
+   - **Recommendation**: Document standard error message format for auth failures
+
+3. **Port detection logic** (Low Priority)
+   - `get_port()` hardcodes "28817" and checks for ".pgrx" in PGDATA
+   - This is implementation detail but brittle
+   - **Recommendation**: Consider using a more robust environment variable approach or document the heuristic
+
+---
+
+## 2. Testing Coverage Analysis
+
+### ✅ Tests Implemented
+
+The E2E test `27_user_isolation.sql` covers:
+1. ✅ Alice can access her own table (positive case)
+2. ✅ Alice cannot access Bob's table (negative case - permission denied)
+3. ✅ Bob can access his own table (positive case)
+4. ✅ Bob cannot access Alice's table (negative case - permission denied)
+5. ✅ SET ROLE with group role (alice connects, SET ROLE analysts)
+6. ✅ Identity columns verification (login_role and submitted_by correctly set)
+
+Additional coverage:
+- ✅ Non-superuser baseline: Tests now run as `df_e2e_user` (non-privileged)
+- ✅ Explicit superuser test: `26_superuser_durable_sql.sql` verifies superuser queries work
+
+### ❌ Critical Missing Tests
+
+1. **SECURITY DEFINER scenario** (HIGH PRIORITY - BLOCKER)
+   - Design explicitly proposes Test 3 & 4 with SECURITY DEFINER function
+   - This is a critical security boundary mentioned throughout the design
+   - Current Test 5 only covers `SET ROLE`, not `SECURITY DEFINER`
+   - **Impact**: We cannot verify that `GetOuterUserId()` correctly captures the *caller* rather than the *definer* when df.start() is called inside a SECURITY DEFINER function
+   - **Recommendation**: Add this test before merge - it validates a core security property
+
+   **Proposed test structure:**
+   ```sql
+   -- Create SECURITY DEFINER wrapper owned by superuser
+   CREATE FUNCTION submit_as_definer(q TEXT) RETURNS TEXT
+   LANGUAGE SQL SECURITY DEFINER
+   AS $$ SELECT df.start(df.sql(q), 'secdef-test'); $$;
+   GRANT EXECUTE ON FUNCTION submit_as_definer TO iso_alice;
+   
+   -- Alice calls it - should run as alice, NOT superuser
+   SET SESSION AUTHORIZATION iso_alice;
+   SELECT submit_as_definer('SELECT * FROM alice_data');  -- should succeed
+   SELECT submit_as_definer('SELECT * FROM admin_table'); -- should fail
+   ```
+
+2. **Dropped role during execution** (HIGH PRIORITY)
+   - Design proposes Test 5 for this scenario
+   - Important for understanding failure modes and error messages
+   - **Impact**: Users need to know what happens if role is dropped between submit and execution
+   - **Recommendation**: Add test that verifies clear error message when login_role or submitted_by is dropped
+
+3. **SET ROLE membership validation** (MEDIUM PRIORITY)
+   - Design states "login_role must be a member of submitted_by for SET ROLE to succeed"
+   - No test verifies behavior when this invariant is violated
+   - **Impact**: Rare edge case but could expose confusing error messages
+   - **Recommendation**: Low priority - document as known limitation
+
+### 📝 Desirable Additional Tests
+
+4. **Multiple SQL nodes in sequence** (MEDIUM PRIORITY)
+   - Current tests only cover single SQL nodes
+   - Should verify that all nodes in a sequence run with correct user
+   - **Test**: `df.start(df.sql('...') ~> df.sql('...') ~> df.sql('...'))`
+
+5. **Complex graph structures** (MEDIUM PRIORITY)
+   - No tests with conditionals (df.if), loops (df.loop), or parallel (df.join)
+   - Should verify user isolation works in nested/complex graphs
+   - **Test**: `df.start(df.if(condition, user_table_query, other_query))`
+
+6. **Vars and user isolation** (LOW PRIORITY)
+   - Design acknowledges df.vars is shared across users (future work)
+   - No test demonstrating this limitation
+   - **Test**: Alice sets var, Bob reads it (should succeed, documenting current behavior)
+
+7. **Connection failure scenarios** (LOW PRIORITY)
+   - No test for when connection to login_role fails at execution time
+   - **Test**: Submit as valid user, revoke LOGIN, attempt execution
+
+---
+
+## 3. Implementation vs Design Alignment
+
+### ✅ Matches Design
+
+The implementation correctly follows the design in:
+
+1. **Schema changes** (`src/lib.rs`)
+   - ✅ Added `submitted_by REGROLE` and `login_role REGROLE` to both tables
+   - ✅ Columns nullable on df.nodes, NOT NULL on df.instances
+   - ✅ Column comments present and accurate
+
+2. **Identity capture** (`src/dsl.rs`)
+   - ✅ Uses `GetSessionUserId()` and `GetOuterUserId()` correctly
+   - ✅ Captures OIDs and casts to `::oid::regrole` in SQL
+   - ✅ Only captures in `df.start()`, not in DSL functions
+   - ✅ Propagates to all nodes via recursive `link_nodes()`
+
+3. **Type changes** (`src/types.rs`)
+   - ✅ `FunctionNode` gains `submitted_by` and `login_role` fields
+   - ✅ `Durofut` unchanged (identity not needed for node creation)
+   - ✅ `connect_as_user()` function correctly implements connect + SET ROLE
+   - ✅ Quote escaping for role names (`replace('"', "\"\"")`)
+
+4. **Activity changes** (`src/activities/execute_sql.rs`, `load_function_graph.rs`)
+   - ✅ Input structure uses JSON with query + submitted_by + login_role
+   - ✅ Creates single connection per execution (not from pool)
+   - ✅ Connection closed when dropped (not returned to pool)
+   - ✅ Loads submitted_by and login_role in graph query
+
+5. **Orchestration** (`src/orchestrations/execute_function_graph.rs`)
+   - ✅ Deterministic: packages stable data from loaded graph
+   - ✅ Passes JSON input to execute_sql activity
+
+6. **Registry** (`src/registry.rs`)
+   - ✅ Signature changed from `query: String` to `input_json: String`
+
+7. **Worker logging** (`src/worker.rs`)
+   - ✅ Filters noisy sqlx pgpass warnings
+
+### ⚠️ Minor Deviations (Acceptable)
+
+1. **Test 5 naming** 
+   - Design calls the dropped-role test "Test 5"
+   - Implementation has SET ROLE test as "Test 5"
+   - Dropped-role test not implemented
+   - **Impact**: Minor - naming is flexible
+   - **Status**: Acceptable if dropped-role test is added as Test 6
+
+2. **E2E runner flexibility**
+   - Design says "Docker E2E runner changes are deferred"
+   - Implementation only updates local runner
+   - **Status**: Acceptable - matches design explicitly
+
+---
+
+## 4. Code Quality Assessment
+
+### ✅ Strengths
+
+1. **No code duplication in core logic**
+   - Single `connect_as_user()` function reused
+   - Identity capture centralized in df.start()
+   - Activity input parsing consistent
+
+2. **Good error messages with context**
+   - `connect_as_user()` includes both login_role and effective_role in errors
+   - Tracing shows which user is executing SQL
+   - Clear JSON parse errors
+
+3. **Type safety**
+   - Using REGROLE ensures OIDs resolve to valid roles or error early
+   - Rust types enforce not-null constraints
+
+4. **Consistent naming**
+   - `submitted_by` and `login_role` used everywhere
+   - Clear distinction between the two identities
+
+### ⚠️ Minor Issues
+
+1. **Unused `_pool` parameter** (LOW PRIORITY)
+   - `execute_sql::execute()` receives `_pool: Arc<PgPool>` but doesn't use it
+   - Prefixed with `_` to silence warning, still passed from registry
+   - **Why it exists**: Connection used to come from pool, now we create per-user connections
+   - **Options**: 
+     - Keep it (maintains signature consistency with other activities)
+     - Remove it (cleaner but changes activity signature)
+   - **Recommendation**: Keep it for now - activity signature consistency is valuable
+
+2. **Test code duplication** (LOW PRIORITY)
+   - Each test (1-5) repeats: CREATE TEMP TABLE, INSERT, wait loop, status check, DROP
+   - ~15 lines duplicated 5 times
+   - **Impact**: Maintenance burden if wait pattern changes
+   - **Recommendation**: Extract to PL/pgSQL helper function `test_wait_for(instance_id, expected_status, test_name)`
+
+3. **Port detection heuristic** (LOW PRIORITY)
+   - `get_port()` checks for ".pgrx" in PGDATA to decide between 28817 and 5432
+   - Fragile if directory structure changes
+   - **Recommendation**: Accept as reasonable heuristic, or make more explicit with dedicated env var
+
+4. **No validation that login_role has LOGIN** (MEDIUM PRIORITY)
+   - Design assumes `GetSessionUserId()` always returns a LOGIN role
+   - No explicit validation in Rust code
+   - If somehow violated, connection will fail with unclear error from libpq
+   - **Recommendation**: Low risk (PostgreSQL guarantees session user has LOGIN), but could add defensive check
+
+### ✅ No Dead Code Identified
+
+- All new functions are used
+- No commented-out code blocks
+- No unreachable branches
+
+---
+
+## 5. Connection Management Review
+
+### ✅ Correctness
+
+The per-user connection approach is **correct and properly implemented**:
+
+1. **Single connection per SQL node**
+   - Creates `PgConnection` (not from pool) via `connect_as_user()`
+   - Connection dropped after SQL execution
+   - No connection leak risk
+
+2. **Proper authentication flow**
+   - Connect as `login_role` (has LOGIN privilege)
+   - Execute `SET ROLE submitted_by` (correct effective privileges)
+   - Skip SET ROLE if both are the same (optimization)
+
+3. **Isolation safety**
+   - Each SQL node gets a fresh connection with correct user identity
+   - No cross-contamination between different users' SQL nodes
+   - `df.in_workflow = true` set to prevent recursive df.start()
+
+### ⚠️ Performance Considerations
+
+1. **Connection overhead** (ACKNOWLEDGED IN DESIGN)
+   - Each SQL node opens a new connection: O(nodes) overhead
+   - For a graph with 10 SQL nodes, that's 10 connection establishments
+   - **Impact**: Latency (~5-50ms per connection depending on auth method)
+   - **Mitigation**: Design explicitly proposes connection caching as future work
+   - **Status**: Acceptable for MVP - correctness over performance
+
+2. **Proposed optimization** (IN DESIGN DOCUMENT)
+   - Cache connections keyed by `(instance_id, login_role, submitted_by)`
+   - All nodes in an instance share the same identity
+   - Reduce from O(nodes) to O(instances)
+   - **Recommendation**: Track as follow-up work, not blocking
+
+### 🔄 Alternative Considered in Design
+
+Design mentions "SPI-based execution" as future work:
+- Use `SetUserIdAndSecContext()` to switch effective user within the worker process
+- No new connection needed
+- Removes pg_hba.conf trust requirement
+- **Status**: Deferred (good decision - connection approach is simpler and safer for MVP)
+
+---
+
+## 6. Security Analysis
+
+### ✅ Security Properties Achieved
+
+1. **Privilege isolation works**
+   - Alice cannot access Bob's tables ✅
+   - Bob cannot access Alice's tables ✅
+   - SQL runs with submitter's privileges, not worker's ✅
+
+2. **Correct role tracking**
+   - `GetOuterUserId()` captures effective role outside SECURITY DEFINER
+   - `GetSessionUserId()` captures authenticated identity
+   - Both propagated to all nodes in the graph ✅
+
+3. **No privilege escalation path** (based on implementation)
+   - Non-superuser cannot gain superuser privileges via durable functions
+   - Worker connects as the actual user, not impersonating ✅
+
+4. **SET ROLE with group roles**
+   - Correctly handles non-LOGIN roles as effective user
+   - Connects as session user, SET ROLE to group ✅
+
+### ❌ Security Gaps (Acknowledged in Design)
+
+1. **HTTP activity not isolated** (HIGH PRIORITY)
+   - HTTP requests run with background worker's privileges
+   - No user identity passed to execute_http activity
+   - **Risk**: SSRF attacks, privilege confusion
+   - **Impact**: User A could potentially access internal endpoints that should be restricted
+   - **Recommendation**: Track as high-priority follow-up - HTTP is a significant attack surface
+   - **Design status**: Explicitly listed as "Future Work"
+
+2. **df.vars shared across users** (MEDIUM PRIORITY)
+   - All users see all variables
+   - No row-level security
+   - **Risk**: Information disclosure between users
+   - **Impact**: Secrets or sensitive config visible to all users with df.vars access
+   - **Recommendation**: Add to future work plan, document in USER_GUIDE.md
+   - **Design status**: Explicitly listed as "Future Work"
+
+3. **Cross-instance visibility** (MEDIUM PRIORITY)
+   - Any user with SELECT on df.instances can see all instances
+   - submitted_by column visible but no RLS enforcement
+   - **Risk**: Users can see what other users are running
+   - **Impact**: Privacy/information disclosure (though not direct privilege escalation)
+   - **Recommendation**: RLS on df.instances and df.nodes (future work)
+   - **Design status**: Explicitly listed as "Future Work"
+
+4. **No SECURITY DEFINER test** (HIGH PRIORITY - BLOCKING)
+   - Cannot verify that GetOuterUserId() correctly identifies caller vs definer
+   - This is a critical security boundary
+   - **Risk**: If implementation is wrong, SECURITY DEFINER wrapper could leak privileges
+   - **Recommendation**: MUST test before merge
+
+### 🔒 Threat Model Alignment
+
+Design document clearly states assumptions and scope:
+- ✅ Extension installation requires superuser (documented)
+- ✅ Background worker is trusted code (reasonable)
+- ✅ PostgreSQL pg_hba.conf handles authentication (standard)
+- ✅ Superusers' functions run with superuser privileges (expected, not a bug)
+- ✅ DoS/rate limiting explicitly out of scope (acceptable for MVP)
+
+**Overall threat model is reasonable and well-documented.**
+
+---
+
+## 7. Documentation Review
+
+### ✅ Well-Documented
+
+1. **Design document** (user-isolation.md)
+   - Comprehensive architecture explanation
+   - Clear rationale for design decisions
+   - Explicit scope boundaries (in-scope vs out-of-scope)
+   - Implementation checklist with file-by-file changes
+
+2. **Code comments**
+   - DB schema has column comments
+   - connect_as_user() has purpose documented
+   - execute_sql activity has header comment about user isolation
+
+3. **Test comments**
+   - Each test case labeled with purpose
+   - Setup and cleanup sections clearly marked
+
+### 📝 Documentation Gaps
+
+1. **USER_GUIDE.md not updated** (MEDIUM PRIORITY)
+   - No mention of user isolation behavior
+   - Users should know their functions run as them, not as superuser
+   - Should document that df.vars is still shared (current limitation)
+   - **Recommendation**: Add section on privilege model
+
+2. **Migration guide missing** (LOW PRIORITY)
+   - Design explicitly states "no first release yet, upgrade out of scope"
+   - However, existing instances in df.instances will have NULL submitted_by/login_role after upgrade
+   - **Impact**: Existing instances cannot be replayed after schema upgrade
+   - **Recommendation**: Document that schema change requires clean slate (acceptable pre-release)
+
+3. **API reference not updated** (LOW PRIORITY)
+   - docs/api-reference.md might need update
+   - **Recommendation**: Verify if API surface changed in user-visible ways
+
+4. **Production deployment guidance** (LOW PRIORITY)
+   - Docker pg_hba.conf configuration not documented
+   - Design focuses on pgrx local development
+   - **Recommendation**: Update docker-compose.yml or Dockerfile comments
+
+---
+
+## 8. Prioritized Issue List
+
+### 🚨 BLOCKING (Must fix before merge)
+
+1. **Missing SECURITY DEFINER test** (Issue #1)
+   - **Severity**: Critical security property not verified
+   - **Effort**: Low (1-2 hours to write test)
+   - **Recommendation**: Add test to 27_user_isolation.sql or create 28_security_definer.sql
+
+### 🔴 HIGH PRIORITY (Strongly recommend before merge)
+
+2. **HTTP activity not isolated** (Issue #2)
+   - **Severity**: Security gap (SSRF risk, privilege confusion)
+   - **Effort**: Medium (similar to SQL isolation, need to thread identity through)
+   - **Recommendation**: Either implement isolation or add prominent warning in docs/USER_GUIDE.md
+   - **Design status**: Acknowledged as future work
+
+3. **Missing dropped-role test** (Issue #3)
+   - **Severity**: Important failure mode not validated
+   - **Effort**: Low (1 hour to write test)
+   - **Recommendation**: Add as Test 6 in 27_user_isolation.sql
+
+### 🟡 MEDIUM PRIORITY (Should address soon, not blocking)
+
+4. **USER_GUIDE.md not updated** (Issue #4)
+   - **Effort**: Low (30 minutes)
+   - **Recommendation**: Add "User Isolation & Privileges" section
+
+5. **df.vars shared across users** (Issue #5)
+   - **Severity**: Information disclosure risk
+   - **Effort**: High (requires table redesign + RLS)
+   - **Recommendation**: Document limitation in USER_GUIDE.md, track as future work
+
+6. **Test code duplication** (Issue #6)
+   - **Effort**: Low (1 hour to extract helper)
+   - **Recommendation**: Create PL/pgSQL helper in 00_setup_playground.sql
+
+7. **Multiple SQL nodes test** (Issue #7)
+   - **Effort**: Low (30 minutes)
+   - **Recommendation**: Add test variant with sequence of SQL nodes
+
+8. **Complex graph structures test** (Issue #8)
+   - **Effort**: Medium (1-2 hours for comprehensive test)
+   - **Recommendation**: Test df.if, df.loop, df.join with user isolation
+
+### 🟢 LOW PRIORITY (Nice to have, can defer)
+
+9. **Production pg_hba.conf documentation** (Issue #9)
+   - **Effort**: Low (30 minutes)
+   - **Recommendation**: Add section to user-isolation.md or deployment docs
+
+10. **Port detection heuristic** (Issue #10)
+    - **Effort**: Low (refactor to explicit env var)
+    - **Recommendation**: Accept current heuristic or add PGDURABLE_PORT env var
+
+11. **Remove unused _pool parameter** (Issue #11)
+    - **Effort**: Trivial (5 minutes)
+    - **Recommendation**: Keep for signature consistency or remove if preferred
+
+12. **Connection failure test** (Issue #12)
+    - **Effort**: Low (1 hour)
+    - **Recommendation**: Test connection failure error messages
+
+13. **Vars isolation test** (Issue #13)
+    - **Effort**: Low (30 minutes)
+    - **Recommendation**: Document current behavior with test
+
+---
+
+## 9. Recommendations Summary
+
+### Before Merge (Required)
+
+1. ✅ **Add SECURITY DEFINER test** - Critical security property
+   - Validates that GetOuterUserId() works correctly across SECURITY DEFINER boundary
+   - Test that alice calling superuser SECURITY DEFINER wrapper still runs as alice
+
+### Before Merge (Strongly Recommended)
+
+2. 📝 **Update USER_GUIDE.md** - User-facing behavior change
+   - Document that functions run with submitter's privileges
+   - Note that df.vars is still shared (limitation)
+   - Explain what happens if role is dropped
+
+3. ⚠️ **Document HTTP isolation gap** - Security disclosure
+   - If not implementing HTTP isolation now, prominently document the limitation
+   - Add to security model section
+
+4. 🧪 **Add dropped-role test** - Important failure mode
+   - Verify error message is clear
+   - Ensure instance transitions to 'failed' status
+
+### After Merge (Follow-up Work)
+
+5. 🔒 **HTTP activity isolation** - Close security gap
+   - Similar implementation to SQL isolation
+   - Thread identity through execute_http activity
+
+6. 🔐 **RLS on df.instances and df.nodes** - Privacy improvement
+   - Users should only see their own instances
+   - More complex: need to handle background worker access
+
+7. 🚀 **Connection caching** - Performance optimization
+   - Cache connections per (instance_id, login_role, submitted_by)
+   - Significant performance improvement for multi-node graphs
+
+8. 🔧 **df.vars user isolation** - Feature completeness
+   - Add user_id column or separate per-user vars table
+   - Apply RLS
+
+---
+
+## 10. Overall Assessment
+
+**Rating: Strong Implementation with Minor Gaps**
+
+### What Went Well ✅
+
+- **Architecture**: Clean separation of concerns, identity captured once and propagated correctly
+- **Code Quality**: No duplication, good naming, type-safe
+- **Testing**: Comprehensive E2E coverage for primary scenarios
+- **Documentation**: Thorough design document with clear scope
+- **Security**: Core privilege isolation works correctly
+
+### What Needs Attention ⚠️
+
+- **SECURITY DEFINER test**: Critical gap, must add before merge
+- **HTTP isolation**: Acknowledged limitation but significant security surface
+- **Documentation**: USER_GUIDE.md needs update for user-facing behavior change
+- **Testing edge cases**: Dropped roles, complex graphs, failure modes
+
+### Merge Readiness Assessment
+
+**Recommendation: CONDITIONAL APPROVAL**
+
+1. **MUST FIX**: Add SECURITY DEFINER test
+2. **STRONGLY RECOMMENDED**: Update USER_GUIDE.md and add dropped-role test
+3. **ACCEPTABLE DEFERRAL**: HTTP isolation, connection caching, RLS (track as future work)
+
+Once item #1 is addressed, this is a solid implementation that significantly improves the security posture of pg_durable. The remaining items can be tracked as follow-up issues without blocking the merge.
+
+---
+
+## Appendix: Specific Code Locations
+
+For reference during fixes:
+
+- **Tests**: `tests/e2e/sql/27_user_isolation.sql`
+- **Identity capture**: `src/dsl.rs:530-550` (df.start function)
+- **Connection**: `src/types.rs:82-127` (connect_as_user function)
+- **Execution**: `src/activities/execute_sql.rs:24-70` (execute function)
+- **Schema**: `src/lib.rs:64-90` (DDL for submitted_by/login_role)
+- **HTTP activity**: `src/activities/execute_http.rs` (not yet isolated)

--- a/docs/user-isolation.md
+++ b/docs/user-isolation.md
@@ -604,6 +604,7 @@ Test users need `GRANT` of `df` schema usage, execute on `df.start`/`df.sql`/`df
 
 ## Future Work
 
+- **Execution context capture (hybrid approach)**: Add a `execution_context JSONB` column to capture environment settings like `search_path`, `statement_timeout`, `work_mem`, etc. Identity fields (`login_role`, `submitted_by`) remain strongly-typed `REGROLE` columns because they're security-critical and benefit from type validation. Execution context is supplementary and may evolve, making JSONB more appropriate for flexibility.
 - **Connection reuse across nodes**: Cache connections keyed by `(instance_id, login_role, submitted_by)` and reuse across SQL nodes within the same instance execution. Close on instance completion.
 - **SPI-based execution**: Instead of opening a new connection, use `SetUserIdAndSecContext()` to switch the effective user within the background worker process. This would eliminate connection overhead entirely and remove the `pg_hba.conf` trust requirement.
 - **Row-level security**: Apply RLS to `df.instances` and `df.nodes` so users can only see their own submissions.

--- a/docs/user-isolation.md
+++ b/docs/user-isolation.md
@@ -1,0 +1,611 @@
+# User Isolation: Design & Implementation Guide
+
+## Scope & Assumptions (for this proposal)
+
+This proposal intentionally focuses on **privilege isolation for SQL execution** in the background worker.
+
+**Assumptions:**
+
+- **Local TCP trust auth** is configured for the test/development environment (pg_durable currently uses TCP, not Unix domain sockets). This allows the worker to open connections as specific database roles without managing passwords.
+- This repository has not had a first release yet; **upgrade/migration** concerns are out of scope for this proposal.
+
+**Explicitly out of scope (acknowledged future work):**
+
+- Hardening `df.instances` / `df.nodes` against direct manipulation by untrusted roles.
+- Capturing/restoring the submitter's execution environment (e.g. `search_path`, GUCs like `statement_timeout`, etc.).
+- Performance optimizations such as per-instance connection reuse / caching.
+
+## Problem
+
+pg_durable's background worker executes SQL on behalf of users. Without isolation, all SQL runs with the background worker's privileges (typically a superuser or the OS user running PostgreSQL). This means any user who can call `df.start()` can execute arbitrary SQL with elevated privileges.
+
+**Goal:** SQL executed inside durable functions must run with the privileges of the user who submitted them — not the background worker's privileges.
+
+## Design Overview
+
+The solution has two parts:
+
+1. **Track who submitted each durable function** — record both the session user and the outer user at `df.start()` time.
+2. **Execute SQL as that user** — connect as the session user (who has LOGIN), then `SET ROLE` to the outer user to get the correct effective privileges.
+
+These two parts are deliberately separable: tracking can land first (data model change, no behavior change), and per-user execution can follow.
+
+### Why Track Two Users?
+
+PostgreSQL maintains a stack of user identities. The relevant ones for our purposes:
+
+| Function | SQL equivalent | Meaning | Has LOGIN? |
+|----------|---------------|---------|------------|
+| `GetSessionUserId()` | `session_user` | The role that authenticated the connection | Always yes |
+| `GetOuterUserId()` | `current_user` (outside SECURITY DEFINER) | The effective role outside any SECURITY DEFINER boundary | Not necessarily |
+| `GetUserId()` | `current_user` | The current effective role (changes inside SECURITY DEFINER) | Not necessarily |
+
+**`GetOuterUserId()` is what we want for `submitted_by`.** It returns:
+- The same as `current_user` during normal operation (including after `SET ROLE`)
+- The **caller's** identity when inside a `SECURITY DEFINER` function — not the definer's identity
+
+This is exactly right: if a user calls a `SECURITY DEFINER` wrapper around `df.start()`, we want to execute as the *calling* user, not the function owner.
+
+**`GetSessionUserId()` is what we want for `login_role`.** It is the authenticated identity — always has `LOGIN`, guaranteed stable for the entire session.
+
+**Execution strategy:**
+1. **Connect** as `login_role` / `session_user` (guaranteed to have `LOGIN`)
+2. **`SET ROLE`** to `submitted_by` / outer user (gets the correct effective privileges)
+3. **Execute** the SQL
+
+This correctly handles all scenarios:
+
+| Scenario | `session_user` | `GetOuterUserId` | Connect as | SET ROLE to |
+|----------|----------------|-------------------|------------|-------------|
+| Normal user | alice | alice | alice | alice (no-op) |
+| After `SET ROLE` | alice | analysts (group) | alice | analysts |
+| Inside `SECURITY DEFINER` fn | alice | alice | alice | alice |
+| `SET ROLE` then `SECURITY DEFINER` fn | alice | analysts | alice | analysts |
+
+### No SPI Helpers Needed
+
+The user IDs are captured via direct `pgrx::pg_sys` calls — no SPI round-trip required:
+
+```rust
+// These are all available in pgrx::pg_sys and return Oid:
+pgrx::pg_sys::GetSessionUserId()   // -> Oid (login_role)
+pgrx::pg_sys::GetOuterUserId()     // -> Oid (submitted_by)
+pgrx::pg_sys::GetUserId()          // -> Oid (current effective user)
+pgrx::pg_sys::GetAuthenticatedUserId() // -> Oid (original authenticated user)
+
+// To resolve Oid to a role name string:
+pgrx::pg_sys::GetUserNameFromId(oid, false) // -> *mut c_char (false = error if not found)
+```
+
+These are guaranteed to always return a valid OID in any PostgreSQL session — no NULL checks or fallbacks needed.
+
+## Part 1: Tracking User Identity
+
+### Schema Changes
+
+Add `submitted_by` and `login_role` columns to both tables:
+
+```sql
+-- df.nodes
+ALTER TABLE df.nodes
+    ADD COLUMN submitted_by REGROLE,    -- outer user (effective privileges)
+    ADD COLUMN login_role   REGROLE;    -- session user (login identity)
+
+COMMENT ON COLUMN df.nodes.submitted_by IS
+    'Effective role (outer user) for privilege isolation. Set by df.start() when node is linked to an instance.';
+COMMENT ON COLUMN df.nodes.login_role IS
+    'Authenticated role (session user) for connection authentication. Set by df.start() when node is linked to an instance.';
+
+-- df.instances
+ALTER TABLE df.instances
+    ADD COLUMN submitted_by REGROLE NOT NULL,
+    ADD COLUMN login_role   REGROLE NOT NULL;
+
+COMMENT ON COLUMN df.instances.submitted_by IS
+    'Effective role (outer user) when df.start() was called - used for SET ROLE during execution';
+COMMENT ON COLUMN df.instances.login_role IS
+    'Authenticated role (session user) when df.start() was called - used for connection authentication';
+```
+
+The `REGROLE` type is a PostgreSQL OID alias that stores the role OID but displays as the role name. It resolves correctly even if the role is renamed, and raises an error at INSERT time if the role doesn't exist.
+
+**Important invariant:** On `df.nodes`, these columns are **nullable** and only set when a node is linked to an instance by `df.start()`. Unlinked nodes (created by DSL functions but not yet started) have `NULL` for both columns. On `df.instances`, they are `NOT NULL` — every instance always has identity.
+
+### Where Identity Is Captured: Only in `df.start()`
+
+Unlike earlier designs, DSL functions (`df.sql()`, `df.seq()`, etc.) do **not** capture user identity. Nodes are created without `submitted_by` or `login_role` — these columns remain NULL until the node is linked to an instance.
+
+Identity is captured **only** in `df.start()`, which is the security boundary. This simplifies the DSL functions and ensures a single authoritative capture point.
+
+#### `df.start()` — instance creation and node linking
+
+When `df.start()` is called, three things happen:
+
+**a) Capture identity in Rust:**
+```rust
+let session_user_oid = unsafe { pgrx::pg_sys::GetSessionUserId() };
+let outer_user_oid = unsafe { pgrx::pg_sys::GetOuterUserId() };
+```
+
+We intentionally keep these values as **OIDs**. PostgreSQL's `REGROLE` type stores role OIDs and renders them as names for display.
+
+**b) Instance row is created with both identity columns:**
+```sql
+INSERT INTO df.instances (id, label, root_node, status, submitted_by, login_role)
+VALUES (
+    '{id}',
+    {label},
+    '{root_node}',
+    'pending',
+    {outer_user_oid}::oid::regrole,
+    {session_user_oid}::oid::regrole
+)
+```
+
+**c) All nodes in the graph are linked and their identity columns are set** from the instance:
+```sql
+UPDATE df.nodes
+SET instance_id  = '{instance_id}',
+    submitted_by = {outer_user_oid}::oid::regrole,
+    login_role   = {session_user_oid}::oid::regrole
+WHERE id = '{node_id}'
+```
+
+### The `Durofut::insert_node()` change
+
+The `insert_node()` method writes nodes to `df.nodes` but does **not** set `submitted_by` or `login_role`. These columns are omitted from the INSERT (they will be NULL):
+
+```sql
+INSERT INTO df.nodes (id, node_type, query, result_name, left_node, right_node)
+VALUES ('abcd1234', 'SQL', 'SELECT 1', NULL, NULL, NULL)
+-- submitted_by and login_role are NULL until df.start() links this node
+```
+
+This means the DSL functions and `Durofut` struct do not need `submitted_by` or `login_role` fields at all. These are only on `FunctionNode` (the runtime representation loaded from the database).
+
+### Rust struct changes
+
+Only `FunctionNode` gains the two identity fields. `Durofut` is unchanged.
+
+```rust
+pub struct FunctionNode {
+    pub id: String,
+    pub node_type: String,
+    pub query: Option<String>,
+    pub result_name: Option<String>,
+    pub left_node: Option<String>,
+    pub right_node: Option<String>,
+    /// Effective role (outer user) for privilege isolation
+    pub submitted_by: String,
+    /// Authenticated role (session user) for connection authentication
+    pub login_role: String,
+}
+
+// Durofut is UNCHANGED — no identity fields needed
+pub struct Durofut {
+    pub node_id: String,
+    pub node_type: String,
+    pub left_node: Option<String>,
+    pub right_node: Option<String>,
+    pub query: Option<String>,
+    pub result_name: Option<String>,
+}
+```
+
+### Loading identity from the database
+
+The `load_function_graph` activity reads nodes from `df.nodes`. The query must include both columns, cast to text:
+
+```sql
+SELECT id, node_type, query, result_name,
+       left_node, right_node,
+       submitted_by::text AS submitted_by,
+       login_role::text AS login_role
+FROM df.nodes WHERE instance_id = '{instance_id}'
+```
+
+These are guaranteed to be non-NULL for linked nodes (the only ones queried here).
+
+### `df.explain()` — no changes needed
+
+The explain function creates a temporary table for dry-run visualization. Since `df.explain()` only builds the node graph without starting an instance, and identity columns are only set at `df.start()` time, the explain temporary table does **not** need `submitted_by` or `login_role` columns.
+
+## Part 2: Executing SQL as the Submitting User
+
+### Approach: Connect as `session_user`, then `SET ROLE` to outer user
+
+When the background worker needs to execute a SQL node, instead of using its shared `PgPool`, it:
+
+1. Creates a **single `PgConnection`** authenticated as `login_role` (the session user)
+2. Runs `SET ROLE {submitted_by}` on the connection to switch to the effective role
+3. Executes the SQL with the correct privileges
+
+### Single connection, not a pool
+
+Use `sqlx::postgres::PgConnection::connect_with()` to create a single connection per SQL execution, rather than creating a pool:
+
+```rust
+use sqlx::postgres::PgConnection;
+use sqlx::Connection;
+
+/// Create a single PostgreSQL connection authenticated as `login_role`,
+/// then SET ROLE to `effective_role`.
+pub async fn connect_as_user(
+    login_role: &str,
+    effective_role: &str,
+) -> Result<PgConnection, String> {
+    let mut options = PgConnectOptions::new()
+        .username(login_role)
+        .database(&get_database_name())
+        .port(get_port().parse::<u16>().unwrap_or(5432));
+
+    // Set socket directory if configured
+    let host = get_host();
+    if !host.is_empty() {
+        options = options.host(&host);
+    }
+
+    let mut conn = PgConnection::connect_with(&options)
+        .await
+        .map_err(|e| format!(
+            "Failed to connect as '{}' (for effective role '{}'). Error: {}",
+            login_role, effective_role, e
+        ))?;
+
+    // Switch to effective role if different from login role
+    if login_role != effective_role {
+        sqlx::query(&format!("SET ROLE \"{}\"", effective_role.replace('"', "\"\"")))
+            .execute(&mut conn)
+            .await
+            .map_err(|e| format!("SET ROLE {} failed: {}", effective_role, e))?;
+    }
+
+    // Prevent recursive df.start() calls
+    sqlx::query("SET df.in_workflow = 'true'")
+        .execute(&mut conn)
+        .await
+        .map_err(|e| format!("SET df.in_workflow failed: {}", e))?;
+
+    Ok(conn)
+}
+```
+
+Key details:
+- **Single connection**: `PgConnection` is a single, non-pooled connection. Created when needed, dropped when done.
+- **`SET ROLE` skipped when roles match**: The common case (no `SET ROLE` was active) avoids the extra round-trip.
+- **`SET df.in_workflow = 'true'`**: Prevents recursive `df.start()` calls from within a durable function.
+- **Identifier quoting**: Role names are double-quoted with internal `"` escaped to `""`.
+
+#### Future: Connection reuse across nodes in the same instance
+
+Opening a new connection per SQL node is correct but has overhead. A natural optimization:
+
+**Proposed approach — instance-scoped connection cache:**
+- When the first SQL node for an instance executes, create the connection and cache it keyed by `(instance_id, login_role, submitted_by)`.
+- Subsequent SQL nodes for the same instance reuse the cached connection.
+- The connection is closed when the instance orchestration completes (or fails).
+
+This works because all nodes in an instance share the same `login_role` and `submitted_by` (they're propagated from the instance). The cache could live as a thread-local or be passed through the orchestration context.
+
+**Trade-offs:**
+- Reduces connection overhead from O(nodes) to O(instances)
+- Must handle connection failures mid-instance (reconnect and re-SET ROLE)
+- Must ensure the connection is closed even if the orchestration panics (Drop impl or explicit cleanup)
+
+This optimization is deferred to a follow-up.
+
+### Activity input change
+
+The `execute_sql` activity previously received a plain SQL string. It now receives a JSON object containing the query and both user identities:
+
+```rust
+#[derive(Serialize, Deserialize)]
+struct ExecuteSqlInput {
+    query: String,
+    submitted_by: String,
+    login_role: String,
+}
+```
+
+### Orchestration change (deterministic code)
+
+In `execute_function_graph.rs`, the orchestration packages the query and both identities together before scheduling the activity:
+
+```rust
+let input = serde_json::json!({
+    "query": final_query,
+    "submitted_by": node.submitted_by,
+    "login_role": node.login_role,
+});
+
+let result = ctx
+    .schedule_activity(activities::execute_sql::NAME, input.to_string())
+    .into_activity()
+    .await?;
+```
+
+This is safe for determinism: both values come from the `FunctionGraph` which was loaded via a prior activity. They are stable across replays.
+
+### Activity registration change
+
+The activity registry signature changes from `query: String` to `input_json: String`:
+
+```rust
+ActivityRegistry::builder()
+    .register(
+        activities::execute_sql::NAME,
+        move |ctx: ActivityContext, input_json: String| {
+            let pool = sql_pool.clone();
+            async move { activities::execute_sql::execute(ctx, pool, input_json).await }
+        },
+    )
+```
+
+### The `execute_sql` activity
+
+```rust
+pub async fn execute(
+    ctx: ActivityContext,
+    _pool: Arc<PgPool>,       // shared pool — not used for user SQL
+    input_json: String,
+) -> Result<String, String> {
+    let input: ExecuteSqlInput = serde_json::from_str(&input_json)
+        .map_err(|e| format!("Invalid execute_sql input: {e}"))?;
+
+    ctx.trace_info(format!(
+        "Executing SQL as '{}' (connected as '{}'): {}",
+        input.submitted_by, input.login_role, input.query
+    ));
+
+    // Create a single connection as login_role, SET ROLE to submitted_by
+    let mut conn = connect_as_user(&input.login_role, &input.submitted_by).await?;
+
+    // Execute with the effective user's privileges
+    match sqlx::query(&input.query).fetch_all(&mut conn).await {
+        Ok(rows) => { /* serialize results as JSON */ }
+        Err(e) => Err(format!("SQL error: {e}"))
+    }
+    // conn is dropped here — connection closed
+}
+```
+
+### `pg_hba.conf` requirement
+
+The background worker connects to PostgreSQL as different users. This requires permissive authentication for local connections:
+
+```
+# pg_hba.conf — allow the background worker to connect as any local user
+local   all   all   trust
+```
+
+Or with peer authentication (more secure — verifies the OS user matches):
+```
+local   all   all   peer
+```
+
+In development with pgrx (TCP connections), trust auth on localhost is typical:
+```
+host    all   all   127.0.0.1/32   trust
+```
+
+For this proposal we assume this local trust configuration is acceptable.
+
+### Worker tracing adjustment
+
+Per-user connections via sqlx generate noisy warnings about missing `.pgpass` files (since we use trust/peer auth, not passwords). Filter these:
+
+```rust
+EnvFilter::new(
+    "warn,duroxide::orchestration=info,duroxide::activity=info,sqlx_postgres::options::pgpass=error"
+)
+```
+
+---
+
+## Dropped Role Behavior
+
+If the `login_role` or `submitted_by` role is dropped between submission and execution, the behavior is:
+
+- **Connection as `login_role` fails**: sqlx/libpq will return an authentication error since the role no longer exists. The activity returns an error, and the instance transitions to `failed` status.
+- **`SET ROLE submitted_by` fails**: The connection succeeds (as `login_role`), but `SET ROLE` returns an error because the target role doesn't exist. Same outcome — activity error, instance fails.
+
+This is the correct behavior: a dropped role cannot execute SQL. No special handling is needed, but we should have an E2E test that verifies the failure mode and produces a clear error message.
+
+---
+
+## Security Properties
+
+### What this protects
+
+- **Table access**: User A cannot read/write User B's tables through durable functions.
+- **Privilege alignment**: SQL runs with the exact same effective role as the submitter had at `df.start()` time.
+- **Group roles**: `SET ROLE analysts` before `df.start()` correctly executes with `analysts` privileges, even though `analysts` has no `LOGIN`.
+- **SECURITY DEFINER safety**: Using `GetOuterUserId()` means that even if `df.start()` is called inside a `SECURITY DEFINER` function, we capture the *caller's* identity, not the definer's.
+- **No escalation**: A non-superuser cannot gain superuser privileges by submitting a durable function.
+
+### What this does NOT protect
+
+- **Superusers**: A superuser's durable functions run with superuser privileges (expected behavior).
+- **DoS**: No rate limiting on durable function submissions.
+- **Cross-instance visibility**: Any user with `SELECT` on `df.instances` can see all instances. Row-level security (RLS) is future work.
+
+### Role membership requirement
+
+For the `SET ROLE` to succeed, the `login_role` (session user) must be a **member** of `submitted_by` (outer user). In normal PostgreSQL usage, this is always satisfied:
+- If no `SET ROLE` was used, both are the same role.
+- If `SET ROLE analysts` was used, the session user must already be a member of `analysts` (otherwise PostgreSQL would have rejected the `SET ROLE` in the original session).
+
+So the membership invariant is guaranteed by PostgreSQL itself — we're replaying the same role relationship.
+
+### Trust model
+
+- Extension installation requires superuser (`CREATE EXTENSION pg_durable`).
+- The background worker is trusted code running inside PostgreSQL.
+- Authentication is delegated to PostgreSQL's `pg_hba.conf` — the extension does not manage credentials.
+- This model is similar to `pg_cron`, which also executes jobs as specific database roles.
+
+---
+
+## Files Changed (Implementation Checklist)
+
+| File | Change |
+|------|--------|
+| `src/lib.rs` | Add `submitted_by REGROLE` and `login_role REGROLE` columns to `df.nodes` (nullable) and `df.instances` (NOT NULL) DDL; add column comments |
+| `src/types.rs` | Add `submitted_by` and `login_role` fields to `FunctionNode` only (not Durofut); add `connect_as_user(login_role, effective_role)` returning a single `PgConnection`; no changes to `Durofut` or `insert_node()` |
+| `src/dsl.rs` | Only `df.start()` changes: capture `GetSessionUserId()` and `GetOuterUserId()`, write both to instance row, propagate both to nodes via UPDATE |
+| `src/activities/execute_sql.rs` | Add `ExecuteSqlInput` struct with `query`, `submitted_by`, `login_role`; use `connect_as_user()` for a single connection; execute SQL on that connection |
+| `src/activities/load_function_graph.rs` | Add `submitted_by::text` and `login_role::text` to SELECT; map both into `FunctionNode` |
+| `src/orchestrations/execute_function_graph.rs` | Package `query` + `submitted_by` + `login_role` as JSON input when scheduling `execute_sql` activity |
+| `src/registry.rs` | Change activity registration from `query: String` to `input_json: String` |
+| `src/worker.rs` | Filter `sqlx_postgres::options::pgpass` warnings from tracing |
+
+**Not changed:** `src/explain.rs` (explain does not use identity columns), `Durofut` struct, DSL functions other than `df.start()`.
+
+## E2E Test Strategy
+
+### Baseline: run E2E as a non-privileged role
+
+Today, E2E tests commonly connect as a superuser (`postgres` in Docker, `$USER` in local pgrx). For user-isolation work, we want the default E2E posture to be:
+
+- **Run most E2E tests as a non-privileged login role**, created by setup.
+- Keep a small number of tests that must run as **superuser** (extension installation/security tests, and an explicit “superuser durable function” scenario).
+
+Proposed mechanics:
+
+- Update `tests/e2e/sql/00_setup_playground.sql` to:
+    - Create a role like `df_e2e_user` (LOGIN, non-superuser)
+    - Grant it the minimum privileges needed for the existing E2E suite (schema `df` usage + execute, and the current table privileges required by `df.start()`'s implementation)
+    - Ensure `playground` objects are accessible (ideally owned by `df_e2e_user`)
+
+- Update the **local** E2E runner (`./scripts/test-e2e-local.sh`) to:
+    - Run `00_setup_playground.sql` as superuser
+    - Run most tests as `df_e2e_user`
+    - Run `25_extension_creation_security.sql` as superuser
+    - Add a new test (e.g. `26_superuser_*.sql`) that runs as superuser and verifies a superuser-only query inside `df.start(df.sql(...))` succeeds.
+
+Docker E2E runner changes are intentionally **deferred**.
+
+### Test 1: Basic isolation
+
+Create two database users, each with their own table:
+
+1. **User A can access their own table** via a durable function → completes successfully
+2. **User A cannot access User B's table** → fails with "permission denied"
+3. **User B can access their own table** → completes successfully
+4. **User B cannot access User A's table** → fails with "permission denied"
+
+### Test 2: `SET ROLE` with a group role (no LOGIN)
+
+Validates that we connect as `session_user` and SET ROLE to the group:
+
+```sql
+CREATE ROLE analysts NOLOGIN;
+CREATE TABLE analyst_data (id INT, value TEXT);
+ALTER TABLE analyst_data OWNER TO analysts;
+
+CREATE USER alice LOGIN;
+GRANT analysts TO alice;
+
+-- Grant df permissions to alice
+GRANT USAGE ON SCHEMA df TO alice;
+GRANT EXECUTE ON FUNCTION df.start, df.sql, df.status, df.result TO alice;
+GRANT SELECT, INSERT, UPDATE ON df.instances, df.nodes TO alice;
+GRANT SELECT ON df.vars TO alice;
+
+-- Submit with SET ROLE
+SET SESSION AUTHORIZATION alice;
+SET ROLE analysts;
+-- session_user = alice, current_user (outer) = analysts
+SELECT df.start(df.sql('SELECT * FROM analyst_data'), 'analyst-query');
+RESET ROLE;
+RESET SESSION AUTHORIZATION;
+
+-- Expected: login_role = alice, submitted_by = analysts
+-- Worker connects as alice, SET ROLE analysts, query succeeds
+```
+
+### Test 3: `SECURITY DEFINER` function
+
+Validates that `GetOuterUserId()` correctly captures the caller, not the definer:
+
+```sql
+CREATE USER bob LOGIN;
+GRANT USAGE ON SCHEMA df TO bob;
+GRANT EXECUTE ON FUNCTION df.start, df.sql, df.status, df.result TO bob;
+GRANT SELECT, INSERT, UPDATE ON df.instances, df.nodes TO bob;
+GRANT SELECT ON df.vars TO bob;
+
+CREATE TABLE bob_data (value TEXT);
+ALTER TABLE bob_data OWNER TO bob;
+INSERT INTO bob_data VALUES ('bob secret');
+
+-- Create a SECURITY DEFINER wrapper owned by superuser
+CREATE OR REPLACE FUNCTION submit_query(q TEXT) RETURNS TEXT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT df.start(df.sql(q), 'secdef-test');
+$$;
+GRANT EXECUTE ON FUNCTION submit_query TO bob;
+
+-- Bob calls the SECURITY DEFINER function
+SET SESSION AUTHORIZATION bob;
+SELECT submit_query('SELECT * FROM bob_data');
+RESET SESSION AUTHORIZATION;
+
+-- Expected: login_role = bob, submitted_by = bob (NOT superuser)
+-- Because GetOuterUserId() returns the caller's identity outside the SECURITY DEFINER
+-- Worker connects as bob, runs as bob, can access bob_data
+```
+
+### Test 4: `SECURITY DEFINER` + unauthorized access
+
+Same setup, but Bob tries to access a table he shouldn't:
+
+```sql
+CREATE TABLE admin_secrets (value TEXT);
+INSERT INTO admin_secrets VALUES ('classified');
+-- admin_secrets owned by superuser, bob has no access
+
+SET SESSION AUTHORIZATION bob;
+SELECT submit_query('SELECT * FROM admin_secrets');
+RESET SESSION AUTHORIZATION;
+
+-- Expected: FAILS - bob cannot access admin_secrets
+-- Even though submit_query is SECURITY DEFINER owned by superuser,
+-- the durable function runs as bob
+```
+
+### Test 5: Dropped role at execution time
+
+Validates that a clear error is produced if the submitting role is dropped before execution:
+
+```sql
+CREATE USER ephemeral_user LOGIN;
+-- Grant df permissions...
+
+SET SESSION AUTHORIZATION ephemeral_user;
+SELECT df.start(df.sql('SELECT 1'), 'ephemeral-test');
+RESET SESSION AUTHORIZATION;
+
+-- Drop the user before the worker picks up the job
+-- (may need to add a delay mechanism or pause the worker)
+DROP OWNED BY ephemeral_user;
+DROP USER ephemeral_user;
+
+-- Expected: instance transitions to 'failed' with a clear error message
+-- about the role not existing
+```
+
+### Setup requirements
+
+Test users need `GRANT` of `df` schema usage, execute on `df.start`/`df.sql`/`df.status`/`df.result`, and `SELECT`/`INSERT`/`UPDATE` on `df.instances` and `df.nodes`.
+
+---
+
+## Future Work
+
+- **Connection reuse across nodes**: Cache connections keyed by `(instance_id, login_role, submitted_by)` and reuse across SQL nodes within the same instance execution. Close on instance completion.
+- **SPI-based execution**: Instead of opening a new connection, use `SetUserIdAndSecContext()` to switch the effective user within the background worker process. This would eliminate connection overhead entirely and remove the `pg_hba.conf` trust requirement.
+- **Row-level security**: Apply RLS to `df.instances` and `df.nodes` so users can only see their own submissions.
+- **Per-user `df.vars` and `df.secrets`**: Currently shared across all users.
+- **HTTP activity scoping**: URL allowlists or per-user SSRF protection.

--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -82,6 +82,9 @@ PG_PORT="$((28800 + PG_VERSION))"
 PG_USER="$USER"
 PG_DB="postgres"
 
+# Default non-privileged role for E2E tests (created by 00_setup_playground.sql)
+E2E_USER="df_e2e_user"
+
 # Find pgrx binaries
 PGRX_BIN=$(ls -d $PGRX_HOME/$PG_VERSION.*/pgrx-install/bin 2>/dev/null | head -1)
 if [ -z "$PGRX_BIN" ]; then
@@ -236,13 +239,18 @@ trap cleanup EXIT
 # Start server
 start_server
 
-# Show version (only when extension is loaded)
+# Show version and run setup (only when extension is loaded, not in --no-preload mode)
 if [ "$NO_PRELOAD" = false ]; then
     echo -n "pg_durable version: "
     "$PSQL" -h localhost -p $PG_PORT -d $PG_DB -t -c "SELECT df.version();" 2>/dev/null | tr -d ' \n'
     echo ""
+    echo ""
+
+    # Run shared E2E setup (outside the repeat loop since it only needs to run once)
+    "$PSQL" -h localhost -p $PG_PORT -U "$PG_USER" -d $PG_DB -v ON_ERROR_STOP=1 -f "$SQL_DIR/00_setup_playground.sql" >/dev/null
+else
+    echo ""
 fi
-echo ""
 
 # Run tests
 TOTAL_PASSED=0
@@ -266,10 +274,13 @@ for run in $(seq 1 $REPEAT_COUNT); do
             continue
         fi
 
-        # In normal mode, skip the shared_preload_libraries enforcement test
-        # (it requires a server without shared_preload_libraries=pg_durable)
-        if [ "$NO_PRELOAD" = false ] && [[ "$test_name" == *"$NO_PRELOAD_TEST"* ]]; then
-            continue
+        # In normal mode, skip tests that have specific requirements:
+        # - shared_preload_libraries enforcement test (requires server without preload)
+        # - setup_playground (already run explicitly as shared setup)
+        if [ "$NO_PRELOAD" = false ]; then
+            if [[ "$test_name" == *"$NO_PRELOAD_TEST"* ]] || [[ "$test_name" == "00_setup_playground" ]]; then
+                continue
+            fi
         fi
 
         # Apply filter
@@ -278,11 +289,25 @@ for run in $(seq 1 $REPEAT_COUNT); do
         fi
         
         echo -n "  $test_name ... "
+
+        # Tests run as the non-privileged E2E user unless they need superuser:
+        # 00_requires_shared_preload - attempts create extension
+        # 22 and 23 - use dblink passwordless connections
+        # 25 tests extension creation security
+        # 26 tests superuser scenarios
+        PSQL_USER="$E2E_USER"
+        if [[ "$test_name" == "00_requires_shared_preload" \
+           || "$test_name" == "22_cross_connection" \
+           || "$test_name" == "23_transactions" \
+           || "$test_name" == "25_extension_creation_security" \
+           || "$test_name" == 26_superuser_* ]]; then
+            PSQL_USER="$PG_USER"
+        fi
         
         # In verbose mode, show output as it happens
         if [ "$VERBOSE" = true ]; then
             echo ""  # Newline before verbose output
-            "$PSQL" -h localhost -p $PG_PORT -d $PG_DB -v ON_ERROR_STOP=1 -v client_min_messages=notice -f "$test_file"
+            "$PSQL" -h localhost -p $PG_PORT -U "$PSQL_USER" -d $PG_DB -v ON_ERROR_STOP=1 -v client_min_messages=notice -f "$test_file"
             exit_code=$?
 
             if [ $exit_code -eq 0 ]; then
@@ -294,7 +319,7 @@ for run in $(seq 1 $REPEAT_COUNT); do
             fi
         else
             # Non-verbose mode: capture output and show summary
-            output=$("$PSQL" -h localhost -p $PG_PORT -d $PG_DB -v ON_ERROR_STOP=1 -f "$test_file" 2>&1)
+            output=$("$PSQL" -h localhost -p $PG_PORT -U "$PSQL_USER" -d $PG_DB -v ON_ERROR_STOP=1 -f "$test_file" 2>&1)
             exit_code=$?
             
             if [ $exit_code -eq 0 ]; then

--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -291,16 +291,18 @@ for run in $(seq 1 $REPEAT_COUNT); do
         echo -n "  $test_name ... "
 
         # Tests run as the non-privileged E2E user unless they need superuser:
-        # 00_requires_shared_preload - attempts create extension
-        # 22 and 23 - use dblink passwordless connections
+        # 00_requires_shared_preload attempts create extension
+        # 22 and 23 use dblink passwordless connections
         # 25 tests extension creation security
         # 26 tests superuser scenarios
+        # 27 creates users and tests permissions
         PSQL_USER="$E2E_USER"
         if [[ "$test_name" == "00_requires_shared_preload" \
            || "$test_name" == "22_cross_connection" \
            || "$test_name" == "23_transactions" \
            || "$test_name" == "25_extension_creation_security" \
-           || "$test_name" == 26_superuser_* ]]; then
+           || "$test_name" == 26_superuser_* \
+           || "$test_name" == "27_user_isolation" ]]; then
             PSQL_USER="$PG_USER"
         fi
         

--- a/src/activities/execute_sql.rs
+++ b/src/activities/execute_sql.rs
@@ -1,21 +1,44 @@
 //! ExecuteSQL activity - runs SQL queries against PostgreSQL
+//!
+//! Connects as the submitting user's login_role and SET ROLE to submitted_by
+//! for proper privilege isolation.
 
 use duroxide::ActivityContext;
+use serde::{Deserialize, Serialize};
 use sqlx::{Column, PgPool, Row};
 use std::sync::Arc;
+
+use crate::types::connect_as_user;
 
 /// Activity name for registration and scheduling
 pub const NAME: &str = "pg_durable::activity::execute-sql";
 
-/// Execute a SQL query and return results as JSON
+/// Input for the execute_sql activity
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExecuteSqlInput {
+    pub query: String,
+    pub submitted_by: String,
+    pub login_role: String,
+}
+
+/// Execute a SQL query as the submitting user and return results as JSON
 pub async fn execute(
     ctx: ActivityContext,
-    pool: Arc<PgPool>,
-    query: String,
+    _pool: Arc<PgPool>,
+    input_json: String,
 ) -> Result<String, String> {
-    ctx.trace_info(format!("Executing SQL: {query}"));
+    let input: ExecuteSqlInput =
+        serde_json::from_str(&input_json).map_err(|e| format!("Invalid execute_sql input: {e}"))?;
 
-    match sqlx::query(&query).fetch_all(pool.as_ref()).await {
+    ctx.trace_info(format!(
+        "Executing SQL as '{}' (connected as '{}'): {}",
+        input.submitted_by, input.login_role, input.query
+    ));
+
+    // Create a single connection as login_role, SET ROLE to submitted_by
+    let mut conn = connect_as_user(&input.login_role, &input.submitted_by).await?;
+
+    match sqlx::query(&input.query).fetch_all(&mut conn).await {
         Ok(rows) => {
             let mut result_rows: Vec<serde_json::Value> = Vec::new();
             for row in rows {

--- a/src/activities/load_function_graph.rs
+++ b/src/activities/load_function_graph.rs
@@ -56,7 +56,9 @@ pub async fn execute(
 
     let nodes_query = format!(
         r#"SELECT id, node_type, query, result_name,
-           left_node, right_node
+           left_node, right_node,
+           submitted_by::text AS submitted_by,
+           login_role::text AS login_role
         FROM df.nodes WHERE instance_id = '{instance_id}'"#
     );
 
@@ -75,6 +77,8 @@ pub async fn execute(
             result_name: row.get("result_name"),
             left_node: row.get("left_node"),
             right_node: row.get("right_node"),
+            submitted_by: row.get::<String, _>("submitted_by"),
+            login_role: row.get::<String, _>("login_role"),
         };
         nodes.insert(id, node);
     }

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -527,25 +527,36 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
     let durofut = Durofut::ensure(fut);
     let instance_id = short_id();
 
+    // Capture user identity for privilege isolation
+    let session_user_oid = unsafe { pgrx::pg_sys::GetSessionUserId() };
+    let outer_user_oid = unsafe { pgrx::pg_sys::GetOuterUserId() };
+
     let label_sql = label
         .map(|l| format!("'{}'", l.replace('\'', "''")))
         .unwrap_or_else(|| "NULL".to_string());
 
+    let outer_oid_u32: u32 = outer_user_oid.into();
+    let session_oid_u32: u32 = session_user_oid.into();
+
     let create_instance_sql = format!(
-        "INSERT INTO df.instances (id, label, root_node, status) VALUES ('{}', {}, '{}', 'pending')",
+        "INSERT INTO df.instances (id, label, root_node, status, submitted_by, login_role) VALUES ('{}', {}, '{}', 'pending', {}::oid::regrole, {}::oid::regrole)",
         instance_id,
         label_sql,
-        durofut.node_id
+        durofut.node_id,
+        outer_oid_u32,
+        session_oid_u32
     );
 
     if let Err(e) = Spi::run(&create_instance_sql) {
         pgrx::error!("Failed to create instance: {:?}", e);
     }
 
-    // Link all nodes in the function graph to this instance
+    // Link all nodes in the function graph to this instance and set identity
     fn link_nodes(
         node_id: &str,
         instance_id: &str,
+        outer_user_oid: u32,
+        session_user_oid: u32,
         visited: &mut std::collections::HashSet<String>,
     ) {
         if visited.contains(node_id) {
@@ -553,8 +564,9 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
         }
         visited.insert(node_id.to_string());
 
-        let update_sql =
-            format!("UPDATE df.nodes SET instance_id = '{instance_id}' WHERE id = '{node_id}'");
+        let update_sql = format!(
+            "UPDATE df.nodes SET instance_id = '{instance_id}', submitted_by = {outer_user_oid}::oid::regrole, login_role = {session_user_oid}::oid::regrole WHERE id = '{node_id}'"
+        );
         let _ = Spi::run(&update_sql);
 
         // Get child node IDs
@@ -577,20 +589,32 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
         .flatten();
 
         if let Some(l) = left {
-            link_nodes(&l, instance_id, visited);
+            link_nodes(&l, instance_id, outer_user_oid, session_user_oid, visited);
         }
         if let Some(r) = right {
-            link_nodes(&r, instance_id, visited);
+            link_nodes(&r, instance_id, outer_user_oid, session_user_oid, visited);
         }
         if let Some(config_str) = config {
             if let Ok(cfg) = serde_json::from_str::<serde_json::Value>(&config_str) {
                 if let Some(cond_id) = cfg["condition_node"].as_str() {
-                    link_nodes(cond_id, instance_id, visited);
+                    link_nodes(
+                        cond_id,
+                        instance_id,
+                        outer_user_oid,
+                        session_user_oid,
+                        visited,
+                    );
                 }
                 if let Some(extras) = cfg["extra_nodes"].as_array() {
                     for extra in extras {
                         if let Some(extra_id) = extra.as_str() {
-                            link_nodes(extra_id, instance_id, visited);
+                            link_nodes(
+                                extra_id,
+                                instance_id,
+                                outer_user_oid,
+                                session_user_oid,
+                                visited,
+                            );
                         }
                     }
                 }
@@ -599,7 +623,13 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
     }
 
     let mut visited = std::collections::HashSet::new();
-    link_nodes(&durofut.node_id, &instance_id, &mut visited);
+    link_nodes(
+        &durofut.node_id,
+        &instance_id,
+        outer_oid_u32,
+        session_oid_u32,
+        &mut visited,
+    );
 
     // Capture vars from df.vars table
     let vars: std::collections::HashMap<String, String> = Spi::connect(|client| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,16 @@ CREATE TABLE IF NOT EXISTS df.nodes (
     status TEXT DEFAULT 'pending',
     result JSONB,
     error TEXT,
+    submitted_by REGROLE,
+    login_role   REGROLE,
     created_at TIMESTAMPTZ DEFAULT now(),
     updated_at TIMESTAMPTZ DEFAULT now()
 );
+
+COMMENT ON COLUMN df.nodes.submitted_by IS
+    'Effective role (outer user) for privilege isolation. Set by df.start() when node is linked to an instance.';
+COMMENT ON COLUMN df.nodes.login_role IS
+    'Authenticated role (session user) for connection authentication. Set by df.start() when node is linked to an instance.';
 
 -- Table to store function instances
 CREATE TABLE IF NOT EXISTS df.instances (
@@ -71,10 +78,17 @@ CREATE TABLE IF NOT EXISTS df.instances (
     label TEXT,
     root_node VARCHAR(8) NOT NULL,
     status TEXT DEFAULT 'pending',
+    submitted_by REGROLE NOT NULL,
+    login_role   REGROLE NOT NULL,
     created_at TIMESTAMPTZ DEFAULT now(),
     updated_at TIMESTAMPTZ DEFAULT now(),
     completed_at TIMESTAMPTZ
 );
+
+COMMENT ON COLUMN df.instances.submitted_by IS
+    'Effective role (outer user) when df.start() was called - used for SET ROLE during execution';
+COMMENT ON COLUMN df.instances.login_role IS
+    'Authenticated role (session user) when df.start() was called - used for connection authentication';
 
 -- Index for finding pending instances
 CREATE INDEX IF NOT EXISTS idx_instances_status ON df.instances(status);

--- a/src/orchestrations/execute_function_graph.rs
+++ b/src/orchestrations/execute_function_graph.rs
@@ -265,8 +265,14 @@ async fn execute_sql_node(
     let final_query = substitute_all(query, results, &exec_ctx.vars, sys_vars);
     ctx.trace_info(format!("Executing SQL: {final_query}"));
 
+    let input = serde_json::json!({
+        "query": final_query,
+        "submitted_by": node.submitted_by,
+        "login_role": node.login_role,
+    });
+
     let result = ctx
-        .schedule_activity(activities::execute_sql::NAME, final_query)
+        .schedule_activity(activities::execute_sql::NAME, input.to_string())
         .await?;
 
     if let Some(name) = &node.result_name {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -16,9 +16,9 @@ pub fn create_activity_registry(pool: Arc<PgPool>) -> ActivityRegistry {
     let node_status_pool = pool.clone();
 
     ActivityRegistry::builder()
-        .register(activities::execute_sql::NAME, move |ctx: ActivityContext, query: String| {
+        .register(activities::execute_sql::NAME, move |ctx: ActivityContext, input_json: String| {
             let pool = sql_pool.clone();
-            async move { activities::execute_sql::execute(ctx, pool, query).await }
+            async move { activities::execute_sql::execute(ctx, pool, input_json).await }
         })
         .register(activities::load_function_graph::NAME, move |ctx: ActivityContext, instance_id: String| {
             let pool = graph_pool.clone();

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,6 +49,84 @@ pub fn postgres_connection_string() -> String {
     format!("postgres://{user}@{host}:{port}/{database}")
 }
 
+/// Get the PostgreSQL host for connections
+pub fn get_host() -> String {
+    std::env::var("PGHOST").unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
+/// Get the PostgreSQL port for connections
+pub fn get_port() -> u16 {
+    std::env::var("PGPORT")
+        .unwrap_or_else(|_| {
+            if let Ok(pgdata) = std::env::var("PGDATA") {
+                if pgdata.contains(".pgrx") {
+                    "28817".to_string()
+                } else {
+                    "5432".to_string()
+                }
+            } else {
+                "28817".to_string()
+            }
+        })
+        .parse::<u16>()
+        .unwrap_or(5432)
+}
+
+/// Get the PostgreSQL database name for connections
+pub fn get_database_name() -> String {
+    std::env::var("POSTGRES_DB")
+        .or_else(|_| std::env::var("PGDATABASE"))
+        .unwrap_or_else(|_| "postgres".to_string())
+}
+
+/// Create a single PostgreSQL connection authenticated as `login_role`,
+/// then SET ROLE to `effective_role`.
+pub async fn connect_as_user(
+    login_role: &str,
+    effective_role: &str,
+) -> Result<sqlx::postgres::PgConnection, String> {
+    use sqlx::postgres::PgConnectOptions;
+    use sqlx::Connection;
+
+    let mut options = PgConnectOptions::new()
+        .username(login_role)
+        .database(&get_database_name())
+        .port(get_port());
+
+    let host = get_host();
+    if !host.is_empty() {
+        options = options.host(&host);
+    }
+
+    let mut conn = sqlx::postgres::PgConnection::connect_with(&options)
+        .await
+        .map_err(|e| {
+            format!(
+                "Failed to connect as '{}' (for effective role '{}'). Error: {}",
+                login_role, effective_role, e
+            )
+        })?;
+
+    // Switch to effective role if different from login role
+    if login_role != effective_role {
+        sqlx::query(&format!(
+            "SET ROLE \"{}\"",
+            effective_role.replace('"', "\"\"")
+        ))
+        .execute(&mut conn)
+        .await
+        .map_err(|e| format!("SET ROLE {} failed: {}", effective_role, e))?;
+    }
+
+    // Prevent recursive df.start() calls
+    sqlx::query("SET df.in_workflow = 'true'")
+        .execute(&mut conn)
+        .await
+        .map_err(|e| format!("SET df.in_workflow failed: {}", e))?;
+
+    Ok(conn)
+}
+
 /// Schema name for Duroxide internal tables
 pub const DUROXIDE_SCHEMA: &str = "duroxide";
 
@@ -245,6 +323,10 @@ pub struct FunctionNode {
     pub result_name: Option<String>,
     pub left_node: Option<String>,
     pub right_node: Option<String>,
+    /// Effective role (outer user) for privilege isolation
+    pub submitted_by: String,
+    /// Authenticated role (session user) for connection authentication
+    pub login_role: String,
 }
 
 /// Represents the entire function graph for an instance

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -20,7 +20,7 @@ use crate::types::{postgres_connection_string, DUROXIDE_SCHEMA};
 /// Must be called before Runtime::start_with_store() to capture all logs.
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        EnvFilter::new("warn,duroxide::orchestration=info,duroxide::activity=info")
+        EnvFilter::new("warn,duroxide::orchestration=info,duroxide::activity=info,sqlx_postgres::options::pgpass=error")
     });
 
     let _ = tracing_subscriber::fmt()

--- a/tests/e2e/sql/00_setup_playground.sql
+++ b/tests/e2e/sql/00_setup_playground.sql
@@ -1,8 +1,43 @@
 -- Setup: Create playground schema and test data for scenario tests
 -- This file runs first (00_) to set up shared test infrastructure
 
+-- ---------------------------------------------------------------------------
+-- E2E test roles
+--
+-- We want the default E2E posture to be: run tests as a non-privileged role.
+-- This setup file is expected to run as a superuser (postgres in Docker,
+-- or the pgrx superuser in local runs) and will create/grant the test role.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'df_e2e_user') THEN
+        CREATE ROLE df_e2e_user LOGIN;
+    END IF;
+END $$;
+
+-- Grant access to df API surface used by tests
+GRANT USAGE ON SCHEMA df TO df_e2e_user;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO df_e2e_user;
+
+-- Install extensions needed by tests (requires superuser)
+CREATE EXTENSION IF NOT EXISTS dblink;
+
+-- Current implementation details: df.start() links nodes/instances and reads vars
+-- via direct table access. Until table hardening lands, E2E needs DML on these.
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.instances TO df_e2e_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.nodes TO df_e2e_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO df_e2e_user;
+
+-- E2E tests create/drop temporary state tables in the public schema.
+-- PG15+ revokes CREATE on public from PUBLIC by default.
+GRANT USAGE, CREATE ON SCHEMA public TO df_e2e_user;
+
 -- Create playground schema
 CREATE SCHEMA IF NOT EXISTS playground;
+
+-- Ensure playground objects are owned by the non-privileged E2E role
+ALTER SCHEMA playground OWNER TO df_e2e_user;
 
 -- Users table
 CREATE TABLE IF NOT EXISTS playground.users (
@@ -13,6 +48,8 @@ CREATE TABLE IF NOT EXISTS playground.users (
     created_at TIMESTAMP DEFAULT now()
 );
 
+ALTER TABLE playground.users OWNER TO df_e2e_user;
+
 -- Orders table
 CREATE TABLE IF NOT EXISTS playground.orders (
     id SERIAL PRIMARY KEY,
@@ -22,6 +59,8 @@ CREATE TABLE IF NOT EXISTS playground.orders (
     created_at TIMESTAMP DEFAULT now(),
     processed_at TIMESTAMP
 );
+
+ALTER TABLE playground.orders OWNER TO df_e2e_user;
 
 -- Task queue for job processing examples
 CREATE TABLE IF NOT EXISTS playground.task_queue (
@@ -34,6 +73,8 @@ CREATE TABLE IF NOT EXISTS playground.task_queue (
     completed_at TIMESTAMP
 );
 
+ALTER TABLE playground.task_queue OWNER TO df_e2e_user;
+
 -- Logs table for function output
 CREATE TABLE IF NOT EXISTS playground.logs (
     id SERIAL PRIMARY KEY,
@@ -41,6 +82,8 @@ CREATE TABLE IF NOT EXISTS playground.logs (
     level VARCHAR(20) DEFAULT 'info',
     created_at TIMESTAMP DEFAULT now()
 );
+
+ALTER TABLE playground.logs OWNER TO df_e2e_user;
 
 -- Staging table for ETL examples
 CREATE TABLE IF NOT EXISTS playground.staging (
@@ -50,6 +93,8 @@ CREATE TABLE IF NOT EXISTS playground.staging (
     processed_at TIMESTAMP
 );
 
+ALTER TABLE playground.staging OWNER TO df_e2e_user;
+
 -- Target table for ETL examples
 CREATE TABLE IF NOT EXISTS playground.target (
     id SERIAL PRIMARY KEY,
@@ -58,6 +103,8 @@ CREATE TABLE IF NOT EXISTS playground.target (
     processed_at TIMESTAMP,
     loaded_at TIMESTAMP DEFAULT now()
 );
+
+ALTER TABLE playground.target OWNER TO df_e2e_user;
 
 -- Insert sample users
 INSERT INTO playground.users (name, email, active) VALUES

--- a/tests/e2e/sql/19_github_api.sql
+++ b/tests/e2e/sql/19_github_api.sql
@@ -102,6 +102,7 @@ SELECT sha, author, committed_at, LEFT(message, 50) AS message FROM github_commi
 
 -- Cleanup
 DROP TABLE _test_github;
+DROP TABLE github_commits;
 SELECT df.clearvars();
 
 SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/22_cross_connection.sql
+++ b/tests/e2e/sql/22_cross_connection.sql
@@ -6,9 +6,6 @@
 -- Setup
 -- ============================================================================
 
--- Enable dblink for cross-connection calls
-CREATE EXTENSION IF NOT EXISTS dblink;
-
 DROP TABLE IF EXISTS cross_conn_log;
 CREATE TABLE cross_conn_log (
     id SERIAL PRIMARY KEY,

--- a/tests/e2e/sql/23_transactions.sql
+++ b/tests/e2e/sql/23_transactions.sql
@@ -171,8 +171,6 @@ END $$;
 -- df.start() is called, and then the transaction is explicitly rolled back.
 -- ============================================================================
 
-CREATE EXTENSION IF NOT EXISTS dblink;
-
 DO $$
 DECLARE
     connstr TEXT := 'host=localhost dbname=postgres port=28817';

--- a/tests/e2e/sql/26_superuser_scenarios.sql
+++ b/tests/e2e/sql/26_superuser_scenarios.sql
@@ -1,0 +1,44 @@
+-- Test: Superuser durable SQL execution
+--
+-- This test is intentionally run as a superuser by the E2E harness.
+-- It verifies that durable functions work when submitted by a superuser,
+-- and exercises a superuser-only query (pg_authid).
+
+CREATE TEMP TABLE _test_state (instance_id TEXT);
+
+INSERT INTO _test_state
+SELECT df.start(
+    df.sql('SELECT (SELECT rolname FROM pg_authid LIMIT 1) AS any_role'),
+    'test-superuser-pg_authid'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    attempts INT := 0;
+    result TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED: expected completed, got %', status;
+    END IF;
+
+    SELECT r INTO result FROM df.result(inst_id) r;
+    IF result NOT LIKE '%any_role%' THEN
+        RAISE EXCEPTION 'TEST FAILED: expected result to contain any_role, got %', result;
+    END IF;
+
+    RAISE NOTICE 'TEST PASSED: superuser durable sql (pg_authid)';
+END $$;
+
+DROP TABLE _test_state;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/27_user_isolation.sql
+++ b/tests/e2e/sql/27_user_isolation.sql
@@ -233,6 +233,104 @@ END $$;
 DROP TABLE _test_state_5;
 
 -- ============================================================================
+-- Test 6: SECURITY DEFINER function - captures caller, not definer
+-- ============================================================================
+-- This verifies that GetOuterUserId() correctly identifies the caller's
+-- identity, not the function owner's identity, when df.start() is called
+-- inside a SECURITY DEFINER function.
+
+-- Create a superuser-only table (alice has no access)
+CREATE TABLE IF NOT EXISTS iso_superuser_secrets (id SERIAL PRIMARY KEY, value TEXT);
+INSERT INTO iso_superuser_secrets (value) VALUES ('classified') ON CONFLICT DO NOTHING;
+-- Do NOT grant alice any access to this table
+
+-- Create a SECURITY DEFINER wrapper function owned by superuser
+CREATE OR REPLACE FUNCTION iso_submit_as_definer(q TEXT) RETURNS TEXT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT df.start(df.sql(q), 'secdef-test');
+$$;
+
+-- Grant alice permission to execute the wrapper
+GRANT EXECUTE ON FUNCTION iso_submit_as_definer TO iso_alice;
+
+-- Test 6a: Alice calls SECURITY DEFINER function to query her own table
+-- Expected: succeeds because the function runs as alice (caller), not superuser (definer)
+SET SESSION AUTHORIZATION iso_alice;
+CREATE TEMP TABLE _test_state_6a (instance_id TEXT);
+INSERT INTO _test_state_6a
+SELECT iso_submit_as_definer('SELECT value FROM iso_alice_data LIMIT 1');
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    final_status TEXT;
+    result TEXT;
+    inst_submitted TEXT;
+    inst_login TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state_6a;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO final_status;
+
+    IF final_status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 6a - SECURITY DEFINER caller access): expected completed, got %', final_status;
+    END IF;
+
+    SELECT r INTO result FROM df.result(inst_id) r;
+    IF result IS NULL OR result NOT LIKE '%alice secret%' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 6a): expected alice secret, got %', result;
+    END IF;
+
+    -- Verify identity columns show alice (caller), not superuser (definer)
+    SELECT submitted_by::text, login_role::text INTO inst_submitted, inst_login
+      FROM df.instances WHERE id = inst_id;
+
+    IF inst_submitted != 'iso_alice' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 6a): expected submitted_by=iso_alice (caller), got % (would be superuser if definer was captured)', inst_submitted;
+    END IF;
+    IF inst_login != 'iso_alice' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 6a): expected login_role=iso_alice, got %', inst_login;
+    END IF;
+
+    RAISE NOTICE 'Test 6a PASSED: SECURITY DEFINER captures caller (alice), not definer (superuser)';
+END $$;
+
+DROP TABLE _test_state_6a;
+
+-- Test 6b: Alice calls SECURITY DEFINER function to query superuser table
+-- Expected: FAILS because the function runs as alice (caller), not superuser (definer)
+-- This proves GetOuterUserId() captured the caller's identity correctly
+SET SESSION AUTHORIZATION iso_alice;
+CREATE TEMP TABLE _test_state_6b (instance_id TEXT);
+INSERT INTO _test_state_6b
+SELECT iso_submit_as_definer('SELECT value FROM iso_superuser_secrets LIMIT 1');
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    final_status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state_6b;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO final_status;
+
+    IF final_status != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 6b - SECURITY DEFINER unauthorized): expected failed, got % (if completed, function incorrectly ran as definer instead of caller)', final_status;
+    END IF;
+
+    RAISE NOTICE 'Test 6b PASSED: SECURITY DEFINER function runs as caller, cannot access superuser table';
+END $$;
+
+DROP TABLE _test_state_6b;
+
+-- Cleanup Test 6 resources
+DROP FUNCTION IF EXISTS iso_submit_as_definer(TEXT);
+DROP TABLE IF EXISTS iso_superuser_secrets CASCADE;
+
+-- ============================================================================
 -- Cleanup
 -- ============================================================================
 DROP TABLE IF EXISTS iso_alice_data CASCADE;

--- a/tests/e2e/sql/27_user_isolation.sql
+++ b/tests/e2e/sql/27_user_isolation.sql
@@ -331,6 +331,106 @@ DROP FUNCTION IF EXISTS iso_submit_as_definer(TEXT);
 DROP TABLE IF EXISTS iso_superuser_secrets CASCADE;
 
 -- ============================================================================
+-- Test 7: Dropped role during execution
+-- ============================================================================
+-- This verifies that clear error messages are produced when the submitting
+-- role is dropped between node executions in a multi-step function.
+
+-- Create ephemeral user and table
+DO $test7_setup$
+BEGIN
+    BEGIN DROP OWNED BY iso_ephemeral; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE iso_ephemeral;     EXCEPTION WHEN undefined_object THEN NULL; END;
+END $test7_setup$;
+
+CREATE ROLE iso_ephemeral LOGIN;
+GRANT USAGE ON SCHEMA df TO iso_ephemeral;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO iso_ephemeral;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.instances, df.nodes TO iso_ephemeral;
+GRANT SELECT ON df.vars TO iso_ephemeral;
+GRANT TEMPORARY ON DATABASE postgres TO iso_ephemeral;
+
+-- Submit a sequence: df.sleep(3) followed by df.sql('SELECT 1')
+-- We'll drop the role after the sleep starts but before the SQL executes.
+-- This tests the realistic scenario: role dropped between nodes in a multi-node graph.
+
+-- Use a regular table (not temp) so we can access it after session switch
+CREATE TABLE IF NOT EXISTS _test_state_7_persistent (instance_id TEXT);
+GRANT INSERT ON _test_state_7_persistent TO iso_ephemeral;
+
+SET SESSION AUTHORIZATION iso_ephemeral;
+INSERT INTO _test_state_7_persistent SELECT df.start(df.sleep(3) ~> df.sql('SELECT 1'), 'ephemeral-test');
+RESET SESSION AUTHORIZATION;
+
+-- Wait for the sleep node to start, then drop the role
+DO $$
+DECLARE
+    inst_id TEXT;
+    attempts INT := 0;
+    node_count INT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state_7_persistent;
+    
+    -- Wait until at least one node has started (status != 'pending')
+    LOOP
+        SELECT COUNT(*) INTO node_count
+          FROM df.nodes
+          WHERE instance_id = inst_id
+            AND status != 'pending'
+            AND status IS NOT NULL;
+        EXIT WHEN node_count > 0 OR attempts > 100;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+    
+    IF node_count = 0 THEN
+        RAISE EXCEPTION 'TEST SETUP FAILED (Test 7): sleep node never started';
+    END IF;
+    
+    RAISE NOTICE 'Test 7: Sleep node started, now dropping role iso_ephemeral';
+    
+    -- Drop the user and their objects (no need to terminate backends)
+    DROP OWNED BY iso_ephemeral;
+    DROP ROLE iso_ephemeral;
+    
+    RAISE NOTICE 'Test 7: Dropped role iso_ephemeral, SQL node should fail when it tries to execute';
+END $$;
+
+-- Wait for execution and verify it fails with clear error
+DO $$
+DECLARE
+    inst_id TEXT;
+    final_status TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state_7_persistent;
+    
+    -- Wait for the instance to complete (should fail when trying to execute SQL node)
+    LOOP
+        SELECT status INTO final_status FROM df.instances WHERE id = inst_id;
+        EXIT WHEN lower(final_status) IN ('failed', 'completed') OR attempts > 100;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+    
+    IF final_status IS NULL THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 7 - dropped role): instance not found';
+    END IF;
+    
+    IF lower(final_status) != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 7 - dropped role): expected failed, got %', final_status;
+    END IF;
+    
+    -- The error should mention connection failure for the dropped role
+    -- We're not checking the exact error text since it comes from libpq/sqlx,
+    -- but we verified the instance transitioned to failed status
+    
+    RAISE NOTICE 'Test 7 PASSED: Dropped role causes clear failure (status=failed)';
+END $$;
+
+DROP TABLE _test_state_7_persistent;
+
+-- ============================================================================
 -- Cleanup
 -- ============================================================================
 DROP TABLE IF EXISTS iso_alice_data CASCADE;

--- a/tests/e2e/sql/27_user_isolation.sql
+++ b/tests/e2e/sql/27_user_isolation.sql
@@ -1,0 +1,254 @@
+-- Test: User Isolation - SQL executed with submitter's privileges
+--
+-- This test must run as SUPERUSER because it creates/drops roles.
+-- It validates that durable functions execute SQL as the submitting user,
+-- not as the background worker's superuser.
+
+-- ============================================================================
+-- Setup: Create two test users with separate tables
+-- ============================================================================
+DO $setup$
+BEGIN
+    -- Clean up from any previous run
+    PERFORM pg_terminate_backend(pid)
+      FROM pg_stat_activity
+      WHERE usename IN ('iso_alice', 'iso_bob')
+        AND pid <> pg_backend_pid();
+
+    -- Drop roles if they exist (CASCADE owned objects first)
+    BEGIN DROP OWNED BY iso_alice; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP OWNED BY iso_bob;   EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE iso_alice;     EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE iso_bob;       EXCEPTION WHEN undefined_object THEN NULL; END;
+END $setup$;
+
+-- Create users
+CREATE ROLE iso_alice LOGIN;
+CREATE ROLE iso_bob   LOGIN;
+
+-- Grant df permissions
+GRANT USAGE ON SCHEMA df TO iso_alice, iso_bob;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO iso_alice, iso_bob;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.instances, df.nodes TO iso_alice, iso_bob;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO iso_alice, iso_bob;
+-- Alice and Bob need CREATE TEMP TABLE for their test state tables
+GRANT TEMPORARY ON DATABASE postgres TO iso_alice, iso_bob;
+
+-- Create per-user tables
+CREATE TABLE IF NOT EXISTS iso_alice_data (id SERIAL PRIMARY KEY, value TEXT);
+ALTER TABLE iso_alice_data OWNER TO iso_alice;
+INSERT INTO iso_alice_data (value) VALUES ('alice secret') ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS iso_bob_data (id SERIAL PRIMARY KEY, value TEXT);
+ALTER TABLE iso_bob_data OWNER TO iso_bob;
+INSERT INTO iso_bob_data (value) VALUES ('bob secret') ON CONFLICT DO NOTHING;
+
+-- ============================================================================
+-- Test 1: Alice can access her own table via durable function
+-- ============================================================================
+-- Create temp table INSIDE SET SESSION AUTHORIZATION so iso_alice owns it
+SET SESSION AUTHORIZATION iso_alice;
+CREATE TEMP TABLE _test_state_1 (instance_id TEXT);
+INSERT INTO _test_state_1
+SELECT df.start(df.sql('SELECT value FROM iso_alice_data LIMIT 1'), 'iso-alice-own');
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    final_status TEXT;
+    result TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state_1;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO final_status;
+
+    IF final_status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 1 - alice own table): expected completed, got %', final_status;
+    END IF;
+
+    SELECT r INTO result FROM df.result(inst_id) r;
+    IF result IS NULL OR result NOT LIKE '%alice secret%' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 1): expected alice secret, got %', result;
+    END IF;
+
+    RAISE NOTICE 'Test 1 PASSED: Alice can access her own table';
+END $$;
+
+DROP TABLE _test_state_1;
+
+-- ============================================================================
+-- Test 2: Alice CANNOT access Bob's table via durable function
+-- ============================================================================
+SET SESSION AUTHORIZATION iso_alice;
+CREATE TEMP TABLE _test_state_2 (instance_id TEXT);
+INSERT INTO _test_state_2
+SELECT df.start(df.sql('SELECT value FROM iso_bob_data LIMIT 1'), 'iso-alice-bob');
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    final_status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state_2;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO final_status;
+
+    IF final_status != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 2 - alice access bob table): expected failed, got %', final_status;
+    END IF;
+
+    RAISE NOTICE 'Test 2 PASSED: Alice cannot access Bob''s table';
+END $$;
+
+DROP TABLE _test_state_2;
+
+-- ============================================================================
+-- Test 3: Bob can access his own table via durable function
+-- ============================================================================
+SET SESSION AUTHORIZATION iso_bob;
+CREATE TEMP TABLE _test_state_3 (instance_id TEXT);
+INSERT INTO _test_state_3
+SELECT df.start(df.sql('SELECT value FROM iso_bob_data LIMIT 1'), 'iso-bob-own');
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    final_status TEXT;
+    result TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state_3;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO final_status;
+
+    IF final_status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 3 - bob own table): expected completed, got %', final_status;
+    END IF;
+
+    SELECT r INTO result FROM df.result(inst_id) r;
+    IF result IS NULL OR result NOT LIKE '%bob secret%' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 3): expected bob secret, got %', result;
+    END IF;
+
+    RAISE NOTICE 'Test 3 PASSED: Bob can access his own table';
+END $$;
+
+DROP TABLE _test_state_3;
+
+-- ============================================================================
+-- Test 4: Bob CANNOT access Alice's table via durable function
+-- ============================================================================
+SET SESSION AUTHORIZATION iso_bob;
+CREATE TEMP TABLE _test_state_4 (instance_id TEXT);
+INSERT INTO _test_state_4
+SELECT df.start(df.sql('SELECT value FROM iso_alice_data LIMIT 1'), 'iso-bob-alice');
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    final_status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state_4;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO final_status;
+
+    IF final_status != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 4 - bob access alice table): expected failed, got %', final_status;
+    END IF;
+
+    RAISE NOTICE 'Test 4 PASSED: Bob cannot access Alice''s table';
+END $$;
+
+DROP TABLE _test_state_4;
+
+-- ============================================================================
+-- Test 5: SET ROLE with a group role (no LOGIN)
+-- ============================================================================
+DO $group_setup$
+BEGIN
+    BEGIN DROP OWNED BY iso_analysts; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE iso_analysts;     EXCEPTION WHEN undefined_object THEN NULL; END;
+END $group_setup$;
+
+CREATE ROLE iso_analysts NOLOGIN;
+CREATE TABLE IF NOT EXISTS iso_analyst_data (id SERIAL PRIMARY KEY, value TEXT);
+ALTER TABLE iso_analyst_data OWNER TO iso_analysts;
+INSERT INTO iso_analyst_data (value) VALUES ('analyst report') ON CONFLICT DO NOTHING;
+
+-- Grant iso_analysts to alice and grant df permissions to the group role
+GRANT iso_analysts TO iso_alice;
+GRANT USAGE ON SCHEMA df TO iso_analysts;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO iso_analysts;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.instances, df.nodes TO iso_analysts;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO iso_analysts;
+GRANT TEMPORARY ON DATABASE postgres TO iso_analysts;
+
+SET SESSION AUTHORIZATION iso_alice;
+SET ROLE iso_analysts;
+-- session_user = iso_alice, current_user (outer) = iso_analysts
+CREATE TEMP TABLE _test_state_5 (instance_id TEXT);
+INSERT INTO _test_state_5
+SELECT df.start(df.sql('SELECT value FROM iso_analyst_data LIMIT 1'), 'iso-set-role');
+RESET ROLE;
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    final_status TEXT;
+    result TEXT;
+    inst_login TEXT;
+    inst_submitted TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state_5;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO final_status;
+
+    IF final_status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 5 - SET ROLE): expected completed, got %', final_status;
+    END IF;
+
+    SELECT r INTO result FROM df.result(inst_id) r;
+    IF result IS NULL OR result NOT LIKE '%analyst report%' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 5): expected analyst report, got %', result;
+    END IF;
+
+    -- Verify identity columns on the instance
+    SELECT submitted_by::text, login_role::text INTO inst_submitted, inst_login
+      FROM df.instances WHERE id = inst_id;
+
+    IF inst_login != 'iso_alice' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 5): expected login_role=iso_alice, got %', inst_login;
+    END IF;
+    IF inst_submitted != 'iso_analysts' THEN
+        RAISE EXCEPTION 'TEST FAILED (Test 5): expected submitted_by=iso_analysts, got %', inst_submitted;
+    END IF;
+
+    RAISE NOTICE 'Test 5 PASSED: SET ROLE group role works (login=iso_alice, effective=iso_analysts)';
+END $$;
+
+DROP TABLE _test_state_5;
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+DROP TABLE IF EXISTS iso_alice_data CASCADE;
+DROP TABLE IF EXISTS iso_bob_data CASCADE;
+DROP TABLE IF EXISTS iso_analyst_data CASCADE;
+
+REVOKE iso_analysts FROM iso_alice;
+
+DO $cleanup$
+BEGIN
+    BEGIN DROP OWNED BY iso_analysts; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP OWNED BY iso_alice;    EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP OWNED BY iso_bob;      EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE iso_analysts;     EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE iso_alice;        EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE iso_bob;          EXCEPTION WHEN undefined_object THEN NULL; END;
+END $cleanup$;
+
+SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## Summary

Implements user isolation for pg_durable: SQL in durable functions now executes with the privileges of the user who submitted them, not the background worker's superuser privileges.

## Changes

### Core Implementation (commit a819959)
- **Schema**: Added `submitted_by` and `login_role` columns (REGROLE type) to `df.nodes` and `df.instances`
- **Identity capture**: `df.start()` captures `GetSessionUserId()` (login_role) and `GetOuterUserId()` (submitted_by) 
- **Connection management**: Per-user connections via `connect_as_user()` - connects as login_role, then SET ROLE to submitted_by
- **Activity changes**: `execute_sql` activity receives JSON input with query + identity and creates isolated connection
- **Type safety**: Used REGROLE to ensure OIDs resolve to valid roles at INSERT time

### E2E Testing (commit e9dc534)
- **Test infrastructure**: Most E2E tests now run as non-privileged `df_e2e_user` role
- **26_superuser_scenarios.sql**: Verifies superuser functions still work
- **27_user_isolation.sql**: Comprehensive test covering:
  - ✅ Users can access their own tables
  - ✅ Users cannot access other users' tables
  - ✅ SET ROLE with group roles (no LOGIN)
  - ✅ Identity columns correctly set (login_role, submitted_by)

### Code Review (commit 91a70e5)
- **docs/user-isolation-review.md**: Comprehensive review identifying strengths, gaps, and recommendations

### Follow-up Improvements
- **9ce49c5**: Added SECURITY DEFINER test (Test 6a and 6b)
- **661a30e**: Added USER_GUIDE.md "User Isolation & Privileges" section
- **7debf88**: Added dropped-role test (Test 7)
- **c64eba8**: Updated review document marking all items as resolved

## Test Results

✅ All unit tests passing  
✅ All E2E tests passing (44 tests)

## Design Document

See [docs/user-isolation.md](https://github.com/microsoft/pg_durable/blob/pinodeca/user-isolation/docs/user-isolation.md) for complete architecture and design rationale.

## Security Considerations

**What this protects:**
- Table access: User A cannot read/write User B's tables through durable functions
- Privilege alignment: SQL runs with exact same effective role as submitter had
- Group roles: SET ROLE analysts correctly executes with group privileges
- No escalation: Non-superusers cannot gain superuser privileges

**Known limitations (acknowledged as future work):**
- HTTP activity not yet isolated (runs with worker privileges)
- `df.vars` shared across all users
- No RLS on `df.instances`/`df.nodes` (cross-instance visibility)

## Review Findings

See [docs/user-isolation-review.md](https://github.com/microsoft/pg_durable/blob/pinodeca/user-isolation/docs/user-isolation-review.md) for detailed analysis.

**All blocking and strongly recommended items have been addressed:**
- ✅ SECURITY DEFINER test added (commit 9ce49c5) - Test 6a and 6b in 27_user_isolation.sql
- ✅ USER_GUIDE.md updated (commit 661a30e) - Added comprehensive "User Isolation & Privileges" section
- ✅ Dropped-role test added (commit 7debf88) - Test 7 in 27_user_isolation.sql
- ✅ HTTP isolation gap documented (commit 661a30e) - Added to USER_GUIDE.md "Current Limitations"
- ✅ Review document updated (commit c64eba8) - Marked all items as resolved

**Status:** Ready for merge

## Related

Part of the pre-release security hardening effort.
