### PR TITLE
Extension lifecycle: CREATE EXTENSION owns duroxide schema, BGW state machine

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[net]
+git-fetch-with-cli = true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,9 @@ pg_durable is a **PostgreSQL extension** (pgrx/Rust) providing durable SQL funct
 | [src/activities/](src/activities/) | Duroxide activities (I/O happens here) |
 | [src/types.rs](src/types.rs) | Core types: `Durofut`, `FunctionGraph`, `FunctionNode` |
 | [tests/e2e/sql/](tests/e2e/sql/) | SQL-based E2E tests (numbered, run sequentially) |
-
+| [sql/duroxide_upstream/](sql/duroxide_upstream/) | Checked-in copies of duroxide-pg-opt migrations |
+| [scripts/gen-duroxide-install-sql.sh](scripts/gen-duroxide-install-sql.sh) | Generates combined install SQL from upstream copies |
+| [scripts/verify-duroxide-migrations.sh](scripts/verify-duroxide-migrations.sh) | Verifies upstream copies match duroxide-pg-opt |
 ## Development Commands
 
 ```bash
@@ -75,6 +77,51 @@ Tests in `tests/e2e/sql/` follow this pattern:
 **Adding a new activity:** Create file in `src/activities/`, add `pub const NAME`, register in [src/registry.rs](src/registry.rs)
 
 **Adding E2E test:** Create numbered SQL file in `tests/e2e/sql/`, follow existing pattern (see [02_sequence.sql](tests/e2e/sql/02_sequence.sql))
+
+## Duroxide Migration Sync Workflow
+
+pg_durable includes the duroxide-pg-opt schema DDL as extension SQL to ensure proper PostgreSQL ownership semantics. This requires maintaining checked-in copies of upstream migrations.
+
+### Migration Files
+
+- **Upstream source**: `duroxide-pg-opt/migrations/000*.sql` (from duroxide-pg-opt repository)
+- **Checked-in copies**: [sql/duroxide_upstream/](sql/duroxide_upstream/) (verbatim copies of upstream)
+- **Combined install SQL**: [sql/duroxide_install.sql](sql/duroxide_install.sql) (generated from copies)
+- **Extension integration**: [src/lib.rs](src/lib.rs) includes via `extension_sql_file!("../sql/duroxide_install.sql")`
+
+### Scripts
+
+**Generate combined install SQL:**
+```bash
+./scripts/gen-duroxide-install-sql.sh
+# Creates sql/duroxide_install.sql from sql/duroxide_upstream/*.sql
+```
+
+**Verify migrations match upstream:**
+```bash
+# Requires duroxide-pg-opt cloned at repository root
+git clone --branch pinodeca/initialization \
+  https://github.com/microsoft/duroxide-pg-opt.git
+./scripts/verify-duroxide-migrations.sh
+```
+
+### When to Update Migrations
+
+1. **Upgrading duroxide-pg-opt dependency**: When Cargo.toml points to a new version/tag/branch:
+   - Clone/pull the matching duroxide-pg-opt version
+   - Copy new/updated migration files from `duroxide-pg-opt/migrations/` to `sql/duroxide_upstream/`
+   - Run `./scripts/gen-duroxide-install-sql.sh` to regenerate install SQL
+   - Run `./scripts/verify-duroxide-migrations.sh` to confirm sync
+   - Commit both the upstream copies and generated install SQL
+
+2. **After cloning pg_durable**: CI automatically verifies migrations on every PR
+
+### Important Notes
+
+- ⚠️ **Never manually edit `sql/duroxide_install.sql`** - it's generated
+- ⚠️ **Keep `sql/duroxide_upstream/` in sync** with the duroxide-pg-opt version referenced in Cargo.toml
+- ✅ **CI enforces sync** - `.github/workflows/ci.yml` clones duroxide-pg-opt and runs verification
+- ✅ **Extension owns the schema** - duroxide schema/tables are created by `CREATE EXTENSION pg_durable`
 
 ## Dependencies
 
@@ -163,7 +210,8 @@ SELECT 'TEST PASSED' AS result;
 Pull requests automatically run the CI workflow (`.github/workflows/ci.yml`):
 
 1. **Format Check**: `cargo fmt --check`
-2. **Clippy & Tests**: `cargo clippy`, `cargo pgrx test pg17`, and `./scripts/test-e2e-local.sh`
+2. **Migration Verification**: Clones duroxide-pg-opt and runs `./scripts/verify-duroxide-migrations.sh`
+3. **Clippy & Tests**: `cargo clippy`, `cargo pgrx test pg17`, and `./scripts/test-e2e-local.sh`
 
 All checks must pass before a PR can be merged. Configure branch protection rules in GitHub to enforce this.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,15 @@ jobs:
         run: |
           git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
 
+      - name: Verify duroxide migrations match upstream
+        run: |
+          # Clone duroxide-pg-opt to verify our checked-in copies match upstream.
+          # NOTE: The branch must match the duroxide-pg-opt ref in Cargo.toml.
+          # Update this when switching to a tag or a different branch.
+          git clone --depth=1 --branch pinodeca/initialization \
+            https://${{ secrets.GH_PAT }}@github.com/microsoft/duroxide-pg-opt.git
+          ./scripts/verify-duroxide-migrations.sh
+
       - name: Run clippy
         run: cargo clippy --no-default-features --features pg${{ matrix.pg_version }} -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "duroxide-pg-opt"
 version = "0.1.18"
-source = "git+https://github.com/microsoft/duroxide-pg-opt.git?branch=pinodeca%2Finitialization#f386df4ed96d584d8471bc741049dc6ecb4f691a"
+source = "git+https://github.com/microsoft/duroxide-pg-opt.git?branch=pinodeca%2Fmigration-policy#8ce65bd8d43851a7ab9966639822ed46d1869296"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1022,7 +1022,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2759,7 +2759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3479,7 +3479,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -3489,23 +3489,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -3520,32 +3507,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3565,24 +3530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "duroxide-pg-opt"
 version = "0.1.18"
-source = "git+https://github.com/microsoft/duroxide-pg-opt.git?tag=v0.1.18#cae71b22aa328ef44cc7a6f45d80e479c3c0908e"
+source = "git+https://github.com/microsoft/duroxide-pg-opt.git?branch=pinodeca%2Finitialization#f386df4ed96d584d8471bc741049dc6ecb4f691a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 
 # duroxide integration
 duroxide = "=0.1.20"
-duroxide-pg-opt = { git = "https://github.com/microsoft/duroxide-pg-opt.git", tag = "v0.1.18", package = "duroxide-pg-opt" }
+duroxide-pg-opt = { git = "https://github.com/microsoft/duroxide-pg-opt.git", branch = "pinodeca/initialization", package = "duroxide-pg-opt" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 
 # For ExecuteSQL activity (connecting back to PostgreSQL)
@@ -59,5 +59,3 @@ panic = "unwind"
 opt-level = 3
 lto = "fat"
 codegen-units = 1
-
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 
 # duroxide integration
 duroxide = "=0.1.20"
-duroxide-pg-opt = { git = "https://github.com/microsoft/duroxide-pg-opt.git", branch = "pinodeca/initialization", package = "duroxide-pg-opt" }
+duroxide-pg-opt = { git = "https://github.com/microsoft/duroxide-pg-opt.git", branch = "pinodeca/migration-policy", package = "duroxide-pg-opt" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 
 # For ExecuteSQL activity (connecting back to PostgreSQL)

--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ Complex integration tests with Docker:
 
 See [tests/e2e/](tests/e2e/) for details.
 
+## Verifying Duroxide Migrations
+
+pg_durable includes checked-in copies of duroxide-pg-opt migration SQL files to ensure the extension owns the duroxide schema. To verify these copies match upstream:
+
+```bash
+# Clone duroxide-pg-opt at the repository root
+git clone --branch pinodeca/initialization \
+  https://github.com/microsoft/duroxide-pg-opt.git
+
+# Verify migrations match upstream
+./scripts/verify-duroxide-migrations.sh
+```
+
+**When to verify:**
+- After updating the `duroxide-pg-opt` dependency in Cargo.toml
+- When contributing changes to pg_durable
+- CI automatically verifies on every pull request
+
+**Note:** The verification script requires the `duroxide-pg-opt` repository to be cloned at the root of the pg_durable repository.
+
 ## Documentation
 
 - [User Guide](USER_GUIDE.md) — Complete usage guide with examples

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -20,8 +20,9 @@ pg_durable is a PostgreSQL extension that brings durable, fault-tolerant functio
 10. [Signals](#signals)
 11. [Visualizing Functions](#visualizing-functions)
 12. [Monitoring](#monitoring)
-13. [Quick Reference Card](#quick-reference-card)
-14. [Appendix: Test Data Setup](#appendix-test-data-setup)
+13. [Troubleshooting](#troubleshooting)
+14. [Quick Reference Card](#quick-reference-card)
+15. [Appendix: Test Data Setup](#appendix-test-data-setup)
 
 ---
 
@@ -59,11 +60,26 @@ pg_durable enables you to define and execute **durable SQL functions** entirely 
 
 ## Getting Started
 
+### Prerequisites
+
+pg_durable requires:
+1. **PostgreSQL configuration**: Add `pg_durable` to `shared_preload_libraries` in `postgresql.conf`
+2. **Server restart**: Required after modifying `shared_preload_libraries`
+3. **Extension creation**: Run `CREATE EXTENSION pg_durable` in your database
+
 ### Enable the Extension
 
 ```sql
 CREATE EXTENSION pg_durable;
 ```
+
+**What happens during `CREATE EXTENSION`:**
+- pg_durable creates its own tables in the `df` schema (for tracking function graphs)
+- It creates the `duroxide` schema and all required tables (for durable execution state)
+- The background worker (started by `shared_preload_libraries`) detects the extension and initializes the runtime
+- Within a few seconds, the system is ready to execute durable functions
+
+> ⚠️ **Important**: The background worker waits for `CREATE EXTENSION` to complete before starting. If you include `pg_durable` in `shared_preload_libraries` but don't create the extension, the worker will remain idle and durable functions cannot execute.
 
 ### Your First Durable Function
 
@@ -1298,6 +1314,148 @@ SELECT df.status('a1b2c3d4');
 -- Result only
 SELECT df.result('a1b2c3d4');
 ```
+
+---
+
+## Troubleshooting
+
+### Extension Exists But Workflows Don't Start
+
+**Symptom**: You've run `CREATE EXTENSION pg_durable` but `df.start()` returns an instance ID that never completes.
+
+**Cause**: The background worker is not running, usually because `pg_durable` is not in `shared_preload_libraries`.
+
+**Solution**:
+1. Check if `pg_durable` is in `shared_preload_libraries`:
+   ```sql
+   SHOW shared_preload_libraries;
+   ```
+2. If missing, add to `postgresql.conf`:
+   ```ini
+   shared_preload_libraries = 'pg_durable'  # or 'pg_durable,other_ext'
+   ```
+3. Restart PostgreSQL (required for `shared_preload_libraries` changes)
+4. Verify the background worker started by checking PostgreSQL logs for:
+   ```
+   pg_durable: duroxide background worker starting...
+   pg_durable: extension detected, proceeding with initialization
+   pg_durable: duroxide runtime started
+   ```
+
+### "Failed to connect to duroxide store" Error
+
+**Symptom**: Calling `df.start()`, `df.status()`, or monitoring functions returns an error:
+```
+Failed to connect to duroxide store: ...
+```
+
+**Possible Causes**:
+
+1. **Extension not created**: Run `CREATE EXTENSION pg_durable`
+
+2. **Schema migration mismatch**: The `duroxide` schema exists but is at an incompatible version
+   - **Solution**: Drop and recreate the extension:
+     ```sql
+     DROP EXTENSION pg_durable CASCADE;
+     CREATE EXTENSION pg_durable;
+     ```
+   
+3. **Database connection issues**: PostgreSQL is not accepting connections
+   - Check PostgreSQL is running
+   - Verify connection string environment variables if customized
+
+### Background Worker Not Initializing
+
+**Symptom**: After `CREATE EXTENSION`, functions still don't execute, and logs show:
+```
+pg_durable: waiting for CREATE EXTENSION pg_durable...
+```
+
+**Cause**: The background worker is waiting for the extension to be created in the database it's connected to.
+
+**Solution**:
+1. Verify you're creating the extension in the correct database
+2. Check which database the background worker connects to:
+   - Defaults to the database specified by `PGDATABASE` environment variable or `postgres`
+   - The background worker only processes functions in **one** database
+3. If you need pg_durable in a different database:
+   - Create the extension in the database the background worker uses, OR
+   - Update environment variables and restart PostgreSQL
+
+### Extension Drop/Recreate Issues
+
+**Symptom**: After `DROP EXTENSION pg_durable CASCADE`, workflows still appear to be running or you see errors.
+
+**Explanation**: The background worker polls for extension existence every 5 seconds. After detecting a drop:
+- It shuts down the duroxide runtime (takes ~10 seconds)
+- Returns to waiting for extension creation
+- Any in-flight workflows are terminated
+
+**Solution**: Wait 15-20 seconds after `DROP EXTENSION` before recreating:
+```sql
+DROP EXTENSION pg_durable CASCADE;
+-- Wait ~20 seconds for background worker to fully shut down
+CREATE EXTENSION pg_durable;
+```
+
+### Functions Complete But Results Are Empty
+
+**Symptom**: `df.status()` shows `Completed` but `df.result()` returns empty or null.
+
+**Possible Causes**:
+
+1. **Query returns no rows**: The SQL query executed successfully but returned no data
+   ```sql
+   SELECT * FROM users WHERE id = 999999;  -- no such user
+   ```
+   
+2. **Variable not named**: Use `|=>` to capture results in named variables
+   ```sql
+   -- Bad: result not captured
+   SELECT df.start('SELECT id FROM users LIMIT 1');
+   
+   -- Good: result captured
+   SELECT df.start('SELECT id FROM users LIMIT 1' |=> 'user_id');
+   ```
+
+3. **ETL workflow that doesn't return data**: If the function performs INSERTs/UPDATEs, those succeed without returning data. Add a final query to return status:
+   ```sql
+   SELECT df.start(
+     'INSERT INTO logs (msg) VALUES (''done'')' ~>
+     'SELECT ''success'' as status'
+   );
+   ```
+
+### Slow Function Startup
+
+**Symptom**: There's a delay between `df.start()` returning and the function actually executing.
+
+**Explanation**: This is normal during:
+- **Initial extension creation**: Background worker needs 1-5 seconds to initialize
+- **After DROP/CREATE**: Background worker needs to reinitialize
+
+**Solution**: If delays persist beyond startup:
+1. Check PostgreSQL logs for errors
+2. Verify the background worker is running (see "Extension Exists But Workflows Don't Start")
+3. Check for resource contention (CPU, disk I/O, connection limits)
+
+### Check Background Worker Logs
+
+To debug background worker issues, check PostgreSQL logs:
+
+```bash
+# Find PostgreSQL log location
+psql -c "SHOW log_directory;"
+psql -c "SHOW log_filename;"
+
+# Example (adjust path for your installation)
+tail -f /var/log/postgresql/postgresql-17-main.log
+
+# Or for pgrx development:
+tail -f ~/.pgrx/17.log
+```
+
+Look for lines starting with `pg_durable:` for background worker activity.
 
 ---
 

--- a/docs/extension_lifecycle.md
+++ b/docs/extension_lifecycle.md
@@ -1,0 +1,505 @@
+# pg_durable Extension Lifecycle and Background Worker
+
+**Status:** Implemented  
+**Last Updated:** 2026-03-01  
+**Dependencies:** duroxide-pg-opt pinodeca/initialization branch
+
+> **Note:** This document describes the extension lifecycle management, background worker behavior, and duroxide-pg-opt schema integration in pg_durable.
+
+## Problem Statement
+
+Historically (before the implementation described below), pg_durable was intrusive when it was included in `shared_preload_libraries` and `CREATE EXTENSION pg_durable` had not been executed:
+
+1. **Background worker creates duroxide schema immediately** on startup via `PostgresProvider::new_with_schema()`, even if `CREATE EXTENSION pg_durable` has never been run
+2. **Two SQL connection pools are created immediately** on startup (one internal to `PostgresProvider`, and one explicit `sqlx::PgPool` for activities), regardless of extension existence
+3. **df functions can trigger duroxide schema creation** if called before the background worker initializes (race condition)
+4. **No mechanism to detect extension drop** - background worker continues running even if `DROP EXTENSION pg_durable` is executed
+5. **Schema lifecycle not managed by extension system** - duroxide schema is created imperatively rather than declaratively via CREATE EXTENSION/ALTER EXTENSION UPDATE
+
+This creates confusion for users who include pg_durable in `shared_preload_libraries` for future use but haven't created the extension yet, and violates PostgreSQL best practices for extension schema management.
+
+## Goals
+
+1. **Minimize footprint when extension not created**: Background worker should do minimal work until `CREATE EXTENSION pg_durable` is executed
+2. **Proper extension lifecycle management**: Schema creation/deletion should be managed by PostgreSQL's extension system
+3. **Handle extension drop gracefully**: Background worker should detect when extension is dropped and return to waiting state
+4. **Prevent race conditions**: df functions should not trigger duroxide schema creation
+5. **Follow PostgreSQL best practices**: Per PostgreSQL expert guidance:
+   - Schemas should be managed by CREATE EXTENSION/ALTER EXTENSION UPDATE
+   - Background worker should use SPI to check extension existence (deferred)
+   - Use processUtility hooks to catch extension create/drop events (deferred)
+
+## Previous Architecture (pre-fix)
+
+### Background Worker Initialization (src/worker.rs)
+
+```rust
+#[pg_guard]
+#[no_mangle]
+pub extern "C-unwind" fn duroxide_worker_main(_arg: pg_sys::Datum) {
+    // ...
+    rt.block_on(async {
+        // Immediately tries to create PostgresProvider (and duroxide schema).
+        // NOTE: PostgresProvider initialization also creates its own internal sqlx pool.
+        let store = loop {
+            match PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA)).await {
+                Ok(s) => break Arc::new(s),
+                Err(e) => {
+                    // Retries every 5 seconds forever
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                }
+
+        
+        // Creates a *second* connection pool immediately (used by activities)
+        let pg_pool = loop {
+            match PgPoolOptions::new().max_connections(5).connect(&pg_conn_str).await {
+                Ok(pool) => break Arc::new(pool),
+                // ...
+            }
+        };
+        
+        // Starts duroxide runtime
+        let duroxide_runtime = runtime::Runtime::start_with_store(store, activities, orchestrations).await;
+        // ...
+    });
+}
+```
+
+**Issues:**
+- No check for extension existence before initialization
+- Two connection pools created eagerly (provider pool + activities pool)
+- No mechanism to detect extension drop
+
+### df Functions Using PostgresProvider (src/client.rs, src/monitoring.rs, src/explain.rs)
+
+```rust
+// src/client.rs - get_duroxide_client()
+fn get_duroxide_client() -> Result<&'static Client, String> {
+    rt.block_on(async {
+        let store = Arc::new(
+            PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA))
+                .await
+                .map_err(|e| format!("Failed to connect to duroxide store: {e}"))?,
+        );
+        // ...
+    })
+}
+```
+
+**Issues:**
+- Can be called before background worker initializes
+- May create duroxide schema before background worker does
+- No coordination with background worker lifecycle
+
+## Proposed Architecture
+
+### 1. Extension-Managed Schema *and* DDL (implemented)
+
+**Change:** pg_durable ships the Duroxide provider schema DDL as extension SQL, executed directly by PostgreSQL during `CREATE EXTENSION pg_durable`.
+
+This is the PostgreSQL best-practice approach for extension-owned objects:
+
+- Objects created by the extension SQL scripts are registered as **extension members** (dependency type `e`).
+- `DROP EXTENSION pg_durable` reliably removes the schema + objects (subject to Postgres semantics; `CASCADE` may be required because the schema is non-empty).
+- `pg_dump`/`pg_restore` behavior is more predictable because the DDL is part of the extension lifecycle rather than “out-of-band”.
+
+#### How we do it (the “migration SQL hand-over”)
+
+We keep an audited, ordered copy of the upstream migration SQL inside this repo:
+
+- `sql/duroxide_upstream/0001_*.sql` … `0005_*.sql` (verbatim copies)
+- `scripts/gen-duroxide-install-sql.sh` generates a combined `sql/duroxide_install.sql`
+- `scripts/verify-duroxide-migrations.sh` checks that:
+  - our copies match `duroxide-pg-opt/migrations/`
+  - the generated combined install SQL matches what’s checked in
+
+Then we include `sql/duroxide_install.sql` as part of the extension install SQL via `extension_sql_file!`.
+
+#### Why we avoid “out-of-band” DDL
+
+We previously considered (and prototyped) applying the schema DDL via Rust code.
+Two variants are tempting but both lose the extension ownership model:
+
+1. **Separate-session migrations** (opening a new SQL connection and running DDL) create objects that are not extension members.
+2. **SPI from a UDF during `CREATE EXTENSION`** can create the objects, but they still are not reliably registered as extension members.
+
+Given those trade-offs, running the DDL as extension SQL is the clearest, most PostgreSQL-native approach.
+
+### 2. Background Worker: `MigrationPolicy::VerifyOnly` by default
+
+duroxide-pg-opt 0.1.18 provides `MigrationPolicy::VerifyOnly` which:
+- **Never executes DDL** - no schema creation, no table creation
+- Verifies schema exists and is at expected version
+- Errors with clear messages if schema missing or version mismatch
+- Errors if schema is ahead of code (`reject_unknown_migrations`)
+
+This eliminates any need for the background worker to execute DDL.
+
+### 3. Background Worker Lifecycle State Machine (implemented, MVP polling)
+
+**Change:** Background worker should wait for extension creation before initializing the duroxide runtime.
+
+#### State Machine
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         BACKGROUND WORKER STATES                        │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  [STARTING] ──────────────────────────────────────────┐                │
+│      │                                                 │                │
+│      │ Check extension exists                          │                │
+│      │                                                 │                │
+│      ├──── No ────> [WAITING_FOR_EXTENSION]           │                │
+│      │                     │                           │                │
+│      │                     │ Poll every 5s             │                │
+│      │                     │ Check: SELECT oid         │                │
+│      │                     │        FROM pg_extension  │                │
+│      │                     │        WHERE extname =    │                │
+│      │                     │        'pg_durable'       │                │
+│      │                     │                           │                │
+│      │                     └──── Yes ───────────┐      │                │
+│      │                                          │      │                │
+│      └──── Yes ──────────────────────────────> [INITIALIZING]          │
+│                                                  │                      │
+│                                     Create duroxide store               │
+│                                     Create connection pool              │
+│                                     Start duroxide runtime              │
+│                                                  │                      │
+│                                                  ▼                      │
+│                                            [RUNNING]                    │
+│                                                  │                      │
+│                                    Poll for extension drop every 5s     │
+│                                    Check: SELECT oid FROM pg_extension  │
+│                                           WHERE extname = 'pg_durable'  │
+│                                                  │                      │
+│                          Extension exists ───────┤                      │
+│                                                  │                      │
+│                          Extension dropped ──────┴────> [SHUTTING_DOWN]│
+│                                                              │          │
+│                                              Shutdown duroxide runtime │
+│                                              Close connections         │
+│                                                              │          │
+│                                                              ▼          │
+│                                                    [WAITING_FOR_        │
+│                                                     EXTENSION]          │
+│                                                              │          │
+│                                                  (cycle repeats)        │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+#### Implementation
+
+See `src/worker.rs` for the full implementation. The main loop in `run_duroxide_runtime()` drives the state machine:
+
+1. `wait_for_extension_creation()` polls `pg_extension` via a reusable `sqlx::PgPool` (max 1 connection) every 5 seconds.
+2. `initialize_duroxide_runtime()` creates a `PostgresProvider` using `worker_provider_config()` (from `src/types.rs`) which sets `VerifyOnly` + `reject_unknown_migrations`, with long-polling intentionally left enabled for work dispatch.
+3. `run_until_extension_dropped_or_shutdown()` uses `tokio::select!` to interleave shutdown checks (every 1 second, via direct volatile read) with extension-drop checks (every 5 seconds via the shared polling pool).
+
+Key design choices vs. the original sketch:
+- **Reusable polling pool**: A single `PgPool(max_connections=1)` is created once and shared across all `check_extension_exists()` calls, avoiding the overhead of opening/closing a TCP connection on every poll.
+- **Direct shutdown check**: `is_shutdown_requested()` reads a volatile atomic and does not need `spawn_blocking`; the check runs every 1 second rather than every 100ms.
+- **Config helpers**: `worker_provider_config()` and `backend_provider_config()` in `src/types.rs` centralize `ProviderConfig` construction, eliminating duplication across ~10 call sites.
+
+### 4. Prevent df Functions from Triggering Schema Creation
+
+**Change:** df functions should fail gracefully if called before the extension has been created, and must never create schema/tables implicitly.
+
+**Implemented:** all call sites use `MigrationPolicy::VerifyOnly`, so they will not execute DDL.
+
+**Implemented:** request/response-style backend calls disable Duroxide long-polling to avoid a dedicated listener connection per backend.
+
+#### Client Functions (src/client.rs)
+
+All backend call sites (client, monitoring, explain) use `backend_provider_config()` from `src/types.rs`, which sets:
+- `VerifyOnly`: never create schema/tables
+- `long_poll.enabled = false`: avoid dedicated listener connection per backend session
+- `reject_unknown_migrations = true`: fail if schema is ahead of code
+
+See `src/client.rs::get_duroxide_client()` for the cached-client implementation.
+
+**Rationale:**
+- (Future) Check extension existence before attempting duroxide connection
+- Use `VerifyOnly` policy to ensure no schema creation from client code
+- Disable long-polling for backend request/response operations to save a dedicated listener connection per backend
+- Fail with clear, actionable error messages for different failure scenarios
+- Note on caching: after `DROP EXTENSION`, the `df.*` entrypoints disappear, so cached clients are not reachable through SQL. However, if the extension is later re-created while a backend session remains alive, a previously cached client may be stale; this can be handled later by recreating the client on specific errors.
+
+#### Monitoring Functions (src/monitoring.rs, src/explain.rs)
+
+Apply the same pattern: use `backend_provider_config()` from `src/types.rs`. See `src/monitoring.rs` and `src/explain.rs` for the full implementations.
+
+**Rationale:**
+- Same benefits as client functions: no schema creation
+- Monitoring functions are also request/response operations
+- Graceful degradation: return empty results if schema not initialized yet
+
+### 5. Extension Lifecycle Detection: sqlx polling (now) vs utility hooks (later)
+
+**Per PostgreSQL expert guidance:** A reactive approach would use utility hooks to catch `CREATE/DROP EXTENSION`.
+
+#### Current Approach (MVP): sqlx polling
+
+This design uses `sqlx` polling (checking `pg_extension` table every 5 seconds):
+
+**Advantages:**
+- Simple to implement with pgrx
+- Works with current pgrx API
+- Low overhead (one query per 5-10 seconds)
+- Avoids introducing hooks in the MVP
+
+**Disadvantages:**
+- Not reactive - up to 5 second delay detecting extension create/drop
+- Requires periodic wake-ups even when idle
+- Not the PostgreSQL "best practice" approach
+
+#### Considered for later: utility hooks
+
+**processUtility hooks** would allow reactive detection of CREATE/DROP EXTENSION:
+
+**Advantages:**
+- Immediate response to extension lifecycle events
+- No polling overhead
+- Follows PostgreSQL expert guidance
+- More architecturally correct
+
+**Challenges:**
+- Need to investigate if pgrx exposes processUtility hooks
+- If not exposed, may need to use unsafe FFI to register hooks
+- More complex implementation
+- Hook registration must happen in `_PG_init()` before extension is created
+
+**Research needed (later):**
+- Whether pgrx exposes utility hooks safely (or we need unsafe FFI)
+- How to coordinate hook callbacks with the async BGW loop
+- Whether hooks materially improve UX vs polling for this extension
+
+## What we'll implement now (MVP)
+
+### Behavior
+
+1. **Background worker does minimal work until the extension exists**
+    - Implementation: poll `pg_extension` (via `sqlx`) until `pg_durable` exists.
+    - Only after extension creation does the BGW initialize `PostgresProvider` + pools + duroxide runtime.
+    - Uses `VerifyOnly` so it never creates the duroxide schema/tables.
+
+2. **Migrations are executed as extension SQL**
+    - `CREATE EXTENSION pg_durable;` creates the `duroxide` schema *and* all Duroxide provider objects.
+    - The schema objects are extension members (created by the extension install SQL).
+
+3. **Strict runtime behavior (simple and conservative)**
+    - Background worker and all `df.*` functions use `MigrationPolicy::VerifyOnly`.
+    - If migrations are missing/behind/incompatible, everything fails closed:
+      - no orchestration execution
+      - no new orchestration submission
+      - monitoring returns errors or empty results (depending on API)
+        - Upgrade behavior will be driven by PostgreSQL extension update scripts (future work).
+
+4. **Background worker detects extension drop (polling-based)**
+        - Implementation: while running, poll `pg_extension`; if `pg_durable` disappears, shutdown the duroxide runtime and return to the wait loop.
+
+5. **Extension creation validation (implemented)**
+    - `CREATE EXTENSION pg_durable` validates prerequisites before allowing installation:
+      - **Validates shared_preload_libraries**: Extension creation fails if `pg_durable` is not in `shared_preload_libraries` (checked in `_PG_init`)
+      - **Validates target database**: Extension creation fails if run in the wrong database
+        - Background worker connects to ONE database (determined by `POSTGRES_DB` or `PGDATABASE` environment variable, defaults to `postgres`)
+        - Extension must be created in that exact database
+        - Validation runs during `CREATE EXTENSION` via SQL block that calls `df.target_database()` function
+        - Error message clearly indicates which database should be used
+    - These validations ensure users get immediate feedback rather than discovering at runtime that workflows won't execute
+
+### Repair story
+
+Because the Duroxide schema DDL runs inside `CREATE EXTENSION` as extension SQL, installs are transactional:
+
+- If `CREATE EXTENSION pg_durable` fails, the install is rolled back.
+- If you need to reset state: `DROP EXTENSION pg_durable CASCADE;` then `CREATE EXTENSION pg_durable;`.
+
+## Considered and left for later
+
+- **Utility hooks** (reactive create/drop detection) instead of polling.
+- **Multi-database support**: Currently, the background worker connects to one database only. Multi-database support would require multiple background worker processes or a more complex connection pooling strategy.
+- **DROP EXTENSION while workflows are running** (currently undefined; BGW may error while writing to `df.*`).
+- **Extension upgrade scripts**: using `pg_durable--X--Y.sql` to apply incremental changes across versions.
+  - Note: the current `CREATE SCHEMA IF NOT EXISTS duroxide;` in the install SQL is safe for fresh installs but needs care in upgrade scripts — `IF NOT EXISTS` could mask situations where the schema already exists from a non-extension source.
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **ProviderConfig integration**
+   - Test that `MigrationPolicy::VerifyOnly` correctly errors when schema missing
+   - Test that `MigrationPolicy::VerifyOnly` succeeds when schema exists and is current
+    - Test that disabling long-polling in backend sessions doesn't create PgListener connections
+
+### E2E Tests
+
+1. **Extension creation with declarative schema**
+   - Start PostgreSQL with pg_durable in shared_preload_libraries
+   - Verify no duroxide schema created (background worker waiting)
+   - Run CREATE EXTENSION pg_durable
+   - Verify duroxide schema created (owned by extension)
+    - Verify duroxide tables/functions created (by extension SQL)
+    - Verify background worker initializes eventually
+   - Verify df functions work
+
+2. **Extension not created**
+   - Start PostgreSQL with pg_durable in shared_preload_libraries
+   - Verify no duroxide schema created
+    - Verify df functions fail (no implicit DDL)
+    - Verify background worker does not create schema/tables while retrying
+
+3. **Extension drop**
+    - Create extension, start workflow
+    - Drop extension
+    - Verify schema + objects are removed (extension-owned)
+    - (Future) Decide and test what the BGW should do on drop (detect + shut down vs keep retrying)
+
+4. **Extension recreate**
+   - Create extension
+   - Drop extension  
+   - Recreate extension
+   - Verify background worker reinitializes
+
+5. **Prerequisite validation tests (implemented)**
+    - Test 00_requires_shared_preload.sql: Validates CREATE EXTENSION fails without shared_preload_libraries
+    - Test 27_database_validation.sql: Validates CREATE EXTENSION fails in wrong database, documents multi-database limitation
+    - Tests ensure users get clear error messages during extension creation rather than discovering issues at runtime
+
+## PostgreSQL Best Practices Alignment
+
+### Where this aligns
+
+1. **Schemas managed by CREATE EXTENSION**
+    - The `duroxide` schema is created by the extension and dropped by `DROP EXTENSION`.
+
+2. **Objects created as extension members**
+    - The Duroxide provider tables/functions are created by extension SQL and are extension members.
+
+3. **Background worker avoids implicit DDL**
+    - Uses `VerifyOnly` and never creates schema/tables.
+
+### Where this is intentionally non-idiomatic (trade-off)
+
+- We duplicate upstream migration SQL as checked-in files and must keep them in sync with `duroxide-pg-opt/migrations`.
+    - This is enforced via `scripts/verify-duroxide-migrations.sh`.
+
+### Rationale for Polling in MVP
+
+While processUtility hooks are the "correct" PostgreSQL approach, polling is acceptable for MVP because:
+- Extensions are created/dropped rarely (not a hot path)
+- 5 second detection latency is tolerable
+- Simpler implementation = faster time to value
+- Can be upgraded to hooks post-MVP without changing client-facing behavior
+
+### Trade-offs with duroxide-pg-opt
+
+We treat the Duroxide provider schema as part of pg_durable’s extension SQL:
+
+- ✅ PostgreSQL-native lifecycle: install/upgrade/drop go through extension scripts.
+- ✅ Clear ownership: objects are extension members.
+- ⚠️ Sync burden: we must keep `sql/duroxide_upstream/` aligned with upstream `duroxide-pg-opt/migrations/`.
+
+### Known Limitations (future work)
+
+1. **shared_preload_libraries validation** ✅ **IMPLEMENTED**
+    - CREATE EXTENSION now fails if pg_durable is NOT in `shared_preload_libraries`
+    - Validation happens in `_PG_init()` during extension load
+    - Clear error message directs users to add pg_durable to `shared_preload_libraries` and restart
+
+2. **Single database limitation** ✅ **VALIDATED**
+   - Background worker connects to ONE database (POSTGRES_DB/PGDATABASE env var, defaults to `postgres`)
+   - CREATE EXTENSION now validates the current database matches the background worker's target database
+   - **Mitigation (implemented):** Extension creation fails with clear error if run in wrong database
+   - **Future:** Support multi-database (would require multiple background workers or more complex architecture)
+
+3. **No multi-database support** ⚠️
+   - pg_durable can only be used in the database where the background worker is connected
+   - This is an architectural limitation of single background worker process
+   - Users attempting to create extension in wrong database now get immediate validation error
+   - **Future consideration:** Multiple background workers (one per database)?
+
+## Compatibility Considerations
+
+### Breaking Changes
+
+- None (the extension has not shipped yet), but behavior becomes stricter: if migrations are missing/behind, the system fails closed.
+
+### Behavioral Changes
+
+1. **duroxide schema creation timing**
+    - **Current behavior:** Schema/tables created implicitly by BGW and backend calls.
+    - **New behavior:** `CREATE EXTENSION` creates the schema and all Duroxide provider objects (extension SQL).
+   
+2. **Background worker wait behavior**
+    - **New behavior:** BGW waits for extension existence, and also stays in "waiting" when migrations are missing/behind (VerifyOnly fails).
+
+3. **Backend sessions disable long-polling**
+    - **Default behavior (upstream):** `duroxide_pg_opt::PostgresProvider` can enable long-polling by default.
+    - **pg_durable behavior:** For backend request/response operations (start/cancel/signal, monitoring), we disable long-polling to avoid a dedicated listener connection and notifier task.
+    - **Impact:** Resource savings for installations with many backends.
+    - **Compatibility:** No user-visible changes expected.
+
+## Open Questions
+
+### Resolved
+
+1. **Should duroxide-pg-opt provide a "don't create schema" mode?**
+   - ✅ **RESOLVED:** duroxide-pg-opt 0.1.18 provides `MigrationPolicy::VerifyOnly` which never executes DDL
+   - No need for upstream changes or manual schema checks
+
+2. **How should pg_durable avoid implicit schema creation?**
+    - ✅ Use `VerifyOnly` for BGW and all `df.*` functions.
+
+3. **Should CREATE EXTENSION validate shared_preload_libraries and target database?**
+    - ✅ **RESOLVED:** Validation implemented during extension creation
+    - shared_preload_libraries validated in `_PG_init()` 
+    - Target database validated via SQL block during CREATE EXTENSION
+    - Users get immediate, clear error messages instead of discovering issues at runtime
+
+### Remaining Questions
+
+1. **How do we handle versioned upgrades over time?**
+    - We will likely need `pg_durable--X--Y.sql` scripts that apply only the delta (including any new upstream Duroxide migrations).
+
+2. **Should background worker use utility hooks instead of polling?**
+    - Expert guidance recommends hooks for reactive detection
+    - **For MVP:** Use polling (simpler, proven)
+    - **Later:** Implement utility hooks if pgrx supports them
+    - **Trade-off:** Simplicity vs 5 second detection latency
+
+3. **What should happen to running workflows when extension is dropped?**
+   - **Option A:** Graceful shutdown - cancel all running instances
+   - **Option B:** Immediate shutdown - let PostgreSQL handle cleanup
+   - **Proposed:** Option B initially (simpler), Option A as enhancement
+
+4. **Should we support pg_durable.enabled GUC to disable background worker?**
+   - Allow users to keep in shared_preload_libraries but disable worker
+   - **Proposed:** Future enhancement, not in initial implementation
+
+## Success Criteria
+
+1. ✅ BGW does not create the duroxide schema/tables and waits when extension/migrations are missing
+2. ✅ Backend `df.*` functions do not create schema/tables and fail closed when migrations are missing/behind
+3. ✅ Migrations are applied via extension SQL during `CREATE EXTENSION pg_durable`
+4. ✅ CREATE EXTENSION validates shared_preload_libraries requirement
+5. ✅ CREATE EXTENSION validates target database matches background worker database
+6. ✅ Documentation clearly states prerequisites, limitations, and recovery steps
+
+## References
+
+- PostgreSQL Extension Documentation: https://www.postgresql.org/docs/current/extend-extensions.html
+- pgrx Background Worker Documentation: https://github.com/pgcentralfoundation/pgrx/blob/develop/pgrx-examples/bgworker/src/lib.rs
+- duroxide-pg-opt: https://github.com/anthropics/duroxide/tree/main/duroxide-pg-opt
+- pg_durable current architecture: [ARCHITECTURE.md](ARCHITECTURE.md)
+
+## Timeline Estimate
+
+### MVP
+
+- Schema declaration + explicit migration function + BGW waiting behavior + backend VerifyOnly + docs/tests.
+
+### Later investigations
+
+- Utility hooks, multi-db, drop semantics, and more PostgreSQL-native migrations.

--- a/docs/extension_lifecycle.md
+++ b/docs/extension_lifecycle.md
@@ -113,7 +113,9 @@ We keep an audited, ordered copy of the upstream migration SQL inside this repo:
   - our copies match `duroxide-pg-opt/migrations/`
   - the generated combined install SQL matches what’s checked in
 
-Then we include `sql/duroxide_install.sql` as part of the extension install SQL via `extension_sql_file!`.
+The generated install SQL sets `search_path` to `duroxide` for the migration DDL, then resets it to `@extschema@` at the end so that subsequent extension SQL blocks (operators, etc.) resolve to the correct schema.
+
+We include `sql/duroxide_install.sql` as part of the extension install SQL via `extension_sql_file!`.
 
 #### Why we avoid “out-of-band” DDL
 
@@ -364,7 +366,7 @@ Because the Duroxide schema DDL runs inside `CREATE EXTENSION` as extension SQL,
 
 5. **Prerequisite validation tests (implemented)**
     - Test 00_requires_shared_preload.sql: Validates CREATE EXTENSION fails without shared_preload_libraries
-    - Test 27_database_validation.sql: Validates CREATE EXTENSION fails in wrong database, documents multi-database limitation
+    - Test 27_database_validation.sql: Validates CREATE EXTENSION succeeds in the correct database, and actually fails with the expected error message in a wrong database (tested via dblink into a throwaway database)
     - Tests ensure users get clear error messages during extension creation rather than discovering issues at runtime
 
 ## PostgreSQL Best Practices Alignment

--- a/scripts/gen-duroxide-install-sql.sh
+++ b/scripts/gen-duroxide-install-sql.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate sql/duroxide_install.sql from the checked-in upstream migration copies.
+#
+# This keeps the extension install DDL explicit/reviewable, while still tracking
+# duroxide-pg-opt's migration sources.
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_FILE="${OUT_FILE:-$ROOT_DIR/sql/duroxide_install.sql}"
+UPSTREAM_DIR="$ROOT_DIR/sql/duroxide_upstream"
+
+if [ ! -d "$UPSTREAM_DIR" ]; then
+  echo "Upstream migrations dir not found: $UPSTREAM_DIR" >&2
+  exit 1
+fi
+
+migrations=("$UPSTREAM_DIR"/000*.sql)
+if [ "${#migrations[@]}" -eq 0 ]; then
+  echo "No upstream migrations found in $UPSTREAM_DIR" >&2
+  exit 1
+fi
+
+{
+  echo "-- BEGIN duroxide-pg-opt migrations (checked-in copy)"
+  echo "CREATE SCHEMA IF NOT EXISTS duroxide;"
+  echo "SET LOCAL search_path TO duroxide;"
+  echo ""
+
+  for path in "${migrations[@]}"; do
+    file="$(basename "$path")"
+
+    # Parse leading version from 0001_foo.sql
+    version="${file%%_*}"
+    if ! [[ "$version" =~ ^[0-9]{4}$ ]]; then
+      echo "Skipping unexpected migration filename: $file" >&2
+      exit 1
+    fi
+
+    echo "-- Migration ${version}: ${file}"
+    cat "$path"
+    echo ""
+
+    # duroxide-pg-opt's MigrationPolicy "ApplyAll" populates _duroxide_migrations. We don't use that policy, so we record the applied migrations manually.
+    version_num=$((10#$version))
+    file_escaped="$(printf "%s" "$file" | sed "s/'/''/g")"
+    printf "INSERT INTO _duroxide_migrations(version, name) VALUES (%s, '%s') ON CONFLICT (version) DO NOTHING;\n" "$version_num" "$file_escaped"
+    echo ""
+  done
+
+  # Restore the search_path that CREATE EXTENSION set.  We cannot use
+  # "RESET search_path" because that reverts to the boot default (typically
+  # '"$user",public'), NOT to what CREATE EXTENSION originally set
+  # ('@extschema@, pg_temp').  @extschema@ is substituted by PostgreSQL
+  # during CREATE EXTENSION, so the operators / helper functions that follow
+  # in the extension SQL will be created in the correct schema.
+  echo "SET LOCAL search_path TO @extschema@;"
+  echo ""
+  echo "-- END duroxide-pg-opt migrations (checked-in copy)"
+} > "$OUT_FILE"
+
+echo "Wrote $OUT_FILE"

--- a/scripts/pg-start.sh
+++ b/scripts/pg-start.sh
@@ -10,15 +10,30 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DATA_DIR="$HOME/.pgrx/data-17"
 PG_CONF="$DATA_DIR/postgresql.conf"
 
+# Resolve pg17 binaries from pgrx config (avoids hardcoding a patch version like 17.7).
+PGRX_CONFIG="$HOME/.pgrx/config.toml"
+if [ ! -f "$PGRX_CONFIG" ]; then
+    echo "pgrx config not found at $PGRX_CONFIG"
+    exit 1
+fi
+
+PG_CONFIG=$(grep -E '^pg17\s*=\s*"' "$PGRX_CONFIG" | head -1 | cut -d'"' -f2)
+if [ -z "$PG_CONFIG" ]; then
+    echo "pg17 not configured in $PGRX_CONFIG"
+    exit 1
+fi
+
+PGRX_BIN_DIR="$(dirname "$PG_CONFIG")"
+
 cd "$PROJECT_DIR"
 
 echo -e "\033[0;33mBuilding and installing extension...\033[0m"
-cargo pgrx install --pg-config ~/.pgrx/17.7/pgrx-install/bin/pg_config 2>&1 | grep -v "^warning:" || true
+cargo pgrx install --pg-config "$PG_CONFIG" 2>&1 | grep -v "^warning:" || true
 
 # Initialize data directory if it doesn't exist
 if [ ! -d "$DATA_DIR" ]; then
     echo -e "\033[0;33mInitializing PostgreSQL data directory...\033[0m"
-    ~/.pgrx/17.7/pgrx-install/bin/initdb -D "$DATA_DIR" 2>/dev/null || true
+    "$PGRX_BIN_DIR/initdb" -D "$DATA_DIR" 2>/dev/null || true
 fi
 
 # Configure shared_preload_libraries for background worker
@@ -34,22 +49,22 @@ cargo pgrx start pg17 2>/dev/null || true
 
 # Wait for PostgreSQL to be ready
 for i in {1..30}; do
-    if ~/.pgrx/17.7/pgrx-install/bin/pg_isready -h localhost -p 28817 -q 2>/dev/null; then
+    if "$PGRX_BIN_DIR/pg_isready" -h localhost -p 28817 -q 2>/dev/null; then
         break
     fi
     sleep 0.2
 done
 
 # Create extension if needed
-~/.pgrx/17.7/pgrx-install/bin/psql -h localhost -p 28817 -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_durable;" 2>/dev/null || true
+"$PGRX_BIN_DIR/psql" -h localhost -p 28817 -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_durable;" 2>/dev/null || true
 
 # Show version
-VERSION=$(~/.pgrx/17.7/pgrx-install/bin/psql -h localhost -p 28817 -d postgres -t -c "SELECT df.version();" 2>/dev/null | tr -d ' \n')
+VERSION=$("$PGRX_BIN_DIR/psql" -h localhost -p 28817 -d postgres -t -c "SELECT df.version();" 2>/dev/null | tr -d ' \n')
 echo -e "\033[0;32mPostgreSQL started with pg_durable $VERSION\033[0m"
 
 echo ""
 echo -e "\033[0;36mConnect:\033[0m"
-echo "  ~/.pgrx/17.7/pgrx-install/bin/psql -h localhost -p 28817 -d postgres"
+echo "  $PGRX_BIN_DIR/psql -h localhost -p 28817 -d postgres"
 echo ""
 echo -e "\033[0;36mLogs:\033[0m"
 echo "  tail -f ~/.pgrx/17.log"

--- a/scripts/verify-duroxide-migrations.sh
+++ b/scripts/verify-duroxide-migrations.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify that pg_durable's checked-in copy of duroxide-pg-opt migrations matches
+# the current duroxide-pg-opt/migrations directory.
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+UPSTREAM_SRC_DIR="$ROOT_DIR/duroxide-pg-opt/migrations"
+UPSTREAM_COPY_DIR="$ROOT_DIR/sql/duroxide_upstream"
+INSTALL_SQL="$ROOT_DIR/sql/duroxide_install.sql"
+
+if [ ! -d "$UPSTREAM_SRC_DIR" ]; then
+  echo "Missing: $UPSTREAM_SRC_DIR" >&2
+  exit 1
+fi
+
+if [ ! -d "$UPSTREAM_COPY_DIR" ]; then
+  echo "Missing: $UPSTREAM_COPY_DIR" >&2
+  exit 1
+fi
+
+src_files=("$UPSTREAM_SRC_DIR"/000*.sql)
+copy_files=("$UPSTREAM_COPY_DIR"/000*.sql)
+
+if [ "${#src_files[@]}" -eq 0 ]; then
+  echo "No migration sql files found in $UPSTREAM_SRC_DIR" >&2
+  exit 1
+fi
+
+# Compare file lists
+src_list="$(for f in "${src_files[@]}"; do basename "$f"; done | sort)"
+copy_list="$(for f in "${copy_files[@]}"; do basename "$f"; done | sort)"
+
+if [ "$src_list" != "$copy_list" ]; then
+  echo "Migration file list mismatch." >&2
+  echo "duroxide-pg-opt/migrations:" >&2
+  echo "$src_list" >&2
+  echo "sql/duroxide_upstream:" >&2
+  echo "$copy_list" >&2
+  exit 1
+fi
+
+# Compare contents
+for f in ${src_list}; do
+  diff -u "$UPSTREAM_SRC_DIR/$f" "$UPSTREAM_COPY_DIR/$f" >/dev/null
+done
+
+echo "OK: upstream migration copies match duroxide-pg-opt" 
+
+# Verify install SQL matches the generator output
+if [ ! -f "$INSTALL_SQL" ]; then
+  echo "Missing: $INSTALL_SQL (run scripts/gen-duroxide-install-sql.sh)" >&2
+  exit 1
+fi
+
+tmp1="$(mktemp)"
+tmp2="$(mktemp)"
+trap 'rm -f "$tmp1" "$tmp2"' EXIT
+
+OUT_FILE="$tmp1" "$ROOT_DIR/scripts/gen-duroxide-install-sql.sh" >/dev/null
+diff -u "$INSTALL_SQL" "$tmp1" >/dev/null
+
+OUT_FILE="$tmp2" "$ROOT_DIR/scripts/gen-duroxide-install-sql.sh" >/dev/null
+diff -u "$tmp1" "$tmp2" >/dev/null
+
+echo "OK: sql/duroxide_install.sql matches generator output"

--- a/sql/duroxide_install.sql
+++ b/sql/duroxide_install.sql
@@ -1,0 +1,2983 @@
+-- BEGIN duroxide-pg-opt migrations (checked-in copy)
+CREATE SCHEMA IF NOT EXISTS duroxide;
+SET LOCAL search_path TO duroxide;
+
+-- Migration 0001: 0001_initial_schema.sql
+-- Migration: 0001_initial_schema.sql
+-- Description: Complete Duroxide PostgreSQL provider schema
+-- All tables, indexes, and stored procedures in a single migration.
+-- All timestamps are NOT NULL without defaults - provider must supply values.
+
+-- ============================================================================
+-- Tables
+-- ============================================================================
+
+-- Instance metadata
+CREATE TABLE IF NOT EXISTS instances (
+    instance_id TEXT PRIMARY KEY,
+    orchestration_name TEXT NOT NULL,
+    orchestration_version TEXT, -- NULLable, set by runtime via ack_orchestration_item metadata
+    current_execution_id BIGINT NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+-- Multi-execution support
+CREATE TABLE IF NOT EXISTS executions (
+    instance_id TEXT NOT NULL,
+    execution_id BIGINT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'Running',
+    output TEXT,
+    started_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ, -- NULL until completed/failed
+    PRIMARY KEY (instance_id, execution_id)
+);
+
+-- Event history (append-only)
+CREATE TABLE IF NOT EXISTS history (
+    instance_id TEXT NOT NULL,
+    execution_id BIGINT NOT NULL,
+    event_id BIGINT NOT NULL,
+    event_type TEXT NOT NULL,
+    event_data TEXT NOT NULL, -- JSON serialized Event
+    created_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (instance_id, execution_id, event_id)
+);
+
+-- Orchestrator queue
+CREATE TABLE IF NOT EXISTS orchestrator_queue (
+    id BIGSERIAL PRIMARY KEY,
+    instance_id TEXT NOT NULL,
+    work_item TEXT NOT NULL, -- JSON serialized WorkItem
+    visible_at TIMESTAMPTZ NOT NULL,
+    lock_token TEXT,
+    locked_until BIGINT, -- Unix timestamp in milliseconds
+    created_at TIMESTAMPTZ NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0
+);
+
+-- Worker queue
+CREATE TABLE IF NOT EXISTS worker_queue (
+    id BIGSERIAL PRIMARY KEY,
+    work_item TEXT NOT NULL, -- JSON serialized WorkItem
+    visible_at TIMESTAMPTZ NOT NULL, -- When the item becomes available for processing
+    lock_token TEXT,
+    locked_until BIGINT, -- Unix timestamp in milliseconds
+    created_at TIMESTAMPTZ NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0
+);
+
+-- Instance-level locks for concurrent dispatcher coordination
+CREATE TABLE IF NOT EXISTS instance_locks (
+    instance_id TEXT PRIMARY KEY,
+    lock_token TEXT NOT NULL,
+    locked_until BIGINT NOT NULL, -- Unix timestamp in milliseconds
+    locked_at BIGINT NOT NULL -- Unix timestamp in milliseconds
+);
+
+-- ============================================================================
+-- Indexes
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_orch_visible ON orchestrator_queue(visible_at, lock_token);
+CREATE INDEX IF NOT EXISTS idx_orch_instance ON orchestrator_queue(instance_id);
+CREATE INDEX IF NOT EXISTS idx_orch_lock ON orchestrator_queue(lock_token);
+CREATE INDEX IF NOT EXISTS idx_worker_visible ON worker_queue(visible_at, lock_token);
+CREATE INDEX IF NOT EXISTS idx_worker_available ON worker_queue(lock_token, id);
+CREATE INDEX IF NOT EXISTS idx_instance_locks_locked_until ON instance_locks(locked_until);
+CREATE INDEX IF NOT EXISTS idx_history_lookup ON history(instance_id, execution_id, event_id);
+
+-- Migration tracking table (create in each schema)
+CREATE TABLE IF NOT EXISTS _duroxide_migrations (
+    version BIGINT PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ============================================================================
+-- NOTIFY Triggers for Long-Polling
+-- Triggers fire on INSERT to notify waiting dispatchers of new work.
+-- Payload contains visible_at as epoch milliseconds for timer scheduling.
+-- NOTE: We use TG_TABLE_SCHEMA (the schema of the table being modified) 
+-- instead of current_schema() because current_schema() returns the first 
+-- schema in the session's search_path, which may not be our schema.
+-- ============================================================================
+
+-- Trigger function for orchestrator queue
+DROP FUNCTION IF EXISTS notify_orch_work() CASCADE;
+CREATE OR REPLACE FUNCTION notify_orch_work()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM pg_notify(
+        TG_TABLE_SCHEMA || '_orch_work',
+        (EXTRACT(EPOCH FROM NEW.visible_at) * 1000)::BIGINT::TEXT
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger function for worker queue
+-- Worker queue items now have visible_at for delayed visibility
+-- Send visible_at timestamp for timer scheduling
+DROP FUNCTION IF EXISTS notify_worker_work() CASCADE;
+CREATE OR REPLACE FUNCTION notify_worker_work()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM pg_notify(
+        TG_TABLE_SCHEMA || '_worker_work',
+        (EXTRACT(EPOCH FROM NEW.visible_at) * 1000)::BIGINT::TEXT
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Attach triggers to queues
+DROP TRIGGER IF EXISTS trg_notify_orch_work ON orchestrator_queue;
+CREATE TRIGGER trg_notify_orch_work
+    AFTER INSERT ON orchestrator_queue
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_orch_work();
+
+DROP TRIGGER IF EXISTS trg_notify_worker_work ON worker_queue;
+CREATE TRIGGER trg_notify_worker_work
+    AFTER INSERT ON worker_queue
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_worker_work();
+
+-- ============================================================================
+-- Stored Procedures
+-- ============================================================================
+
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    -- ============================================================================
+    -- Schema Management Procedures
+    -- ============================================================================
+
+    -- Procedure: cleanup_schema
+    -- Drops all tables AND functions in the schema (for testing only)
+    -- Functions must be dropped because PostgreSQL cannot change return types with CREATE OR REPLACE
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.cleanup_schema()', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.cleanup_schema()
+        RETURNS VOID AS $cleanup$
+        BEGIN
+            -- Drop tables first
+            DROP TABLE IF EXISTS %I.instances CASCADE;
+            DROP TABLE IF EXISTS %I.executions CASCADE;
+            DROP TABLE IF EXISTS %I.history CASCADE;
+            DROP TABLE IF EXISTS %I.orchestrator_queue CASCADE;
+            DROP TABLE IF EXISTS %I.worker_queue CASCADE;
+            DROP TABLE IF EXISTS %I.instance_locks CASCADE;
+            DROP TABLE IF EXISTS %I._duroxide_migrations CASCADE;
+            
+            -- Drop all stored procedures (required because return type changes cannot use CREATE OR REPLACE)
+            DROP FUNCTION IF EXISTS %I.cleanup_schema();
+            DROP FUNCTION IF EXISTS %I.list_instances();
+            DROP FUNCTION IF EXISTS %I.list_executions(TEXT);
+            DROP FUNCTION IF EXISTS %I.latest_execution_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.list_instances_by_status(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_execution_info(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.get_system_metrics();
+            DROP FUNCTION IF EXISTS %I.get_queue_depths(BIGINT);
+            DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.abandon_work_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.enqueue_orchestrator_work(TEXT, TEXT, TIMESTAMPTZ, BIGINT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB);
+            DROP FUNCTION IF EXISTS %I.abandon_orchestration_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.renew_orchestration_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_history(TEXT);
+            DROP FUNCTION IF EXISTS %I.fetch_history_with_execution(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.append_history(TEXT, BIGINT, JSONB, BIGINT);
+            
+            -- Drop trigger functions (not schema-qualified, they use search_path)
+            -- CASCADE is required because triggers depend on these functions
+            DROP FUNCTION IF EXISTS notify_orch_work() CASCADE;
+            DROP FUNCTION IF EXISTS notify_worker_work() CASCADE;
+        END;
+        $cleanup$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Simple Query Procedures
+    -- ============================================================================
+
+    -- Procedure: list_instances
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.list_instances()', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.list_instances()
+        RETURNS TABLE(instance_id TEXT) AS $list_inst$
+        BEGIN
+            RETURN QUERY
+            SELECT i.instance_id
+            FROM %I.instances i
+            ORDER BY i.created_at DESC;
+        END;
+        $list_inst$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: list_executions
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.list_executions(TEXT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.list_executions(p_instance_id TEXT)
+        RETURNS TABLE(execution_id BIGINT) AS $list_exec$
+        BEGIN
+            RETURN QUERY
+            SELECT e.execution_id
+            FROM %I.executions e
+            WHERE e.instance_id = p_instance_id
+            ORDER BY e.execution_id;
+        END;
+        $list_exec$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: latest_execution_id
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.latest_execution_id(TEXT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.latest_execution_id(p_instance_id TEXT)
+        RETURNS BIGINT AS $latest_exec$
+        DECLARE
+            v_execution_id BIGINT;
+        BEGIN
+            SELECT i.current_execution_id INTO v_execution_id
+            FROM %I.instances i
+            WHERE i.instance_id = p_instance_id;
+            RETURN v_execution_id;
+        END;
+        $latest_exec$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: list_instances_by_status
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.list_instances_by_status(TEXT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.list_instances_by_status(p_status TEXT)
+        RETURNS TABLE(instance_id TEXT) AS $list_by_status$
+        BEGIN
+            RETURN QUERY
+            SELECT i.instance_id
+            FROM %I.instances i
+            JOIN %I.executions e ON i.instance_id = e.instance_id 
+              AND i.current_execution_id = e.execution_id
+            WHERE e.status = p_status
+            ORDER BY i.created_at DESC;
+        END;
+        $list_by_status$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Join and Aggregate Query Procedures
+    -- ============================================================================
+
+    -- Procedure: get_instance_info
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_instance_info(p_instance_id TEXT)
+        RETURNS TABLE(
+            instance_id TEXT,
+            orchestration_name TEXT,
+            orchestration_version TEXT,
+            current_execution_id BIGINT,
+            created_at TIMESTAMPTZ,
+            updated_at TIMESTAMPTZ,
+            status TEXT,
+            output TEXT
+        ) AS $get_inst_info$
+        BEGIN
+            RETURN QUERY
+            SELECT i.instance_id, i.orchestration_name, 
+                   COALESCE(i.orchestration_version, ''unknown'') as orchestration_version,
+                   i.current_execution_id, i.created_at, i.updated_at,
+                   e.status, e.output
+            FROM %I.instances i
+            LEFT JOIN %I.executions e ON i.instance_id = e.instance_id 
+              AND i.current_execution_id = e.execution_id
+            WHERE i.instance_id = p_instance_id;
+        END;
+        $get_inst_info$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: get_execution_info
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.get_execution_info(TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_execution_info(
+            p_instance_id TEXT,
+            p_execution_id BIGINT
+        )
+        RETURNS TABLE(
+            execution_id BIGINT,
+            status TEXT,
+            output TEXT,
+            started_at TIMESTAMPTZ,
+            completed_at TIMESTAMPTZ,
+            event_count BIGINT
+        ) AS $get_exec_info$
+        BEGIN
+            RETURN QUERY
+            SELECT e.execution_id, e.status, e.output, 
+                   e.started_at, e.completed_at,
+                   COALESCE(COUNT(h.event_id), 0)::BIGINT as event_count
+            FROM %I.executions e
+            LEFT JOIN %I.history h ON e.instance_id = h.instance_id 
+              AND e.execution_id = h.execution_id
+            WHERE e.instance_id = p_instance_id AND e.execution_id = p_execution_id
+            GROUP BY e.execution_id, e.status, e.output, e.started_at, e.completed_at;
+        END;
+        $get_exec_info$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: get_system_metrics
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.get_system_metrics()', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_system_metrics()
+        RETURNS TABLE(
+            total_instances BIGINT,
+            total_executions BIGINT,
+            running_instances BIGINT,
+            completed_instances BIGINT,
+            failed_instances BIGINT,
+            total_events BIGINT
+        ) AS $get_metrics$
+        BEGIN
+            RETURN QUERY
+            SELECT 
+                (SELECT COUNT(*)::BIGINT FROM %I.instances) as total_instances,
+                (SELECT COUNT(*)::BIGINT FROM %I.executions) as total_executions,
+                (SELECT COUNT(DISTINCT i.instance_id)::BIGINT
+                 FROM %I.instances i
+                 JOIN %I.executions e ON i.instance_id = e.instance_id 
+                   AND i.current_execution_id = e.execution_id
+                 WHERE e.status = ''Running'') as running_instances,
+                (SELECT COUNT(DISTINCT i.instance_id)::BIGINT
+                 FROM %I.instances i
+                 JOIN %I.executions e ON i.instance_id = e.instance_id 
+                   AND i.current_execution_id = e.execution_id
+                 WHERE e.status = ''Completed'') as completed_instances,
+                (SELECT COUNT(DISTINCT i.instance_id)::BIGINT
+                 FROM %I.instances i
+                 JOIN %I.executions e ON i.instance_id = e.instance_id 
+                   AND i.current_execution_id = e.execution_id
+                 WHERE e.status = ''Failed'') as failed_instances,
+                (SELECT COUNT(*)::BIGINT FROM %I.history) as total_events;
+        END;
+        $get_metrics$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: get_queue_depths
+    -- Returns count of items available for processing (visible and unlocked/lock expired)
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.get_queue_depths(BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_queue_depths(p_now_ms BIGINT)
+        RETURNS TABLE(
+            orchestrator_queue BIGINT,
+            worker_queue BIGINT
+        ) AS $get_queue_depths$
+        BEGIN
+            RETURN QUERY
+            SELECT 
+                (SELECT COUNT(*)::BIGINT FROM %I.orchestrator_queue 
+                 WHERE visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                   AND (lock_token IS NULL OR locked_until <= p_now_ms)) as orchestrator_queue,
+                (SELECT COUNT(*)::BIGINT FROM %I.worker_queue 
+                 WHERE visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                   AND (lock_token IS NULL OR locked_until <= p_now_ms)) as worker_queue;
+        END;
+        $get_queue_depths$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Queue Operation Procedures
+    -- All procedures accept p_now_ms for timestamp generation (Rust clock only)
+    -- ============================================================================
+
+    -- Procedure: enqueue_worker_work
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.enqueue_worker_work(
+            p_work_item TEXT,
+            p_now_ms BIGINT
+        )
+        RETURNS VOID AS $enq_worker$
+        DECLARE
+            v_now_ts TIMESTAMPTZ;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+            INSERT INTO %I.worker_queue (work_item, visible_at, created_at)
+            VALUES (p_work_item, v_now_ts, v_now_ts);
+        END;
+        $enq_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: ack_worker
+    -- When p_completion_json is NULL, only delete from worker_queue (no enqueue)
+    -- This is used when the orchestration is terminal or missing
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_worker(
+            p_lock_token TEXT,
+            p_instance_id TEXT,
+            p_completion_json TEXT,
+            p_now_ms BIGINT
+        )
+        RETURNS VOID AS $ack_worker$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_now_ts TIMESTAMPTZ;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+            
+            DELETE FROM %I.worker_queue WHERE lock_token = p_lock_token;
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Worker queue item not found or already processed'';
+            END IF;
+
+            -- Validate: if completion provided, instance_id must also be provided
+            IF p_completion_json IS NOT NULL AND p_instance_id IS NULL THEN
+                RAISE EXCEPTION ''instance_id required when completion_json is provided'';
+            END IF;
+
+            -- Only enqueue completion if provided (not NULL)
+            IF p_completion_json IS NOT NULL THEN
+                INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                VALUES (p_instance_id, p_completion_json, v_now_ts, v_now_ts);
+            END IF;
+        END;
+        $ack_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: renew_work_item_lock
+    -- Returns execution_status for cancellation support
+    -- Note: DROP first because return type changed from VOID to TEXT
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.renew_work_item_lock(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_extend_ms BIGINT
+        )
+        RETURNS TEXT AS $renew_lock$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_work_item_json JSONB;
+            v_instance_id TEXT;
+            v_execution_id BIGINT;
+            v_execution_status TEXT;
+        BEGIN
+            -- Get the work item before updating
+            SELECT work_item::JSONB INTO v_work_item_json
+            FROM %I.worker_queue
+            WHERE lock_token = p_lock_token
+              AND locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Lock token invalid, expired, or already acked'';
+            END IF;
+
+            -- Check execution status BEFORE extending the lock
+            -- Per provider contract: lock can only be renewed if execution is Running
+            IF v_work_item_json ? ''ActivityExecute'' THEN
+                v_instance_id := v_work_item_json->''ActivityExecute''->>''instance'';
+                v_execution_id := (v_work_item_json->''ActivityExecute''->>''execution_id'')::BIGINT;
+                
+                -- Get execution status directly from executions table
+                -- Note: We check executions table, not instances table, because:
+                -- 1. Instance record may not exist if ack_orchestration_item was called with NULL version
+                -- 2. Execution record is the authoritative source for execution state
+                SELECT e.status INTO v_execution_status
+                FROM %I.executions e
+                WHERE e.instance_id = v_instance_id AND e.execution_id = v_execution_id;
+                
+                IF v_execution_status IS NULL THEN
+                    -- Execution record missing - return NULL to signal Missing state
+                    -- Do NOT extend lock per contract
+                    RETURN NULL;
+                END IF;
+                
+                IF v_execution_status <> ''Running'' THEN
+                    -- Execution is terminal - return status but do NOT extend lock per contract
+                    RETURN v_execution_status;
+                END IF;
+            END IF;
+            
+            -- Only extend lock if execution is Running (or non-ActivityExecute item)
+            UPDATE %I.worker_queue
+            SET locked_until = GREATEST(locked_until, p_now_ms) + p_extend_ms
+            WHERE lock_token = p_lock_token
+              AND locked_until > p_now_ms;
+            
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+            
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Lock token invalid, expired, or already acked'';
+            END IF;
+            
+            RETURN v_execution_status;
+        END;
+        $renew_lock$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: fetch_work_item
+    -- Item is available if:
+    -- 1. visible_at <= now (not delayed)
+    -- 2. AND (lock_token IS NULL OR locked_until <= now) (not locked or lock expired)
+    -- Returns execution_status from the execution table for cancellation support
+    -- Note: DROP first because return type changed to include out_execution_status
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_work_item(
+            p_now_ms BIGINT,
+            p_lock_timeout_ms BIGINT
+        )
+        RETURNS TABLE(
+            out_work_item TEXT,
+            out_lock_token TEXT,
+            out_attempt_count INTEGER,
+            out_execution_status TEXT
+        ) AS $fetch_worker$
+        DECLARE
+            v_id BIGINT;
+            v_work_item_json JSONB;
+            v_instance_id TEXT;
+            v_execution_id BIGINT;
+        BEGIN
+            SELECT q.id INTO v_id
+            FROM %I.worker_queue q
+            WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+              AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms)
+            ORDER BY q.id
+            LIMIT 1
+            FOR UPDATE OF q SKIP LOCKED;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            out_lock_token := ''lock_'' || gen_random_uuid()::TEXT;
+
+            UPDATE %I.worker_queue
+            SET lock_token = out_lock_token,
+                locked_until = p_now_ms + p_lock_timeout_ms,
+                attempt_count = attempt_count + 1
+            WHERE id = v_id;
+
+            SELECT work_item, attempt_count
+            INTO out_work_item, out_attempt_count
+            FROM %I.worker_queue
+            WHERE id = v_id;
+
+            -- Parse work item to get instance and execution_id for status lookup
+            v_work_item_json := out_work_item::JSONB;
+            IF v_work_item_json ? ''ActivityExecute'' THEN
+                v_instance_id := v_work_item_json->''ActivityExecute''->>''instance'';
+                v_execution_id := (v_work_item_json->''ActivityExecute''->>''execution_id'')::BIGINT;
+                
+                SELECT e.status INTO out_execution_status
+                FROM %I.executions e
+                WHERE e.instance_id = v_instance_id AND e.execution_id = v_execution_id;
+            ELSE
+                out_execution_status := NULL;
+            END IF;
+
+            RETURN NEXT;
+        END;
+        $fetch_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: abandon_work_item
+    -- Always clear lock_token and locked_until when abandoning.
+    -- Use visible_at to control when item becomes available again.
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.abandon_work_item(TEXT, BIGINT, BIGINT, BOOLEAN)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.abandon_work_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_delay_ms BIGINT DEFAULT NULL,
+            p_ignore_attempt BOOLEAN DEFAULT FALSE
+        )
+        RETURNS VOID AS $abandon_worker$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_visible_at TIMESTAMPTZ;
+        BEGIN
+            -- Calculate visible_at based on delay using Rust-provided time
+            IF p_delay_ms IS NOT NULL AND p_delay_ms > 0 THEN
+                v_visible_at := TO_TIMESTAMP((p_now_ms + p_delay_ms) / 1000.0);
+            ELSE
+                v_visible_at := TO_TIMESTAMP(p_now_ms / 1000.0);
+            END IF;
+
+            -- Always clear lock_token and locked_until when abandoning
+            -- Use visible_at to control when item becomes available again
+            IF p_ignore_attempt THEN
+                UPDATE %I.worker_queue
+                SET lock_token = NULL,
+                    locked_until = NULL,
+                    visible_at = v_visible_at,
+                    attempt_count = GREATEST(0, attempt_count - 1)
+                WHERE lock_token = p_lock_token;
+            ELSE
+                UPDATE %I.worker_queue
+                SET lock_token = NULL,
+                    locked_until = NULL,
+                    visible_at = v_visible_at
+                WHERE lock_token = p_lock_token;
+            END IF;
+
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Invalid lock token or already acked'';
+            END IF;
+        END;
+        $abandon_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: enqueue_orchestrator_work
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.enqueue_orchestrator_work(TEXT, TEXT, TIMESTAMPTZ, BIGINT, TEXT, TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.enqueue_orchestrator_work(
+            p_instance_id TEXT,
+            p_work_item TEXT,
+            p_visible_at TIMESTAMPTZ,
+            p_now_ms BIGINT,
+            p_orchestration_name TEXT DEFAULT NULL,
+            p_orchestration_version TEXT DEFAULT NULL,
+            p_execution_id BIGINT DEFAULT NULL
+        )
+        RETURNS VOID AS $enq_orch$
+        BEGIN
+            -- Parameters p_orchestration_name, p_orchestration_version, p_execution_id are ignored
+            -- Instance creation happens ONLY via ack_orchestration_item metadata
+            INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+            VALUES (p_instance_id, p_work_item, p_visible_at, TO_TIMESTAMP(p_now_ms / 1000.0));
+        END;
+        $enq_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: fetch_orchestration_item
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_orchestration_item(
+            p_now_ms BIGINT,
+            p_lock_timeout_ms BIGINT
+        )
+        RETURNS TABLE(
+            out_instance_id TEXT,
+            out_orchestration_name TEXT,
+            out_orchestration_version TEXT,
+            out_execution_id BIGINT,
+            out_history JSONB,
+            out_messages JSONB,
+            out_lock_token TEXT,
+            out_attempt_count INTEGER
+        ) AS $fetch_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_lock_token TEXT;
+            v_locked_until BIGINT;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_current_execution_id BIGINT;
+            v_history JSONB;
+            v_messages JSONB;
+            v_lock_acquired INTEGER;
+            v_max_attempt_count INTEGER;
+        BEGIN
+            -- Phase 1: Find a candidate instance (no FOR UPDATE yet)
+            SELECT q.instance_id INTO v_instance_id
+            FROM %I.orchestrator_queue q
+            WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+              AND NOT EXISTS (
+                SELECT 1 FROM %I.instance_locks il
+                WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+              )
+            ORDER BY q.visible_at, q.id
+            LIMIT 1;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            -- Phase 2: Acquire instance-level advisory lock
+            PERFORM pg_advisory_xact_lock(hashtext(v_instance_id));
+
+            -- Phase 3: Re-verify with FOR UPDATE
+            SELECT q.instance_id INTO v_instance_id
+            FROM %I.orchestrator_queue q
+            WHERE q.instance_id = v_instance_id
+              AND q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+              AND NOT EXISTS (
+                SELECT 1 FROM %I.instance_locks il
+                WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+              )
+            FOR UPDATE OF q SKIP LOCKED;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            v_lock_token := ''lock_'' || gen_random_uuid()::TEXT;
+            v_locked_until := p_now_ms + p_lock_timeout_ms;
+
+            INSERT INTO %I.instance_locks (instance_id, lock_token, locked_until, locked_at)
+            VALUES (v_instance_id, v_lock_token, v_locked_until, p_now_ms)
+            ON CONFLICT(instance_id) DO UPDATE
+            SET lock_token = EXCLUDED.lock_token,
+                locked_until = EXCLUDED.locked_until,
+                locked_at = EXCLUDED.locked_at
+            WHERE %I.instance_locks.locked_until <= p_now_ms;
+
+            GET DIAGNOSTICS v_lock_acquired = ROW_COUNT;
+
+            IF v_lock_acquired = 0 THEN
+                RETURN;
+            END IF;
+
+            UPDATE %I.orchestrator_queue q
+            SET lock_token = v_lock_token,
+                locked_until = v_locked_until,
+                attempt_count = q.attempt_count + 1
+            WHERE q.instance_id = v_instance_id
+              AND q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+              AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms);
+
+            SELECT COALESCE(JSONB_AGG(q.work_item::JSONB ORDER BY q.id), ''[]''::JSONB),
+                   COALESCE(MAX(q.attempt_count), 1)
+            INTO v_messages, v_max_attempt_count
+            FROM %I.orchestrator_queue q
+            WHERE q.lock_token = v_lock_token;
+
+            SELECT i.orchestration_name, i.orchestration_version, i.current_execution_id
+            INTO v_orchestration_name, v_orchestration_version, v_current_execution_id
+            FROM %I.instances i
+            WHERE i.instance_id = v_instance_id;
+
+            IF FOUND THEN
+                SELECT COALESCE(JSONB_AGG(h.event_data::JSONB ORDER BY h.event_id), ''[]''::JSONB)
+                INTO v_history
+                FROM %I.history h
+                WHERE h.instance_id = v_instance_id AND h.execution_id = v_current_execution_id;
+                
+                v_orchestration_version := COALESCE(v_orchestration_version, ''unknown'');
+            ELSE
+                SELECT COALESCE(JSONB_AGG(h.event_data::JSONB ORDER BY h.execution_id, h.event_id), ''[]''::JSONB)
+                INTO v_history
+                FROM %I.history h
+                WHERE h.instance_id = v_instance_id;
+
+                IF JSONB_ARRAY_LENGTH(v_history) > 0 AND v_history->0 ? ''OrchestrationStarted'' THEN
+                    v_orchestration_name := v_history->0->''OrchestrationStarted''->>''name'';
+                    v_orchestration_version := v_history->0->''OrchestrationStarted''->>''version'';
+                    v_current_execution_id := 1;
+                ELSIF JSONB_ARRAY_LENGTH(v_messages) > 0 AND v_messages->0 ? ''StartOrchestration'' THEN
+                    v_orchestration_name := v_messages->0->''StartOrchestration''->>''orchestration'';
+                    v_orchestration_version := COALESCE(v_messages->0->''StartOrchestration''->>''version'', ''unknown'');
+                    v_current_execution_id := COALESCE((v_messages->0->''StartOrchestration''->>''execution_id'')::BIGINT, 1);
+                ELSIF JSONB_ARRAY_LENGTH(v_messages) > 0 AND v_messages->0 ? ''ContinueAsNew'' THEN
+                    v_orchestration_name := v_messages->0->''ContinueAsNew''->>''orchestration'';
+                    v_orchestration_version := COALESCE(v_messages->0->''ContinueAsNew''->>''version'', ''unknown'');
+                    v_current_execution_id := 1;
+                ELSE
+                    v_orchestration_name := ''Unknown'';
+                    v_orchestration_version := ''unknown'';
+                    v_current_execution_id := 1;
+                END IF;
+            END IF;
+
+            RETURN QUERY SELECT
+                v_instance_id,
+                v_orchestration_name,
+                v_orchestration_version,
+                v_current_execution_id,
+                v_history,
+                v_messages,
+                v_lock_token,
+                v_max_attempt_count;
+        END;
+        $fetch_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name);
+
+    -- Procedure: ack_orchestration_item
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_execution_id BIGINT,
+            p_history_delta JSONB,
+            p_worker_items JSONB,
+            p_orchestrator_items JSONB,
+            p_metadata JSONB,
+            p_cancelled_activities JSONB DEFAULT ''[]''::JSONB
+        )
+        RETURNS VOID AS $ack_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_now_ts TIMESTAMPTZ;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_status TEXT;
+            v_output TEXT;
+            v_completed_at TIMESTAMPTZ;
+            v_elem JSONB;
+            v_visible_at TIMESTAMPTZ;
+            v_fire_at_ms BIGINT;
+            v_item_instance_id TEXT;
+            v_cancelled JSONB;
+            v_cancelled_execution_id BIGINT;
+            v_cancelled_activity_id BIGINT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token AND il.locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            v_orchestration_name := p_metadata->>''orchestration_name'';
+            v_orchestration_version := p_metadata->>''orchestration_version'';
+            v_status := p_metadata->>''status'';
+            v_output := p_metadata->>''output'';
+
+            IF v_orchestration_name IS NOT NULL AND v_orchestration_version IS NOT NULL THEN
+                INSERT INTO %I.instances (instance_id, orchestration_name, orchestration_version, current_execution_id, created_at, updated_at)
+                VALUES (v_instance_id, v_orchestration_name, v_orchestration_version, p_execution_id, v_now_ts, v_now_ts)
+                ON CONFLICT (instance_id) DO NOTHING;
+
+                UPDATE %I.instances i
+                SET orchestration_name = v_orchestration_name,
+                    orchestration_version = v_orchestration_version,
+                    updated_at = v_now_ts
+                WHERE i.instance_id = v_instance_id;
+            END IF;
+
+            INSERT INTO %I.executions (instance_id, execution_id, status, started_at)
+            VALUES (v_instance_id, p_execution_id, ''Running'', v_now_ts)
+            ON CONFLICT (instance_id, execution_id) DO NOTHING;
+
+            UPDATE %I.instances i
+            SET current_execution_id = GREATEST(i.current_execution_id, p_execution_id),
+                updated_at = v_now_ts
+            WHERE i.instance_id = v_instance_id;
+
+            IF p_history_delta IS NOT NULL AND JSONB_ARRAY_LENGTH(p_history_delta) > 0 THEN
+                INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+                SELECT
+                    v_instance_id,
+                    p_execution_id,
+                    (elem->>''event_id'')::BIGINT,
+                    elem->>''event_type'',
+                    elem->>''event_data'',
+                    v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_history_delta) AS elem;
+            END IF;
+
+            IF v_status IS NOT NULL THEN
+                v_completed_at := CASE 
+                    WHEN v_status IN (''Completed'', ''Failed'') THEN v_now_ts 
+                    ELSE NULL 
+                END;
+                
+                UPDATE %I.executions e
+                SET status = v_status, output = v_output, completed_at = v_completed_at
+                WHERE e.instance_id = v_instance_id AND e.execution_id = p_execution_id;
+            END IF;
+
+            IF p_worker_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_worker_items) > 0 THEN
+                INSERT INTO %I.worker_queue (work_item, visible_at, created_at)
+                SELECT elem::TEXT, v_now_ts, v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_worker_items) AS elem;
+            END IF;
+
+            IF p_orchestrator_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_orchestrator_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_orchestrator_items) LOOP
+                    IF v_elem ? ''StartOrchestration'' THEN
+                        v_item_instance_id := v_elem->''StartOrchestration''->>''instance'';
+                    ELSIF v_elem ? ''ContinueAsNew'' THEN
+                        v_item_instance_id := v_elem->''ContinueAsNew''->>''instance'';
+                    ELSIF v_elem ? ''TimerFired'' THEN
+                        v_item_instance_id := v_elem->''TimerFired''->>''instance'';
+                        v_fire_at_ms := (v_elem->''TimerFired''->>''fire_at_ms'')::BIGINT;
+                    ELSIF v_elem ? ''ActivityCompleted'' THEN
+                        v_item_instance_id := v_elem->''ActivityCompleted''->>''instance'';
+                    ELSIF v_elem ? ''ActivityFailed'' THEN
+                        v_item_instance_id := v_elem->''ActivityFailed''->>''instance'';
+                    ELSIF v_elem ? ''ExternalRaised'' THEN
+                        v_item_instance_id := v_elem->''ExternalRaised''->>''instance'';
+                    ELSIF v_elem ? ''CancelInstance'' THEN
+                        v_item_instance_id := v_elem->''CancelInstance''->>''instance'';
+                    ELSIF v_elem ? ''SubOrchCompleted'' THEN
+                        v_item_instance_id := v_elem->''SubOrchCompleted''->>''parent_instance'';
+                    ELSIF v_elem ? ''SubOrchFailed'' THEN
+                        v_item_instance_id := v_elem->''SubOrchFailed''->>''parent_instance'';
+                    ELSE
+                        v_item_instance_id := v_instance_id;
+                    END IF;
+
+                    IF v_elem ? ''TimerFired'' AND v_fire_at_ms IS NOT NULL AND v_fire_at_ms > 0 THEN
+                        v_visible_at := TO_TIMESTAMP(v_fire_at_ms / 1000.0);
+                    ELSE
+                        v_visible_at := v_now_ts;
+                    END IF;
+
+                    INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                    VALUES (v_item_instance_id, v_elem::TEXT, v_visible_at, v_now_ts);
+                    
+                    v_fire_at_ms := NULL;
+                END LOOP;
+            END IF;
+
+            -- ================================================================
+            -- Lock-Stealing: Delete worker queue entries for cancelled activities
+            -- Uses v_instance_id (from lock_token) for instance constraint
+            -- Uses execution_id and activity_id from JSON to identify activities
+            -- ================================================================
+            IF p_cancelled_activities IS NOT NULL AND JSONB_ARRAY_LENGTH(p_cancelled_activities) > 0 THEN
+                FOR v_cancelled IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_cancelled_activities) LOOP
+                    v_cancelled_execution_id := (v_cancelled->>''execution_id'')::BIGINT;
+                    v_cancelled_activity_id := (v_cancelled->>''activity_id'')::BIGINT;
+                    
+                    -- Delete matching ActivityExecute items from worker_queue
+                    -- The work_item JSON contains ActivityExecute with instance, execution_id, and id (activity_id)
+                    DELETE FROM %I.worker_queue wq
+                    WHERE wq.work_item::JSONB ? ''ActivityExecute''
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''instance'') = v_instance_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''execution_id'')::BIGINT = v_cancelled_execution_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''id'')::BIGINT = v_cancelled_activity_id;
+                END LOOP;
+            END IF;
+
+            DELETE FROM %I.orchestrator_queue q WHERE q.lock_token = p_lock_token;
+
+            DELETE FROM %I.instance_locks il
+            WHERE il.instance_id = v_instance_id AND il.lock_token = p_lock_token;
+        END;
+        $ack_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: abandon_orchestration_item
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.abandon_orchestration_item(TEXT, BIGINT, BIGINT, BOOLEAN)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.abandon_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_delay_ms BIGINT DEFAULT NULL,
+            p_ignore_attempt BOOLEAN DEFAULT FALSE
+        )
+        RETURNS TEXT AS $abandon_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_visible_at TIMESTAMPTZ;
+        BEGIN
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            IF p_delay_ms IS NOT NULL AND p_delay_ms > 0 THEN
+                v_visible_at := TO_TIMESTAMP((p_now_ms + p_delay_ms) / 1000.0);
+                
+                IF p_ignore_attempt THEN
+                    UPDATE %I.orchestrator_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL,
+                        visible_at = v_visible_at,
+                        attempt_count = GREATEST(0, attempt_count - 1)
+                    WHERE lock_token = p_lock_token;
+                ELSE
+                    UPDATE %I.orchestrator_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL,
+                        visible_at = v_visible_at
+                    WHERE lock_token = p_lock_token;
+                END IF;
+            ELSE
+                IF p_ignore_attempt THEN
+                    UPDATE %I.orchestrator_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL,
+                        attempt_count = GREATEST(0, attempt_count - 1)
+                    WHERE lock_token = p_lock_token;
+                ELSE
+                    UPDATE %I.orchestrator_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL
+                    WHERE lock_token = p_lock_token;
+                END IF;
+            END IF;
+
+            DELETE FROM %I.instance_locks
+            WHERE lock_token = p_lock_token;
+
+            RETURN v_instance_id;
+        END;
+        $abandon_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: renew_orchestration_item_lock
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.renew_orchestration_item_lock(TEXT, BIGINT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.renew_orchestration_item_lock(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_extend_ms BIGINT
+        )
+        RETURNS VOID AS $renew_orch_lock$
+        DECLARE
+            v_rows_affected INTEGER;
+        BEGIN
+            UPDATE %I.instance_locks
+            SET locked_until = GREATEST(locked_until, p_now_ms) + p_extend_ms
+            WHERE lock_token = p_lock_token
+              AND locked_until > p_now_ms;
+            
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+            
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Lock token invalid, expired, or already released'';
+            END IF;
+
+            UPDATE %I.orchestrator_queue
+            SET locked_until = GREATEST(locked_until, p_now_ms) + p_extend_ms
+            WHERE lock_token = p_lock_token;
+        END;
+        $renew_orch_lock$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- History Procedures
+    -- ============================================================================
+
+    -- Procedure: fetch_history
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_history(TEXT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_history(
+            p_instance_id TEXT
+        )
+        RETURNS TABLE(out_event_data TEXT) AS $fetch_history$
+        DECLARE
+            v_execution_id BIGINT;
+        BEGIN
+            SELECT COALESCE(MAX(execution_id), 1)
+            INTO v_execution_id
+            FROM %I.executions
+            WHERE instance_id = p_instance_id;
+
+            RETURN QUERY
+            SELECT h.event_data
+            FROM %I.history h
+            WHERE h.instance_id = p_instance_id
+              AND h.execution_id = v_execution_id
+            ORDER BY h.event_id;
+        END;
+        $fetch_history$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: fetch_history_with_execution
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_history_with_execution(TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_history_with_execution(
+            p_instance_id TEXT,
+            p_execution_id BIGINT
+        )
+        RETURNS TABLE(out_event_data TEXT) AS $fetch_history_exec$
+        BEGIN
+            RETURN QUERY
+            SELECT h.event_data
+            FROM %I.history h
+            WHERE h.instance_id = p_instance_id
+              AND h.execution_id = p_execution_id
+            ORDER BY h.event_id;
+        END;
+        $fetch_history_exec$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: append_history
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.append_history(TEXT, BIGINT, JSONB, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.append_history(
+            p_instance_id TEXT,
+            p_execution_id BIGINT,
+            p_events JSONB,
+            p_now_ms BIGINT
+        )
+        RETURNS VOID AS $append_hist$
+        DECLARE
+            v_now_ts TIMESTAMPTZ;
+        BEGIN
+            IF p_events IS NULL OR JSONB_ARRAY_LENGTH(p_events) = 0 THEN
+                RETURN;
+            END IF;
+
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            IF EXISTS (
+                SELECT 1
+                FROM JSONB_ARRAY_ELEMENTS(p_events) elem
+                WHERE COALESCE((elem->>''event_id'')::BIGINT, 0) <= 0
+            ) THEN
+                RAISE EXCEPTION ''Invalid event_id in append_history'';
+            END IF;
+
+            INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+            SELECT
+                p_instance_id,
+                p_execution_id,
+                (elem->>''event_id'')::BIGINT,
+                elem->>''event_type'',
+                elem->>''event_data'',
+                v_now_ts
+            FROM JSONB_ARRAY_ELEMENTS(p_events) AS elem
+            ON CONFLICT (instance_id, execution_id, event_id) DO NOTHING;
+        END;
+        $append_hist$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+END $$;
+
+INSERT INTO _duroxide_migrations(version, name) VALUES (1, '0001_initial_schema.sql') ON CONFLICT (version) DO NOTHING;
+
+-- Migration 0002: 0002_add_deletion_and_pruning_support.sql
+-- Migration 0002: Add deletion and pruning support
+-- This migration adds:
+-- 1. parent_instance_id column to instances table (for cascade deletion)
+-- 2. Updates get_instance_info to include parent_instance_id
+-- 3. Updates ack_orchestration_item to store parent_instance_id from metadata
+-- 4. New stored procedures for ProviderAdmin methods:
+--    - list_children
+--    - get_parent_id
+--    - delete_instances_atomic
+--    - prune_executions
+
+-- Add parent_instance_id column to instances table
+ALTER TABLE instances ADD COLUMN IF NOT EXISTS parent_instance_id TEXT;
+
+-- Add index for efficient child lookups
+CREATE INDEX IF NOT EXISTS idx_instances_parent ON instances(parent_instance_id);
+
+-- Get the current schema name (set by migration runner)
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    -- ============================================================================
+    -- Update get_instance_info to include parent_instance_id
+    -- ============================================================================
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT)', v_schema_name);
+    
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_instance_info(p_instance_id TEXT)
+        RETURNS TABLE(
+            instance_id TEXT,
+            orchestration_name TEXT,
+            orchestration_version TEXT,
+            current_execution_id BIGINT,
+            created_at TIMESTAMPTZ,
+            updated_at TIMESTAMPTZ,
+            status TEXT,
+            output TEXT,
+            parent_instance_id TEXT
+        ) AS $get_inst_info$
+        BEGIN
+            RETURN QUERY
+            SELECT i.instance_id, i.orchestration_name, 
+                   COALESCE(i.orchestration_version, ''unknown'') as orchestration_version,
+                   i.current_execution_id, i.created_at, i.updated_at,
+                   e.status, e.output, i.parent_instance_id
+            FROM %I.instances i
+            LEFT JOIN %I.executions e ON i.instance_id = e.instance_id 
+              AND i.current_execution_id = e.execution_id
+            WHERE i.instance_id = p_instance_id;
+        END;
+        $get_inst_info$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Update ack_orchestration_item to store parent_instance_id from metadata
+    -- This is critical for hierarchy tracking (cascade deletion, list_children, etc)
+    -- ============================================================================
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_execution_id BIGINT,
+            p_history_delta JSONB,
+            p_worker_items JSONB,
+            p_orchestrator_items JSONB,
+            p_metadata JSONB,
+            p_cancelled_activities JSONB DEFAULT ''[]''::JSONB
+        )
+        RETURNS VOID AS $ack_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_now_ts TIMESTAMPTZ;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_parent_instance_id TEXT;
+            v_status TEXT;
+            v_output TEXT;
+            v_completed_at TIMESTAMPTZ;
+            v_elem JSONB;
+            v_visible_at TIMESTAMPTZ;
+            v_fire_at_ms BIGINT;
+            v_item_instance_id TEXT;
+            v_cancelled JSONB;
+            v_cancelled_execution_id BIGINT;
+            v_cancelled_activity_id BIGINT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token AND il.locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            v_orchestration_name := p_metadata->>''orchestration_name'';
+            v_orchestration_version := p_metadata->>''orchestration_version'';
+            v_parent_instance_id := p_metadata->>''parent_instance_id'';
+            v_status := p_metadata->>''status'';
+            v_output := p_metadata->>''output'';
+
+            IF v_orchestration_name IS NOT NULL AND v_orchestration_version IS NOT NULL THEN
+                INSERT INTO %I.instances (instance_id, orchestration_name, orchestration_version, current_execution_id, parent_instance_id, created_at, updated_at)
+                VALUES (v_instance_id, v_orchestration_name, v_orchestration_version, p_execution_id, v_parent_instance_id, v_now_ts, v_now_ts)
+                ON CONFLICT (instance_id) DO NOTHING;
+
+                UPDATE %I.instances i
+                SET orchestration_name = v_orchestration_name,
+                    orchestration_version = v_orchestration_version,
+                    parent_instance_id = COALESCE(i.parent_instance_id, v_parent_instance_id),
+                    updated_at = v_now_ts
+                WHERE i.instance_id = v_instance_id;
+            END IF;
+
+            INSERT INTO %I.executions (instance_id, execution_id, status, started_at)
+            VALUES (v_instance_id, p_execution_id, ''Running'', v_now_ts)
+            ON CONFLICT (instance_id, execution_id) DO NOTHING;
+
+            UPDATE %I.instances i
+            SET current_execution_id = GREATEST(i.current_execution_id, p_execution_id),
+                updated_at = v_now_ts
+            WHERE i.instance_id = v_instance_id;
+
+            IF p_history_delta IS NOT NULL AND JSONB_ARRAY_LENGTH(p_history_delta) > 0 THEN
+                INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+                SELECT
+                    v_instance_id,
+                    p_execution_id,
+                    (elem->>''event_id'')::BIGINT,
+                    elem->>''event_type'',
+                    elem->>''event_data'',
+                    v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_history_delta) AS elem;
+            END IF;
+
+            IF v_status IS NOT NULL THEN
+                v_completed_at := CASE 
+                    WHEN v_status IN (''Completed'', ''Failed'') THEN v_now_ts 
+                    ELSE NULL 
+                END;
+                
+                UPDATE %I.executions e
+                SET status = v_status, output = v_output, completed_at = v_completed_at
+                WHERE e.instance_id = v_instance_id AND e.execution_id = p_execution_id;
+            END IF;
+
+            IF p_worker_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_worker_items) > 0 THEN
+                INSERT INTO %I.worker_queue (work_item, visible_at, created_at)
+                SELECT elem::TEXT, v_now_ts, v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_worker_items) AS elem;
+            END IF;
+
+            IF p_orchestrator_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_orchestrator_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_orchestrator_items) LOOP
+                    IF v_elem ? ''StartOrchestration'' THEN
+                        v_item_instance_id := v_elem->''StartOrchestration''->>''instance'';
+                    ELSIF v_elem ? ''ContinueAsNew'' THEN
+                        v_item_instance_id := v_elem->''ContinueAsNew''->>''instance'';
+                    ELSIF v_elem ? ''TimerFired'' THEN
+                        v_item_instance_id := v_elem->''TimerFired''->>''instance'';
+                        v_fire_at_ms := (v_elem->''TimerFired''->>''fire_at_ms'')::BIGINT;
+                    ELSIF v_elem ? ''ActivityCompleted'' THEN
+                        v_item_instance_id := v_elem->''ActivityCompleted''->>''instance'';
+                    ELSIF v_elem ? ''ActivityFailed'' THEN
+                        v_item_instance_id := v_elem->''ActivityFailed''->>''instance'';
+                    ELSIF v_elem ? ''ExternalRaised'' THEN
+                        v_item_instance_id := v_elem->''ExternalRaised''->>''instance'';
+                    ELSIF v_elem ? ''CancelInstance'' THEN
+                        v_item_instance_id := v_elem->''CancelInstance''->>''instance'';
+                    ELSIF v_elem ? ''SubOrchCompleted'' THEN
+                        v_item_instance_id := v_elem->''SubOrchCompleted''->>''parent_instance'';
+                    ELSIF v_elem ? ''SubOrchFailed'' THEN
+                        v_item_instance_id := v_elem->''SubOrchFailed''->>''parent_instance'';
+                    ELSE
+                        v_item_instance_id := v_instance_id;
+                    END IF;
+
+                    IF v_elem ? ''TimerFired'' AND v_fire_at_ms IS NOT NULL AND v_fire_at_ms > 0 THEN
+                        v_visible_at := TO_TIMESTAMP(v_fire_at_ms / 1000.0);
+                    ELSE
+                        v_visible_at := v_now_ts;
+                    END IF;
+
+                    INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                    VALUES (v_item_instance_id, v_elem::TEXT, v_visible_at, v_now_ts);
+                    
+                    v_fire_at_ms := NULL;
+                END LOOP;
+            END IF;
+
+            -- Lock-Stealing: Delete worker queue entries for cancelled activities
+            IF p_cancelled_activities IS NOT NULL AND JSONB_ARRAY_LENGTH(p_cancelled_activities) > 0 THEN
+                FOR v_cancelled IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_cancelled_activities) LOOP
+                    v_cancelled_execution_id := (v_cancelled->>''execution_id'')::BIGINT;
+                    v_cancelled_activity_id := (v_cancelled->>''activity_id'')::BIGINT;
+                    
+                    DELETE FROM %I.worker_queue wq
+                    WHERE wq.work_item::JSONB ? ''ActivityExecute''
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''instance'') = v_instance_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''execution_id'')::BIGINT = v_cancelled_execution_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''id'')::BIGINT = v_cancelled_activity_id;
+                END LOOP;
+            END IF;
+
+            DELETE FROM %I.orchestrator_queue q WHERE q.lock_token = p_lock_token;
+
+            DELETE FROM %I.instance_locks il
+            WHERE il.instance_id = v_instance_id AND il.lock_token = p_lock_token;
+        END;
+        $ack_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Hierarchy Primitive Procedures
+    -- ============================================================================
+
+    -- Procedure: list_children
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.list_children(p_instance_id TEXT)
+        RETURNS TABLE(child_instance_id TEXT) AS $list_children$
+        BEGIN
+            RETURN QUERY
+            SELECT i.instance_id
+            FROM %I.instances i
+            WHERE i.parent_instance_id = p_instance_id
+            ORDER BY i.created_at;
+        END;
+        $list_children$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: get_parent_id
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_parent_id(p_instance_id TEXT)
+        RETURNS TEXT AS $get_parent$
+        DECLARE
+            v_parent_id TEXT;
+        BEGIN
+            SELECT i.parent_instance_id
+            INTO v_parent_id
+            FROM %I.instances i
+            WHERE i.instance_id = p_instance_id;
+            
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Instance not found: %%'', p_instance_id;
+            END IF;
+            
+            RETURN v_parent_id;
+        END;
+        $get_parent$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Deletion Procedures
+    -- ============================================================================
+
+    -- Procedure: delete_instances_atomic
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.delete_instances_atomic(
+            p_instance_ids TEXT[],
+            p_force BOOLEAN
+        )
+        RETURNS TABLE(
+            instances_deleted BIGINT,
+            executions_deleted BIGINT,
+            events_deleted BIGINT,
+            queue_messages_deleted BIGINT
+        ) AS $delete_atomic$
+        DECLARE
+            v_instance_id TEXT;
+            v_orphan_id TEXT;
+            v_instances_deleted BIGINT := 0;
+            v_executions_deleted BIGINT := 0;
+            v_events_deleted BIGINT := 0;
+            v_queue_deleted BIGINT := 0;
+            v_count BIGINT;
+        BEGIN
+            IF p_instance_ids IS NULL OR array_length(p_instance_ids, 1) IS NULL THEN
+                instances_deleted := 0;
+                executions_deleted := 0;
+                events_deleted := 0;
+                queue_messages_deleted := 0;
+                RETURN NEXT;
+                RETURN;
+            END IF;
+
+            IF NOT p_force THEN
+                SELECT i.instance_id INTO v_instance_id
+                FROM %I.instances i
+                JOIN %I.executions e ON i.instance_id = e.instance_id 
+                  AND i.current_execution_id = e.execution_id
+                WHERE i.instance_id = ANY(p_instance_ids)
+                  AND e.status = ''Running''
+                LIMIT 1;
+                
+                IF v_instance_id IS NOT NULL THEN
+                    RAISE EXCEPTION ''Instance %% is Running. Use force=true to delete.'', v_instance_id;
+                END IF;
+            END IF;
+
+            PERFORM 1 FROM %I.instances
+            WHERE instance_id = ANY(p_instance_ids)
+            FOR UPDATE;
+
+            SELECT i.instance_id INTO v_orphan_id
+            FROM %I.instances i
+            WHERE i.parent_instance_id = ANY(p_instance_ids)
+              AND NOT (i.instance_id = ANY(p_instance_ids))
+            LIMIT 1;
+            
+            IF v_orphan_id IS NOT NULL THEN
+                RAISE EXCEPTION ''Orphan detected: instance %% has parent in delete list but is not included'', v_orphan_id;
+            END IF;
+
+            DELETE FROM %I.history WHERE instance_id = ANY(p_instance_ids);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_events_deleted := v_count;
+
+            DELETE FROM %I.executions WHERE instance_id = ANY(p_instance_ids);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_executions_deleted := v_count;
+
+            DELETE FROM %I.orchestrator_queue WHERE instance_id = ANY(p_instance_ids);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_queue_deleted := v_count;
+
+            DELETE FROM %I.worker_queue 
+            WHERE work_item::JSONB ? ''ActivityExecute''
+              AND (work_item::JSONB->''ActivityExecute''->>''instance'') = ANY(p_instance_ids);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_queue_deleted := v_queue_deleted + v_count;
+
+            DELETE FROM %I.instance_locks WHERE instance_id = ANY(p_instance_ids);
+
+            DELETE FROM %I.instances WHERE instance_id = ANY(p_instance_ids);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_instances_deleted := v_count;
+
+            instances_deleted := v_instances_deleted;
+            executions_deleted := v_executions_deleted;
+            events_deleted := v_events_deleted;
+            queue_messages_deleted := v_queue_deleted;
+            RETURN NEXT;
+        END;
+        $delete_atomic$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Pruning Procedures
+    -- ============================================================================
+
+    -- Procedure: prune_executions
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.prune_executions(
+            p_instance_id TEXT,
+            p_keep_last INTEGER DEFAULT NULL,
+            p_completed_before_ms BIGINT DEFAULT NULL
+        )
+        RETURNS TABLE(
+            instances_processed BIGINT,
+            executions_deleted BIGINT,
+            events_deleted BIGINT
+        ) AS $prune_exec$
+        DECLARE
+            v_current_execution_id BIGINT;
+            v_executions_deleted BIGINT := 0;
+            v_events_deleted BIGINT := 0;
+            v_count BIGINT;
+            v_exec_ids_to_delete BIGINT[];
+        BEGIN
+            SELECT i.current_execution_id INTO v_current_execution_id
+            FROM %I.instances i
+            WHERE i.instance_id = p_instance_id;
+            
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Instance %% not found'', p_instance_id;
+            END IF;
+
+            SELECT array_agg(e.execution_id) INTO v_exec_ids_to_delete
+            FROM %I.executions e
+            WHERE e.instance_id = p_instance_id
+              AND e.execution_id != v_current_execution_id
+              AND e.status != ''Running''
+              AND (p_completed_before_ms IS NULL 
+                   OR e.completed_at < TO_TIMESTAMP(p_completed_before_ms / 1000.0))
+              AND (p_keep_last IS NULL 
+                   OR e.execution_id NOT IN (
+                       SELECT e2.execution_id 
+                       FROM %I.executions e2
+                       WHERE e2.instance_id = p_instance_id
+                       ORDER BY e2.execution_id DESC
+                       LIMIT p_keep_last
+                   ));
+
+            IF v_exec_ids_to_delete IS NULL OR array_length(v_exec_ids_to_delete, 1) IS NULL THEN
+                instances_processed := 1;
+                executions_deleted := 0;
+                events_deleted := 0;
+                RETURN NEXT;
+                RETURN;
+            END IF;
+
+            DELETE FROM %I.history h
+            WHERE h.instance_id = p_instance_id
+              AND h.execution_id = ANY(v_exec_ids_to_delete);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_events_deleted := v_count;
+
+            DELETE FROM %I.executions e
+            WHERE e.instance_id = p_instance_id
+              AND e.execution_id = ANY(v_exec_ids_to_delete);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_executions_deleted := v_count;
+
+            instances_processed := 1;
+            executions_deleted := v_executions_deleted;
+            events_deleted := v_events_deleted;
+            RETURN NEXT;
+        END;
+        $prune_exec$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+END $$;
+
+INSERT INTO _duroxide_migrations(version, name) VALUES (2, '0002_add_deletion_and_pruning_support.sql') ON CONFLICT (version) DO NOTHING;
+
+-- Migration 0003: 0003_add_capability_filtering.sql
+-- Migration 0003: Add capability filtering support
+-- This migration adds:
+-- 1. duroxide_version_major/minor/patch columns to executions table
+-- 2. Updates fetch_orchestration_item to accept version filter parameters
+-- 3. Updates ack_orchestration_item to store pinned_duroxide_version from metadata
+-- 4. Updates cleanup_schema to drop new function signatures
+
+-- Add version columns to executions table
+ALTER TABLE executions ADD COLUMN IF NOT EXISTS duroxide_version_major INTEGER;
+ALTER TABLE executions ADD COLUMN IF NOT EXISTS duroxide_version_minor INTEGER;
+ALTER TABLE executions ADD COLUMN IF NOT EXISTS duroxide_version_patch INTEGER;
+
+-- Get the current schema name (set by migration runner)
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    -- ============================================================================
+    -- Update fetch_orchestration_item to accept version filter parameters
+    -- Drop old 2-param signature, create new 4-param signature
+    -- ============================================================================
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_orchestration_item(
+            p_now_ms BIGINT,
+            p_lock_timeout_ms BIGINT,
+            p_min_version_packed BIGINT DEFAULT NULL,
+            p_max_version_packed BIGINT DEFAULT NULL
+        )
+        RETURNS TABLE(
+            out_instance_id TEXT,
+            out_orchestration_name TEXT,
+            out_orchestration_version TEXT,
+            out_execution_id BIGINT,
+            out_history JSONB,
+            out_messages JSONB,
+            out_lock_token TEXT,
+            out_attempt_count INTEGER
+        ) AS $fetch_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_lock_token TEXT;
+            v_locked_until BIGINT;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_current_execution_id BIGINT;
+            v_history JSONB;
+            v_messages JSONB;
+            v_lock_acquired INTEGER;
+            v_max_attempt_count INTEGER;
+        BEGIN
+            -- Phase 1: Find a candidate instance (no FOR UPDATE yet)
+            IF p_min_version_packed IS NOT NULL THEN
+                -- Version-filtered path: join to instances and executions to check pinned version
+                SELECT q.instance_id INTO v_instance_id
+                FROM %I.orchestrator_queue q
+                LEFT JOIN %I.instances i ON q.instance_id = i.instance_id
+                LEFT JOIN %I.executions e ON i.instance_id = e.instance_id
+                  AND i.current_execution_id = e.execution_id
+                WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM %I.instance_locks il
+                    WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+                  )
+                  AND (
+                    e.duroxide_version_major IS NULL
+                    OR (e.duroxide_version_major * 1000000 + e.duroxide_version_minor * 1000 + e.duroxide_version_patch)
+                       BETWEEN p_min_version_packed AND p_max_version_packed
+                  )
+                ORDER BY q.visible_at, q.id
+                LIMIT 1;
+            ELSE
+                -- No filter: original behavior
+                SELECT q.instance_id INTO v_instance_id
+                FROM %I.orchestrator_queue q
+                WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM %I.instance_locks il
+                    WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+                  )
+                ORDER BY q.visible_at, q.id
+                LIMIT 1;
+            END IF;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            -- Phase 2: Acquire instance-level advisory lock
+            PERFORM pg_advisory_xact_lock(hashtext(v_instance_id));
+
+            -- Phase 3: Re-verify with FOR UPDATE (include version filter if applicable)
+            IF p_min_version_packed IS NOT NULL THEN
+                SELECT q.instance_id INTO v_instance_id
+                FROM %I.orchestrator_queue q
+                LEFT JOIN %I.instances i ON q.instance_id = i.instance_id
+                LEFT JOIN %I.executions e ON i.instance_id = e.instance_id
+                  AND i.current_execution_id = e.execution_id
+                WHERE q.instance_id = v_instance_id
+                  AND q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM %I.instance_locks il
+                    WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+                  )
+                  AND (
+                    e.duroxide_version_major IS NULL
+                    OR (e.duroxide_version_major * 1000000 + e.duroxide_version_minor * 1000 + e.duroxide_version_patch)
+                       BETWEEN p_min_version_packed AND p_max_version_packed
+                  )
+                FOR UPDATE OF q SKIP LOCKED;
+            ELSE
+                SELECT q.instance_id INTO v_instance_id
+                FROM %I.orchestrator_queue q
+                WHERE q.instance_id = v_instance_id
+                  AND q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM %I.instance_locks il
+                    WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+                  )
+                FOR UPDATE OF q SKIP LOCKED;
+            END IF;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            v_lock_token := ''lock_'' || gen_random_uuid()::TEXT;
+            v_locked_until := p_now_ms + p_lock_timeout_ms;
+
+            INSERT INTO %I.instance_locks (instance_id, lock_token, locked_until, locked_at)
+            VALUES (v_instance_id, v_lock_token, v_locked_until, p_now_ms)
+            ON CONFLICT(instance_id) DO UPDATE
+            SET lock_token = EXCLUDED.lock_token,
+                locked_until = EXCLUDED.locked_until,
+                locked_at = EXCLUDED.locked_at
+            WHERE %I.instance_locks.locked_until <= p_now_ms;
+
+            GET DIAGNOSTICS v_lock_acquired = ROW_COUNT;
+
+            IF v_lock_acquired = 0 THEN
+                RETURN;
+            END IF;
+
+            UPDATE %I.orchestrator_queue q
+            SET lock_token = v_lock_token,
+                locked_until = v_locked_until,
+                attempt_count = q.attempt_count + 1
+            WHERE q.instance_id = v_instance_id
+              AND q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+              AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms);
+
+            SELECT COALESCE(JSONB_AGG(q.work_item::JSONB ORDER BY q.id), ''[]''::JSONB),
+                   COALESCE(MAX(q.attempt_count), 1)
+            INTO v_messages, v_max_attempt_count
+            FROM %I.orchestrator_queue q
+            WHERE q.lock_token = v_lock_token;
+
+            SELECT i.orchestration_name, i.orchestration_version, i.current_execution_id
+            INTO v_orchestration_name, v_orchestration_version, v_current_execution_id
+            FROM %I.instances i
+            WHERE i.instance_id = v_instance_id;
+
+            IF FOUND THEN
+                SELECT COALESCE(JSONB_AGG(h.event_data::JSONB ORDER BY h.event_id), ''[]''::JSONB)
+                INTO v_history
+                FROM %I.history h
+                WHERE h.instance_id = v_instance_id AND h.execution_id = v_current_execution_id;
+                
+                v_orchestration_version := COALESCE(v_orchestration_version, ''unknown'');
+            ELSE
+                SELECT COALESCE(JSONB_AGG(h.event_data::JSONB ORDER BY h.execution_id, h.event_id), ''[]''::JSONB)
+                INTO v_history
+                FROM %I.history h
+                WHERE h.instance_id = v_instance_id;
+
+                IF JSONB_ARRAY_LENGTH(v_history) > 0 AND v_history->0 ? ''OrchestrationStarted'' THEN
+                    v_orchestration_name := v_history->0->''OrchestrationStarted''->>''name'';
+                    v_orchestration_version := v_history->0->''OrchestrationStarted''->>''version'';
+                    v_current_execution_id := 1;
+                ELSIF JSONB_ARRAY_LENGTH(v_messages) > 0 AND v_messages->0 ? ''StartOrchestration'' THEN
+                    v_orchestration_name := v_messages->0->''StartOrchestration''->>''orchestration'';
+                    v_orchestration_version := COALESCE(v_messages->0->''StartOrchestration''->>''version'', ''unknown'');
+                    v_current_execution_id := COALESCE((v_messages->0->''StartOrchestration''->>''execution_id'')::BIGINT, 1);
+                ELSIF JSONB_ARRAY_LENGTH(v_messages) > 0 AND v_messages->0 ? ''ContinueAsNew'' THEN
+                    v_orchestration_name := v_messages->0->''ContinueAsNew''->>''orchestration'';
+                    v_orchestration_version := COALESCE(v_messages->0->''ContinueAsNew''->>''version'', ''unknown'');
+                    v_current_execution_id := 1;
+                ELSE
+                    v_orchestration_name := ''Unknown'';
+                    v_orchestration_version := ''unknown'';
+                    v_current_execution_id := 1;
+                END IF;
+            END IF;
+
+            RETURN QUERY SELECT
+                v_instance_id,
+                v_orchestration_name,
+                v_orchestration_version,
+                v_current_execution_id,
+                v_history,
+                v_messages,
+                v_lock_token,
+                v_max_attempt_count;
+        END;
+        $fetch_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Update ack_orchestration_item to handle pinned_duroxide_version
+    -- Drop old signature, create new one with version handling
+    -- ============================================================================
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_execution_id BIGINT,
+            p_history_delta JSONB,
+            p_worker_items JSONB,
+            p_orchestrator_items JSONB,
+            p_metadata JSONB,
+            p_cancelled_activities JSONB DEFAULT ''[]''::JSONB
+        )
+        RETURNS VOID AS $ack_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_now_ts TIMESTAMPTZ;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_parent_instance_id TEXT;
+            v_status TEXT;
+            v_output TEXT;
+            v_completed_at TIMESTAMPTZ;
+            v_elem JSONB;
+            v_visible_at TIMESTAMPTZ;
+            v_fire_at_ms BIGINT;
+            v_item_instance_id TEXT;
+            v_cancelled JSONB;
+            v_cancelled_execution_id BIGINT;
+            v_cancelled_activity_id BIGINT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token AND il.locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            v_orchestration_name := p_metadata->>''orchestration_name'';
+            v_orchestration_version := p_metadata->>''orchestration_version'';
+            v_parent_instance_id := p_metadata->>''parent_instance_id'';
+            v_status := p_metadata->>''status'';
+            v_output := p_metadata->>''output'';
+
+            IF v_orchestration_name IS NOT NULL AND v_orchestration_version IS NOT NULL THEN
+                INSERT INTO %I.instances (instance_id, orchestration_name, orchestration_version, current_execution_id, parent_instance_id, created_at, updated_at)
+                VALUES (v_instance_id, v_orchestration_name, v_orchestration_version, p_execution_id, v_parent_instance_id, v_now_ts, v_now_ts)
+                ON CONFLICT (instance_id) DO NOTHING;
+
+                UPDATE %I.instances i
+                SET orchestration_name = v_orchestration_name,
+                    orchestration_version = v_orchestration_version,
+                    parent_instance_id = COALESCE(i.parent_instance_id, v_parent_instance_id),
+                    updated_at = v_now_ts
+                WHERE i.instance_id = v_instance_id;
+            END IF;
+
+            INSERT INTO %I.executions (instance_id, execution_id, status, started_at)
+            VALUES (v_instance_id, p_execution_id, ''Running'', v_now_ts)
+            ON CONFLICT (instance_id, execution_id) DO NOTHING;
+
+            UPDATE %I.instances i
+            SET current_execution_id = GREATEST(i.current_execution_id, p_execution_id),
+                updated_at = v_now_ts
+            WHERE i.instance_id = v_instance_id;
+
+            IF p_history_delta IS NOT NULL AND JSONB_ARRAY_LENGTH(p_history_delta) > 0 THEN
+                INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+                SELECT
+                    v_instance_id,
+                    p_execution_id,
+                    (elem->>''event_id'')::BIGINT,
+                    elem->>''event_type'',
+                    elem->>''event_data'',
+                    v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_history_delta) AS elem;
+            END IF;
+
+            IF v_status IS NOT NULL THEN
+                v_completed_at := CASE 
+                    WHEN v_status IN (''Completed'', ''Failed'') THEN v_now_ts 
+                    ELSE NULL 
+                END;
+                
+                UPDATE %I.executions e
+                SET status = v_status, output = v_output, completed_at = v_completed_at
+                WHERE e.instance_id = v_instance_id AND e.execution_id = p_execution_id;
+            END IF;
+
+            -- Store pinned duroxide version on execution if provided
+            IF p_metadata ? ''pinned_duroxide_version'' AND p_metadata->''pinned_duroxide_version'' IS NOT NULL
+               AND p_metadata->>''pinned_duroxide_version'' != ''null'' THEN
+                UPDATE %I.executions
+                SET duroxide_version_major = (p_metadata->''pinned_duroxide_version''->>''major'')::INTEGER,
+                    duroxide_version_minor = (p_metadata->''pinned_duroxide_version''->>''minor'')::INTEGER,
+                    duroxide_version_patch = (p_metadata->''pinned_duroxide_version''->>''patch'')::INTEGER
+                WHERE instance_id = v_instance_id AND execution_id = p_execution_id;
+            END IF;
+
+            IF p_worker_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_worker_items) > 0 THEN
+                INSERT INTO %I.worker_queue (work_item, visible_at, created_at)
+                SELECT elem::TEXT, v_now_ts, v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_worker_items) AS elem;
+            END IF;
+
+            IF p_orchestrator_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_orchestrator_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_orchestrator_items) LOOP
+                    IF v_elem ? ''StartOrchestration'' THEN
+                        v_item_instance_id := v_elem->''StartOrchestration''->>''instance'';
+                    ELSIF v_elem ? ''ContinueAsNew'' THEN
+                        v_item_instance_id := v_elem->''ContinueAsNew''->>''instance'';
+                    ELSIF v_elem ? ''TimerFired'' THEN
+                        v_item_instance_id := v_elem->''TimerFired''->>''instance'';
+                        v_fire_at_ms := (v_elem->''TimerFired''->>''fire_at_ms'')::BIGINT;
+                    ELSIF v_elem ? ''ActivityCompleted'' THEN
+                        v_item_instance_id := v_elem->''ActivityCompleted''->>''instance'';
+                    ELSIF v_elem ? ''ActivityFailed'' THEN
+                        v_item_instance_id := v_elem->''ActivityFailed''->>''instance'';
+                    ELSIF v_elem ? ''ExternalRaised'' THEN
+                        v_item_instance_id := v_elem->''ExternalRaised''->>''instance'';
+                    ELSIF v_elem ? ''CancelInstance'' THEN
+                        v_item_instance_id := v_elem->''CancelInstance''->>''instance'';
+                    ELSIF v_elem ? ''SubOrchCompleted'' THEN
+                        v_item_instance_id := v_elem->''SubOrchCompleted''->>''parent_instance'';
+                    ELSIF v_elem ? ''SubOrchFailed'' THEN
+                        v_item_instance_id := v_elem->''SubOrchFailed''->>''parent_instance'';
+                    ELSE
+                        v_item_instance_id := v_instance_id;
+                    END IF;
+
+                    IF v_elem ? ''TimerFired'' AND v_fire_at_ms IS NOT NULL AND v_fire_at_ms > 0 THEN
+                        v_visible_at := TO_TIMESTAMP(v_fire_at_ms / 1000.0);
+                    ELSE
+                        v_visible_at := v_now_ts;
+                    END IF;
+
+                    INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                    VALUES (v_item_instance_id, v_elem::TEXT, v_visible_at, v_now_ts);
+                    
+                    v_fire_at_ms := NULL;
+                END LOOP;
+            END IF;
+
+            -- Lock-Stealing: Delete worker queue entries for cancelled activities
+            IF p_cancelled_activities IS NOT NULL AND JSONB_ARRAY_LENGTH(p_cancelled_activities) > 0 THEN
+                FOR v_cancelled IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_cancelled_activities) LOOP
+                    v_cancelled_execution_id := (v_cancelled->>''execution_id'')::BIGINT;
+                    v_cancelled_activity_id := (v_cancelled->>''activity_id'')::BIGINT;
+                    
+                    DELETE FROM %I.worker_queue wq
+                    WHERE wq.work_item::JSONB ? ''ActivityExecute''
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''instance'') = v_instance_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''execution_id'')::BIGINT = v_cancelled_execution_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''id'')::BIGINT = v_cancelled_activity_id;
+                END LOOP;
+            END IF;
+
+            DELETE FROM %I.orchestrator_queue q WHERE q.lock_token = p_lock_token;
+
+            DELETE FROM %I.instance_locks il
+            WHERE il.instance_id = v_instance_id AND il.lock_token = p_lock_token;
+        END;
+        $ack_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Update cleanup_schema to drop new function signatures
+    -- ============================================================================
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.cleanup_schema()', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.cleanup_schema()
+        RETURNS VOID AS $cleanup$
+        BEGIN
+            -- Drop tables first
+            DROP TABLE IF EXISTS %I.instances CASCADE;
+            DROP TABLE IF EXISTS %I.executions CASCADE;
+            DROP TABLE IF EXISTS %I.history CASCADE;
+            DROP TABLE IF EXISTS %I.orchestrator_queue CASCADE;
+            DROP TABLE IF EXISTS %I.worker_queue CASCADE;
+            DROP TABLE IF EXISTS %I.instance_locks CASCADE;
+            DROP TABLE IF EXISTS %I._duroxide_migrations CASCADE;
+            
+            -- Drop all stored procedures (required because return type changes cannot use CREATE OR REPLACE)
+            DROP FUNCTION IF EXISTS %I.cleanup_schema();
+            DROP FUNCTION IF EXISTS %I.list_instances();
+            DROP FUNCTION IF EXISTS %I.list_executions(TEXT);
+            DROP FUNCTION IF EXISTS %I.latest_execution_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.list_instances_by_status(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_execution_info(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.get_system_metrics();
+            DROP FUNCTION IF EXISTS %I.get_queue_depths(BIGINT);
+            DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.abandon_work_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.enqueue_orchestrator_work(TEXT, TEXT, TIMESTAMPTZ, BIGINT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB);
+            DROP FUNCTION IF EXISTS %I.abandon_orchestration_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.renew_orchestration_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_history(TEXT);
+            DROP FUNCTION IF EXISTS %I.fetch_history_with_execution(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.append_history(TEXT, BIGINT, JSONB, BIGINT);
+            DROP FUNCTION IF EXISTS %I.list_children(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_parent_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.delete_instances_atomic(TEXT[], BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.prune_executions(TEXT, INTEGER, BIGINT);
+            
+            -- Drop trigger functions (not schema-qualified, they use search_path)
+            -- CASCADE is required because triggers depend on these functions
+            DROP FUNCTION IF EXISTS notify_orch_work() CASCADE;
+            DROP FUNCTION IF EXISTS notify_worker_work() CASCADE;
+        END;
+        $cleanup$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name);
+
+END $$;
+
+INSERT INTO _duroxide_migrations(version, name) VALUES (3, '0003_add_capability_filtering.sql') ON CONFLICT (version) DO NOTHING;
+
+-- Migration 0004: 0004_add_session_support.sql
+-- Migration 0004: Add session affinity support
+-- This migration adds:
+-- 1. session_id column to worker_queue
+-- 2. sessions table for tracking session ownership
+-- 3. Session-aware fetch_work_item with routing logic
+-- 4. Session piggybacking in ack_worker and renew_work_item_lock
+-- 5. renew_session_lock and cleanup_orphaned_sessions stored procedures
+-- 6. Updated enqueue_worker_work and ack_orchestration_item for session_id
+
+-- Schema changes using unqualified names (search_path set by migration runner)
+ALTER TABLE worker_queue ADD COLUMN IF NOT EXISTS session_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_worker_queue_session_id ON worker_queue(session_id);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id TEXT PRIMARY KEY,
+    worker_id TEXT NOT NULL,
+    locked_until BIGINT NOT NULL,
+    last_activity_at BIGINT NOT NULL
+);
+
+-- Stored procedure changes using schema-qualified names
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    -- ============================================================================
+    -- Part 1: Update enqueue_worker_work to accept session_id
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.enqueue_worker_work(
+            p_work_item TEXT,
+            p_now_ms BIGINT,
+            p_session_id TEXT DEFAULT NULL
+        )
+        RETURNS VOID AS $enq_worker$
+        DECLARE
+            v_now_ts TIMESTAMPTZ;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+            INSERT INTO %I.worker_queue (work_item, visible_at, created_at, session_id)
+            VALUES (p_work_item, v_now_ts, v_now_ts, p_session_id);
+        END;
+        $enq_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 2: Update fetch_work_item with session routing
+    -- Drop old 2-param version, create new 4-param version returning 3 columns
+    -- (out_execution_status removed - cancellation now via lock-stealing)
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_work_item(
+            p_now_ms BIGINT,
+            p_lock_timeout_ms BIGINT,
+            p_owner_id TEXT DEFAULT NULL,
+            p_session_lock_timeout_ms BIGINT DEFAULT NULL
+        )
+        RETURNS TABLE(
+            out_work_item TEXT,
+            out_lock_token TEXT,
+            out_attempt_count INTEGER
+        ) AS $fetch_worker$
+        DECLARE
+            v_id BIGINT;
+            v_session_id TEXT;
+            v_session_locked_until BIGINT;
+        BEGIN
+            IF p_owner_id IS NOT NULL THEN
+                -- Session-aware fetch: find eligible items considering session routing
+                -- Eligible items are:
+                -- 1. Non-session items (q.session_id IS NULL)
+                -- 2. Items for sessions owned by this worker (s.worker_id = p_owner_id AND s.locked_until > p_now_ms)
+                -- 3. Items for claimable sessions (no active session row, or expired lock)
+                SELECT q.id, q.session_id INTO v_id, v_session_id
+                FROM %I.worker_queue q
+                LEFT JOIN %I.sessions s ON s.session_id = q.session_id AND s.locked_until > p_now_ms
+                WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms)
+                  AND (
+                    q.session_id IS NULL
+                    OR s.worker_id = p_owner_id
+                    OR s.session_id IS NULL
+                  )
+                ORDER BY q.id
+                LIMIT 1
+                FOR UPDATE OF q SKIP LOCKED;
+            ELSE
+                -- Non-session fetch: only non-session items
+                SELECT q.id, q.session_id INTO v_id, v_session_id
+                FROM %I.worker_queue q
+                WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms)
+                  AND q.session_id IS NULL
+                ORDER BY q.id
+                LIMIT 1
+                FOR UPDATE OF q SKIP LOCKED;
+            END IF;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            out_lock_token := ''lock_'' || gen_random_uuid()::TEXT;
+
+            -- Increment attempt_count and lock the item
+            UPDATE %I.worker_queue
+            SET lock_token = out_lock_token,
+                locked_until = p_now_ms + p_lock_timeout_ms,
+                attempt_count = attempt_count + 1
+            WHERE id = v_id;
+
+            SELECT work_item, attempt_count
+            INTO out_work_item, out_attempt_count
+            FROM %I.worker_queue
+            WHERE id = v_id;
+
+            -- If session-bound, upsert the sessions row
+            IF v_session_id IS NOT NULL AND p_owner_id IS NOT NULL THEN
+                v_session_locked_until := p_now_ms + COALESCE(p_session_lock_timeout_ms, p_lock_timeout_ms);
+
+                INSERT INTO %I.sessions (session_id, worker_id, locked_until, last_activity_at)
+                VALUES (v_session_id, p_owner_id, v_session_locked_until, p_now_ms)
+                ON CONFLICT (session_id) DO UPDATE
+                SET worker_id = p_owner_id,
+                    locked_until = v_session_locked_until,
+                    last_activity_at = p_now_ms
+                WHERE %I.sessions.locked_until <= p_now_ms OR %I.sessions.worker_id = p_owner_id;
+
+                -- If upsert affected 0 rows, another worker owns this session.
+                -- Roll back: clear lock so item can be retried.
+                IF NOT FOUND THEN
+                    UPDATE %I.worker_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL,
+                        attempt_count = attempt_count - 1
+                    WHERE id = v_id;
+                    RETURN;
+                END IF;
+            END IF;
+
+            RETURN NEXT;
+        END;
+        $fetch_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 3: Update ack_worker to piggyback session last_activity_at
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_worker(
+            p_lock_token TEXT,
+            p_instance_id TEXT,
+            p_completion_json TEXT,
+            p_now_ms BIGINT
+        )
+        RETURNS VOID AS $ack_worker$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_now_ts TIMESTAMPTZ;
+            v_session_id TEXT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            -- Capture session_id before deleting
+            SELECT session_id INTO v_session_id
+            FROM %I.worker_queue WHERE lock_token = p_lock_token;
+
+            -- Delete the worker queue item
+            DELETE FROM %I.worker_queue WHERE lock_token = p_lock_token;
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Worker queue item not found or already processed'';
+            END IF;
+
+            -- Validate: if completion provided, instance_id must also be provided
+            IF p_completion_json IS NOT NULL AND p_instance_id IS NULL THEN
+                RAISE EXCEPTION ''instance_id required when completion_json is provided'';
+            END IF;
+
+            -- Only enqueue completion if provided (not NULL)
+            IF p_completion_json IS NOT NULL THEN
+                INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                VALUES (p_instance_id, p_completion_json, v_now_ts, v_now_ts);
+            END IF;
+
+            -- Piggyback: update session last_activity_at
+            IF v_session_id IS NOT NULL AND p_now_ms IS NOT NULL THEN
+                UPDATE %I.sessions SET last_activity_at = p_now_ms
+                WHERE session_id = v_session_id AND locked_until > p_now_ms;
+            END IF;
+        END;
+        $ack_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 4: Update renew_work_item_lock to piggyback session last_activity_at
+    -- Also change return type from TEXT to VOID (execution_status removed in 0.1.8)
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.renew_work_item_lock(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_extend_ms BIGINT
+        )
+        RETURNS VOID AS $renew_lock$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_session_id TEXT;
+        BEGIN
+            -- Read session_id before updating
+            SELECT session_id INTO v_session_id
+            FROM %I.worker_queue
+            WHERE lock_token = p_lock_token;
+
+            -- Update lock timeout only if lock is still valid
+            UPDATE %I.worker_queue
+            SET locked_until = GREATEST(locked_until, p_now_ms) + p_extend_ms
+            WHERE lock_token = p_lock_token
+              AND locked_until > p_now_ms;
+
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Lock token invalid, expired, or already acked'';
+            END IF;
+
+            -- Piggyback: update session last_activity_at
+            IF v_session_id IS NOT NULL THEN
+                UPDATE %I.sessions SET last_activity_at = p_now_ms
+                WHERE session_id = v_session_id AND locked_until > p_now_ms;
+            END IF;
+        END;
+        $renew_lock$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 5: Create renew_session_lock stored procedure
+    -- ============================================================================
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.renew_session_lock(
+            p_owner_ids TEXT[],
+            p_now_ms BIGINT,
+            p_extend_ms BIGINT,
+            p_idle_timeout_ms BIGINT
+        )
+        RETURNS BIGINT AS $renew_session$
+        DECLARE
+            v_count BIGINT;
+        BEGIN
+            UPDATE %I.sessions SET locked_until = p_now_ms + p_extend_ms
+            WHERE worker_id = ANY(p_owner_ids)
+              AND locked_until > p_now_ms
+              AND last_activity_at > (p_now_ms - p_idle_timeout_ms);
+
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            RETURN v_count;
+        END;
+        $renew_session$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 6: Create cleanup_orphaned_sessions stored procedure
+    -- ============================================================================
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.cleanup_orphaned_sessions(
+            p_now_ms BIGINT
+        )
+        RETURNS BIGINT AS $cleanup_sessions$
+        DECLARE
+            v_count BIGINT;
+        BEGIN
+            DELETE FROM %I.sessions
+            WHERE locked_until < p_now_ms
+              AND NOT EXISTS (SELECT 1 FROM %I.worker_queue WHERE worker_queue.session_id = sessions.session_id);
+
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            RETURN v_count;
+        END;
+        $cleanup_sessions$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 7: Update ack_orchestration_item to extract session_id from worker items
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_execution_id BIGINT,
+            p_history_delta JSONB,
+            p_worker_items JSONB,
+            p_orchestrator_items JSONB,
+            p_metadata JSONB,
+            p_cancelled_activities JSONB DEFAULT ''[]''::JSONB
+        )
+        RETURNS VOID AS $ack_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_now_ts TIMESTAMPTZ;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_parent_instance_id TEXT;
+            v_status TEXT;
+            v_output TEXT;
+            v_completed_at TIMESTAMPTZ;
+            v_elem JSONB;
+            v_visible_at TIMESTAMPTZ;
+            v_fire_at_ms BIGINT;
+            v_item_instance_id TEXT;
+            v_item_session_id TEXT;
+            v_cancelled JSONB;
+            v_cancelled_execution_id BIGINT;
+            v_cancelled_activity_id BIGINT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token AND il.locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            v_orchestration_name := p_metadata->>''orchestration_name'';
+            v_orchestration_version := p_metadata->>''orchestration_version'';
+            v_parent_instance_id := p_metadata->>''parent_instance_id'';
+            v_status := p_metadata->>''status'';
+            v_output := p_metadata->>''output'';
+
+            IF v_orchestration_name IS NOT NULL AND v_orchestration_version IS NOT NULL THEN
+                INSERT INTO %I.instances (instance_id, orchestration_name, orchestration_version, current_execution_id, parent_instance_id, created_at, updated_at)
+                VALUES (v_instance_id, v_orchestration_name, v_orchestration_version, p_execution_id, v_parent_instance_id, v_now_ts, v_now_ts)
+                ON CONFLICT (instance_id) DO NOTHING;
+
+                UPDATE %I.instances i
+                SET orchestration_name = v_orchestration_name,
+                    orchestration_version = v_orchestration_version,
+                    parent_instance_id = COALESCE(i.parent_instance_id, v_parent_instance_id),
+                    updated_at = v_now_ts
+                WHERE i.instance_id = v_instance_id;
+            END IF;
+
+            INSERT INTO %I.executions (instance_id, execution_id, status, started_at)
+            VALUES (v_instance_id, p_execution_id, ''Running'', v_now_ts)
+            ON CONFLICT (instance_id, execution_id) DO NOTHING;
+
+            UPDATE %I.instances i
+            SET current_execution_id = GREATEST(i.current_execution_id, p_execution_id),
+                updated_at = v_now_ts
+            WHERE i.instance_id = v_instance_id;
+
+            IF p_history_delta IS NOT NULL AND JSONB_ARRAY_LENGTH(p_history_delta) > 0 THEN
+                INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+                SELECT
+                    v_instance_id,
+                    p_execution_id,
+                    (elem->>''event_id'')::BIGINT,
+                    elem->>''event_type'',
+                    elem->>''event_data'',
+                    v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_history_delta) AS elem;
+            END IF;
+
+            IF v_status IS NOT NULL THEN
+                v_completed_at := CASE 
+                    WHEN v_status IN (''Completed'', ''Failed'') THEN v_now_ts 
+                    ELSE NULL 
+                END;
+                
+                UPDATE %I.executions e
+                SET status = v_status, output = v_output, completed_at = v_completed_at
+                WHERE e.instance_id = v_instance_id AND e.execution_id = p_execution_id;
+            END IF;
+
+            -- Store pinned duroxide version on execution if provided
+            IF p_metadata ? ''pinned_duroxide_version'' AND p_metadata->''pinned_duroxide_version'' IS NOT NULL
+               AND p_metadata->>''pinned_duroxide_version'' != ''null'' THEN
+                UPDATE %I.executions
+                SET duroxide_version_major = (p_metadata->''pinned_duroxide_version''->>''major'')::INTEGER,
+                    duroxide_version_minor = (p_metadata->''pinned_duroxide_version''->>''minor'')::INTEGER,
+                    duroxide_version_patch = (p_metadata->''pinned_duroxide_version''->>''patch'')::INTEGER
+                WHERE instance_id = v_instance_id AND execution_id = p_execution_id;
+            END IF;
+
+            -- Enqueue worker items with session_id support
+            IF p_worker_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_worker_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_worker_items) LOOP
+                    IF v_elem ? ''ActivityExecute'' THEN
+                        v_item_session_id := v_elem->''ActivityExecute''->>''session_id'';
+                    ELSE
+                        v_item_session_id := NULL;
+                    END IF;
+
+                    INSERT INTO %I.worker_queue (work_item, visible_at, created_at, session_id)
+                    VALUES (v_elem::TEXT, v_now_ts, v_now_ts, v_item_session_id);
+                END LOOP;
+            END IF;
+
+            IF p_orchestrator_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_orchestrator_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_orchestrator_items) LOOP
+                    IF v_elem ? ''StartOrchestration'' THEN
+                        v_item_instance_id := v_elem->''StartOrchestration''->>''instance'';
+                    ELSIF v_elem ? ''ContinueAsNew'' THEN
+                        v_item_instance_id := v_elem->''ContinueAsNew''->>''instance'';
+                    ELSIF v_elem ? ''TimerFired'' THEN
+                        v_item_instance_id := v_elem->''TimerFired''->>''instance'';
+                        v_fire_at_ms := (v_elem->''TimerFired''->>''fire_at_ms'')::BIGINT;
+                    ELSIF v_elem ? ''ActivityCompleted'' THEN
+                        v_item_instance_id := v_elem->''ActivityCompleted''->>''instance'';
+                    ELSIF v_elem ? ''ActivityFailed'' THEN
+                        v_item_instance_id := v_elem->''ActivityFailed''->>''instance'';
+                    ELSIF v_elem ? ''ExternalRaised'' THEN
+                        v_item_instance_id := v_elem->''ExternalRaised''->>''instance'';
+                    ELSIF v_elem ? ''CancelInstance'' THEN
+                        v_item_instance_id := v_elem->''CancelInstance''->>''instance'';
+                    ELSIF v_elem ? ''SubOrchCompleted'' THEN
+                        v_item_instance_id := v_elem->''SubOrchCompleted''->>''parent_instance'';
+                    ELSIF v_elem ? ''SubOrchFailed'' THEN
+                        v_item_instance_id := v_elem->''SubOrchFailed''->>''parent_instance'';
+                    ELSE
+                        v_item_instance_id := v_instance_id;
+                    END IF;
+
+                    IF v_elem ? ''TimerFired'' AND v_fire_at_ms IS NOT NULL AND v_fire_at_ms > 0 THEN
+                        v_visible_at := TO_TIMESTAMP(v_fire_at_ms / 1000.0);
+                    ELSE
+                        v_visible_at := v_now_ts;
+                    END IF;
+
+                    INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                    VALUES (v_item_instance_id, v_elem::TEXT, v_visible_at, v_now_ts);
+                    
+                    v_fire_at_ms := NULL;
+                END LOOP;
+            END IF;
+
+            -- Lock-Stealing: Delete worker queue entries for cancelled activities
+            IF p_cancelled_activities IS NOT NULL AND JSONB_ARRAY_LENGTH(p_cancelled_activities) > 0 THEN
+                FOR v_cancelled IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_cancelled_activities) LOOP
+                    v_cancelled_execution_id := (v_cancelled->>''execution_id'')::BIGINT;
+                    v_cancelled_activity_id := (v_cancelled->>''activity_id'')::BIGINT;
+                    
+                    DELETE FROM %I.worker_queue wq
+                    WHERE wq.work_item::JSONB ? ''ActivityExecute''
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''instance'') = v_instance_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''execution_id'')::BIGINT = v_cancelled_execution_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''id'')::BIGINT = v_cancelled_activity_id;
+                END LOOP;
+            END IF;
+
+            DELETE FROM %I.orchestrator_queue q WHERE q.lock_token = p_lock_token;
+
+            DELETE FROM %I.instance_locks il
+            WHERE il.instance_id = v_instance_id AND il.lock_token = p_lock_token;
+        END;
+        $ack_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 8: Update cleanup_schema to drop new functions and sessions table
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.cleanup_schema()', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.cleanup_schema()
+        RETURNS VOID AS $cleanup$
+        BEGIN
+            -- Drop tables first
+            DROP TABLE IF EXISTS %I.sessions CASCADE;
+            DROP TABLE IF EXISTS %I.instances CASCADE;
+            DROP TABLE IF EXISTS %I.executions CASCADE;
+            DROP TABLE IF EXISTS %I.history CASCADE;
+            DROP TABLE IF EXISTS %I.orchestrator_queue CASCADE;
+            DROP TABLE IF EXISTS %I.worker_queue CASCADE;
+            DROP TABLE IF EXISTS %I.instance_locks CASCADE;
+            DROP TABLE IF EXISTS %I._duroxide_migrations CASCADE;
+            
+            -- Drop all stored procedures
+            DROP FUNCTION IF EXISTS %I.cleanup_schema();
+            DROP FUNCTION IF EXISTS %I.list_instances();
+            DROP FUNCTION IF EXISTS %I.list_executions(TEXT);
+            DROP FUNCTION IF EXISTS %I.latest_execution_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.list_instances_by_status(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_execution_info(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.get_system_metrics();
+            DROP FUNCTION IF EXISTS %I.get_queue_depths(BIGINT);
+            DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT, TEXT);
+            DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.abandon_work_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.enqueue_orchestrator_work(TEXT, TEXT, TIMESTAMPTZ, BIGINT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB);
+            DROP FUNCTION IF EXISTS %I.abandon_orchestration_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.renew_orchestration_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_history(TEXT);
+            DROP FUNCTION IF EXISTS %I.fetch_history_with_execution(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.append_history(TEXT, BIGINT, JSONB, BIGINT);
+            DROP FUNCTION IF EXISTS %I.list_children(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_parent_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.delete_instances_atomic(TEXT[], BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.prune_executions(TEXT, INTEGER, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_session_lock(TEXT[], BIGINT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.cleanup_orphaned_sessions(BIGINT);
+            
+            -- Drop trigger functions (not schema-qualified, they use search_path)
+            DROP FUNCTION IF EXISTS notify_orch_work() CASCADE;
+            DROP FUNCTION IF EXISTS notify_worker_work() CASCADE;
+        END;
+        $cleanup$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name);
+
+    RAISE NOTICE 'Migration 0004: Added session support (sessions table, session routing in fetch, session piggybacking in ack/renew)';
+END $$;
+
+INSERT INTO _duroxide_migrations(version, name) VALUES (4, '0004_add_session_support.sql') ON CONFLICT (version) DO NOTHING;
+
+-- Migration 0005: 0005_add_custom_status.sql
+-- Migration 0005: Add custom status support
+-- Description: Adds custom status support for orchestration instances.
+-- Adds custom_status and custom_status_version columns to instances table,
+-- updates ack_orchestration_item to handle custom status updates,
+-- and adds get_custom_status stored procedure for polling.
+
+-- Schema changes using unqualified names (search_path set by migration runner)
+ALTER TABLE instances ADD COLUMN IF NOT EXISTS custom_status TEXT;
+ALTER TABLE instances ADD COLUMN IF NOT EXISTS custom_status_version INTEGER NOT NULL DEFAULT 0;
+
+-- Stored procedure changes using schema-qualified names
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    -- ============================================================================
+    -- Part 1: Update ack_orchestration_item to handle custom_status
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_execution_id BIGINT,
+            p_history_delta JSONB,
+            p_worker_items JSONB,
+            p_orchestrator_items JSONB,
+            p_metadata JSONB,
+            p_cancelled_activities JSONB DEFAULT ''[]''::JSONB
+        )
+        RETURNS VOID AS $ack_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_now_ts TIMESTAMPTZ;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_parent_instance_id TEXT;
+            v_status TEXT;
+            v_output TEXT;
+            v_completed_at TIMESTAMPTZ;
+            v_elem JSONB;
+            v_visible_at TIMESTAMPTZ;
+            v_fire_at_ms BIGINT;
+            v_item_instance_id TEXT;
+            v_item_session_id TEXT;
+            v_cancelled JSONB;
+            v_cancelled_execution_id BIGINT;
+            v_cancelled_activity_id BIGINT;
+            v_custom_status_action TEXT;
+            v_custom_status_value TEXT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token AND il.locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            v_orchestration_name := p_metadata->>''orchestration_name'';
+            v_orchestration_version := p_metadata->>''orchestration_version'';
+            v_parent_instance_id := p_metadata->>''parent_instance_id'';
+            v_status := p_metadata->>''status'';
+            v_output := p_metadata->>''output'';
+
+            IF v_orchestration_name IS NOT NULL AND v_orchestration_version IS NOT NULL THEN
+                INSERT INTO %I.instances (instance_id, orchestration_name, orchestration_version, current_execution_id, parent_instance_id, created_at, updated_at)
+                VALUES (v_instance_id, v_orchestration_name, v_orchestration_version, p_execution_id, v_parent_instance_id, v_now_ts, v_now_ts)
+                ON CONFLICT (instance_id) DO NOTHING;
+
+                UPDATE %I.instances i
+                SET orchestration_name = v_orchestration_name,
+                    orchestration_version = v_orchestration_version,
+                    parent_instance_id = COALESCE(i.parent_instance_id, v_parent_instance_id),
+                    updated_at = v_now_ts
+                WHERE i.instance_id = v_instance_id;
+            END IF;
+
+            INSERT INTO %I.executions (instance_id, execution_id, status, started_at)
+            VALUES (v_instance_id, p_execution_id, ''Running'', v_now_ts)
+            ON CONFLICT (instance_id, execution_id) DO NOTHING;
+
+            UPDATE %I.instances i
+            SET current_execution_id = GREATEST(i.current_execution_id, p_execution_id),
+                updated_at = v_now_ts
+            WHERE i.instance_id = v_instance_id;
+
+            IF p_history_delta IS NOT NULL AND JSONB_ARRAY_LENGTH(p_history_delta) > 0 THEN
+                INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+                SELECT
+                    v_instance_id,
+                    p_execution_id,
+                    (elem->>''event_id'')::BIGINT,
+                    elem->>''event_type'',
+                    elem->>''event_data'',
+                    v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_history_delta) AS elem;
+            END IF;
+
+            IF v_status IS NOT NULL THEN
+                v_completed_at := CASE 
+                    WHEN v_status IN (''Completed'', ''Failed'') THEN v_now_ts 
+                    ELSE NULL 
+                END;
+                
+                UPDATE %I.executions e
+                SET status = v_status, output = v_output, completed_at = v_completed_at
+                WHERE e.instance_id = v_instance_id AND e.execution_id = p_execution_id;
+            END IF;
+
+            -- Store pinned duroxide version on execution if provided
+            IF p_metadata ? ''pinned_duroxide_version'' AND p_metadata->''pinned_duroxide_version'' IS NOT NULL
+               AND p_metadata->>''pinned_duroxide_version'' != ''null'' THEN
+                UPDATE %I.executions
+                SET duroxide_version_major = (p_metadata->''pinned_duroxide_version''->>''major'')::INTEGER,
+                    duroxide_version_minor = (p_metadata->''pinned_duroxide_version''->>''minor'')::INTEGER,
+                    duroxide_version_patch = (p_metadata->''pinned_duroxide_version''->>''patch'')::INTEGER
+                WHERE instance_id = v_instance_id AND execution_id = p_execution_id;
+            END IF;
+
+            -- Handle custom_status update on instances table
+            v_custom_status_action := p_metadata->>''custom_status_action'';
+            IF v_custom_status_action = ''set'' THEN
+                v_custom_status_value := p_metadata->>''custom_status_value'';
+                UPDATE %I.instances
+                SET custom_status = v_custom_status_value,
+                    custom_status_version = custom_status_version + 1
+                WHERE instance_id = v_instance_id;
+            ELSIF v_custom_status_action = ''clear'' THEN
+                UPDATE %I.instances
+                SET custom_status = NULL,
+                    custom_status_version = custom_status_version + 1
+                WHERE instance_id = v_instance_id;
+            END IF;
+
+            -- Enqueue worker items with session_id support
+            IF p_worker_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_worker_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_worker_items) LOOP
+                    IF v_elem ? ''ActivityExecute'' THEN
+                        v_item_session_id := v_elem->''ActivityExecute''->>''session_id'';
+                    ELSE
+                        v_item_session_id := NULL;
+                    END IF;
+
+                    INSERT INTO %I.worker_queue (work_item, visible_at, created_at, session_id)
+                    VALUES (v_elem::TEXT, v_now_ts, v_now_ts, v_item_session_id);
+                END LOOP;
+            END IF;
+
+            IF p_orchestrator_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_orchestrator_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_orchestrator_items) LOOP
+                    IF v_elem ? ''StartOrchestration'' THEN
+                        v_item_instance_id := v_elem->''StartOrchestration''->>''instance'';
+                    ELSIF v_elem ? ''ContinueAsNew'' THEN
+                        v_item_instance_id := v_elem->''ContinueAsNew''->>''instance'';
+                    ELSIF v_elem ? ''TimerFired'' THEN
+                        v_item_instance_id := v_elem->''TimerFired''->>''instance'';
+                        v_fire_at_ms := (v_elem->''TimerFired''->>''fire_at_ms'')::BIGINT;
+                    ELSIF v_elem ? ''ActivityCompleted'' THEN
+                        v_item_instance_id := v_elem->''ActivityCompleted''->>''instance'';
+                    ELSIF v_elem ? ''ActivityFailed'' THEN
+                        v_item_instance_id := v_elem->''ActivityFailed''->>''instance'';
+                    ELSIF v_elem ? ''ExternalRaised'' THEN
+                        v_item_instance_id := v_elem->''ExternalRaised''->>''instance'';
+                    ELSIF v_elem ? ''CancelInstance'' THEN
+                        v_item_instance_id := v_elem->''CancelInstance''->>''instance'';
+                    ELSIF v_elem ? ''SubOrchCompleted'' THEN
+                        v_item_instance_id := v_elem->''SubOrchCompleted''->>''parent_instance'';
+                    ELSIF v_elem ? ''SubOrchFailed'' THEN
+                        v_item_instance_id := v_elem->''SubOrchFailed''->>''parent_instance'';
+                    ELSIF v_elem ? ''QueueMessage'' THEN
+                        v_item_instance_id := v_elem->''QueueMessage''->>''instance'';
+                    ELSE
+                        v_item_instance_id := v_instance_id;
+                    END IF;
+
+                    IF v_elem ? ''TimerFired'' AND v_fire_at_ms IS NOT NULL AND v_fire_at_ms > 0 THEN
+                        v_visible_at := TO_TIMESTAMP(v_fire_at_ms / 1000.0);
+                    ELSE
+                        v_visible_at := v_now_ts;
+                    END IF;
+
+                    INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                    VALUES (v_item_instance_id, v_elem::TEXT, v_visible_at, v_now_ts);
+                    
+                    v_fire_at_ms := NULL;
+                END LOOP;
+            END IF;
+
+            -- Lock-Stealing: Delete worker queue entries for cancelled activities
+            IF p_cancelled_activities IS NOT NULL AND JSONB_ARRAY_LENGTH(p_cancelled_activities) > 0 THEN
+                FOR v_cancelled IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_cancelled_activities) LOOP
+                    v_cancelled_execution_id := (v_cancelled->>''execution_id'')::BIGINT;
+                    v_cancelled_activity_id := (v_cancelled->>''activity_id'')::BIGINT;
+                    
+                    DELETE FROM %I.worker_queue wq
+                    WHERE wq.work_item::JSONB ? ''ActivityExecute''
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''instance'') = v_instance_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''execution_id'')::BIGINT = v_cancelled_execution_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''id'')::BIGINT = v_cancelled_activity_id;
+                END LOOP;
+            END IF;
+
+            DELETE FROM %I.orchestrator_queue q WHERE q.lock_token = p_lock_token;
+
+            DELETE FROM %I.instance_locks il
+            WHERE il.instance_id = v_instance_id AND il.lock_token = p_lock_token;
+        END;
+        $ack_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 2: Update ack_worker to validate lock expiry
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_worker(TEXT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_worker(
+            p_lock_token TEXT,
+            p_instance_id TEXT DEFAULT NULL,
+            p_completion_json TEXT DEFAULT NULL,
+            p_now_ms BIGINT DEFAULT NULL
+        )
+        RETURNS VOID AS $ack_worker$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_now_ts TIMESTAMPTZ;
+            v_session_id TEXT;
+        BEGIN
+            -- Capture session_id before deleting
+            SELECT session_id INTO v_session_id
+            FROM %I.worker_queue WHERE lock_token = p_lock_token;
+
+            -- Delete the worker queue item, only if lock is still valid
+            IF p_now_ms IS NOT NULL THEN
+                DELETE FROM %I.worker_queue WHERE lock_token = p_lock_token AND locked_until > p_now_ms;
+            ELSE
+                DELETE FROM %I.worker_queue WHERE lock_token = p_lock_token;
+            END IF;
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Worker queue item not found or already processed'';
+            END IF;
+
+            -- Only enqueue completion if provided (NULL means cancelled activity)
+            IF p_completion_json IS NOT NULL THEN
+                -- Validate required parameters for completion
+                IF p_instance_id IS NULL THEN
+                    RAISE EXCEPTION ''p_instance_id is required when p_completion_json is provided'';
+                END IF;
+                IF p_now_ms IS NULL THEN
+                    RAISE EXCEPTION ''p_now_ms is required when p_completion_json is provided'';
+                END IF;
+                
+                v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+                INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                VALUES (p_instance_id, p_completion_json, v_now_ts, v_now_ts);
+            END IF;
+
+            -- Piggyback: update session last_activity_at
+            IF v_session_id IS NOT NULL AND p_now_ms IS NOT NULL THEN
+                UPDATE %I.sessions SET last_activity_at = p_now_ms
+                WHERE session_id = v_session_id AND locked_until > p_now_ms;
+            END IF;
+        END;
+        $ack_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 3: Create get_custom_status stored procedure
+    -- ============================================================================
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_custom_status(
+            p_instance_id TEXT,
+            p_last_seen_version BIGINT
+        )
+        RETURNS TABLE(
+            out_custom_status TEXT,
+            out_custom_status_version BIGINT
+        ) AS $get_cs$
+        BEGIN
+            RETURN QUERY
+            SELECT i.custom_status, i.custom_status_version::BIGINT
+            FROM %I.instances i
+            WHERE i.instance_id = p_instance_id
+              AND i.custom_status_version > p_last_seen_version;
+        END;
+        $get_cs$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 4: Update cleanup_schema to drop new function
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.cleanup_schema()', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.cleanup_schema()
+        RETURNS VOID AS $cleanup$
+        BEGIN
+            -- Drop tables first
+            DROP TABLE IF EXISTS %I.sessions CASCADE;
+            DROP TABLE IF EXISTS %I.instances CASCADE;
+            DROP TABLE IF EXISTS %I.executions CASCADE;
+            DROP TABLE IF EXISTS %I.history CASCADE;
+            DROP TABLE IF EXISTS %I.orchestrator_queue CASCADE;
+            DROP TABLE IF EXISTS %I.worker_queue CASCADE;
+            DROP TABLE IF EXISTS %I.instance_locks CASCADE;
+            DROP TABLE IF EXISTS %I._duroxide_migrations CASCADE;
+            
+            -- Drop all stored procedures
+            DROP FUNCTION IF EXISTS %I.cleanup_schema();
+            DROP FUNCTION IF EXISTS %I.list_instances();
+            DROP FUNCTION IF EXISTS %I.list_executions(TEXT);
+            DROP FUNCTION IF EXISTS %I.latest_execution_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.list_instances_by_status(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_execution_info(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.get_system_metrics();
+            DROP FUNCTION IF EXISTS %I.get_queue_depths(BIGINT);
+            DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT, TEXT);
+            DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.abandon_work_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.enqueue_orchestrator_work(TEXT, TEXT, TIMESTAMPTZ, BIGINT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB);
+            DROP FUNCTION IF EXISTS %I.abandon_orchestration_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.renew_orchestration_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_history(TEXT);
+            DROP FUNCTION IF EXISTS %I.fetch_history_with_execution(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.append_history(TEXT, BIGINT, JSONB, BIGINT);
+            DROP FUNCTION IF EXISTS %I.list_children(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_parent_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.delete_instances_atomic(TEXT[], BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.prune_executions(TEXT, INTEGER, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_session_lock(TEXT[], BIGINT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.cleanup_orphaned_sessions(BIGINT);
+            DROP FUNCTION IF EXISTS %I.get_custom_status(TEXT, BIGINT);
+            
+            -- Drop trigger functions (not schema-qualified, they use search_path)
+            DROP FUNCTION IF EXISTS notify_orch_work() CASCADE;
+            DROP FUNCTION IF EXISTS notify_worker_work() CASCADE;
+        END;
+        $cleanup$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name);
+
+    RAISE NOTICE 'Migration 0005: Added custom status support (custom_status/custom_status_version columns, get_custom_status function, updated ack_orchestration_item)';
+END $$;
+
+INSERT INTO _duroxide_migrations(version, name) VALUES (5, '0005_add_custom_status.sql') ON CONFLICT (version) DO NOTHING;
+
+SET LOCAL search_path TO @extschema@;
+
+-- END duroxide-pg-opt migrations (checked-in copy)

--- a/sql/duroxide_upstream/0001_initial_schema.sql
+++ b/sql/duroxide_upstream/0001_initial_schema.sql
@@ -1,0 +1,1159 @@
+-- Migration: 0001_initial_schema.sql
+-- Description: Complete Duroxide PostgreSQL provider schema
+-- All tables, indexes, and stored procedures in a single migration.
+-- All timestamps are NOT NULL without defaults - provider must supply values.
+
+-- ============================================================================
+-- Tables
+-- ============================================================================
+
+-- Instance metadata
+CREATE TABLE IF NOT EXISTS instances (
+    instance_id TEXT PRIMARY KEY,
+    orchestration_name TEXT NOT NULL,
+    orchestration_version TEXT, -- NULLable, set by runtime via ack_orchestration_item metadata
+    current_execution_id BIGINT NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+-- Multi-execution support
+CREATE TABLE IF NOT EXISTS executions (
+    instance_id TEXT NOT NULL,
+    execution_id BIGINT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'Running',
+    output TEXT,
+    started_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ, -- NULL until completed/failed
+    PRIMARY KEY (instance_id, execution_id)
+);
+
+-- Event history (append-only)
+CREATE TABLE IF NOT EXISTS history (
+    instance_id TEXT NOT NULL,
+    execution_id BIGINT NOT NULL,
+    event_id BIGINT NOT NULL,
+    event_type TEXT NOT NULL,
+    event_data TEXT NOT NULL, -- JSON serialized Event
+    created_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (instance_id, execution_id, event_id)
+);
+
+-- Orchestrator queue
+CREATE TABLE IF NOT EXISTS orchestrator_queue (
+    id BIGSERIAL PRIMARY KEY,
+    instance_id TEXT NOT NULL,
+    work_item TEXT NOT NULL, -- JSON serialized WorkItem
+    visible_at TIMESTAMPTZ NOT NULL,
+    lock_token TEXT,
+    locked_until BIGINT, -- Unix timestamp in milliseconds
+    created_at TIMESTAMPTZ NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0
+);
+
+-- Worker queue
+CREATE TABLE IF NOT EXISTS worker_queue (
+    id BIGSERIAL PRIMARY KEY,
+    work_item TEXT NOT NULL, -- JSON serialized WorkItem
+    visible_at TIMESTAMPTZ NOT NULL, -- When the item becomes available for processing
+    lock_token TEXT,
+    locked_until BIGINT, -- Unix timestamp in milliseconds
+    created_at TIMESTAMPTZ NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0
+);
+
+-- Instance-level locks for concurrent dispatcher coordination
+CREATE TABLE IF NOT EXISTS instance_locks (
+    instance_id TEXT PRIMARY KEY,
+    lock_token TEXT NOT NULL,
+    locked_until BIGINT NOT NULL, -- Unix timestamp in milliseconds
+    locked_at BIGINT NOT NULL -- Unix timestamp in milliseconds
+);
+
+-- ============================================================================
+-- Indexes
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_orch_visible ON orchestrator_queue(visible_at, lock_token);
+CREATE INDEX IF NOT EXISTS idx_orch_instance ON orchestrator_queue(instance_id);
+CREATE INDEX IF NOT EXISTS idx_orch_lock ON orchestrator_queue(lock_token);
+CREATE INDEX IF NOT EXISTS idx_worker_visible ON worker_queue(visible_at, lock_token);
+CREATE INDEX IF NOT EXISTS idx_worker_available ON worker_queue(lock_token, id);
+CREATE INDEX IF NOT EXISTS idx_instance_locks_locked_until ON instance_locks(locked_until);
+CREATE INDEX IF NOT EXISTS idx_history_lookup ON history(instance_id, execution_id, event_id);
+
+-- Migration tracking table (create in each schema)
+CREATE TABLE IF NOT EXISTS _duroxide_migrations (
+    version BIGINT PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ============================================================================
+-- NOTIFY Triggers for Long-Polling
+-- Triggers fire on INSERT to notify waiting dispatchers of new work.
+-- Payload contains visible_at as epoch milliseconds for timer scheduling.
+-- NOTE: We use TG_TABLE_SCHEMA (the schema of the table being modified) 
+-- instead of current_schema() because current_schema() returns the first 
+-- schema in the session's search_path, which may not be our schema.
+-- ============================================================================
+
+-- Trigger function for orchestrator queue
+DROP FUNCTION IF EXISTS notify_orch_work() CASCADE;
+CREATE OR REPLACE FUNCTION notify_orch_work()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM pg_notify(
+        TG_TABLE_SCHEMA || '_orch_work',
+        (EXTRACT(EPOCH FROM NEW.visible_at) * 1000)::BIGINT::TEXT
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger function for worker queue
+-- Worker queue items now have visible_at for delayed visibility
+-- Send visible_at timestamp for timer scheduling
+DROP FUNCTION IF EXISTS notify_worker_work() CASCADE;
+CREATE OR REPLACE FUNCTION notify_worker_work()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM pg_notify(
+        TG_TABLE_SCHEMA || '_worker_work',
+        (EXTRACT(EPOCH FROM NEW.visible_at) * 1000)::BIGINT::TEXT
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Attach triggers to queues
+DROP TRIGGER IF EXISTS trg_notify_orch_work ON orchestrator_queue;
+CREATE TRIGGER trg_notify_orch_work
+    AFTER INSERT ON orchestrator_queue
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_orch_work();
+
+DROP TRIGGER IF EXISTS trg_notify_worker_work ON worker_queue;
+CREATE TRIGGER trg_notify_worker_work
+    AFTER INSERT ON worker_queue
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_worker_work();
+
+-- ============================================================================
+-- Stored Procedures
+-- ============================================================================
+
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    -- ============================================================================
+    -- Schema Management Procedures
+    -- ============================================================================
+
+    -- Procedure: cleanup_schema
+    -- Drops all tables AND functions in the schema (for testing only)
+    -- Functions must be dropped because PostgreSQL cannot change return types with CREATE OR REPLACE
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.cleanup_schema()', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.cleanup_schema()
+        RETURNS VOID AS $cleanup$
+        BEGIN
+            -- Drop tables first
+            DROP TABLE IF EXISTS %I.instances CASCADE;
+            DROP TABLE IF EXISTS %I.executions CASCADE;
+            DROP TABLE IF EXISTS %I.history CASCADE;
+            DROP TABLE IF EXISTS %I.orchestrator_queue CASCADE;
+            DROP TABLE IF EXISTS %I.worker_queue CASCADE;
+            DROP TABLE IF EXISTS %I.instance_locks CASCADE;
+            DROP TABLE IF EXISTS %I._duroxide_migrations CASCADE;
+            
+            -- Drop all stored procedures (required because return type changes cannot use CREATE OR REPLACE)
+            DROP FUNCTION IF EXISTS %I.cleanup_schema();
+            DROP FUNCTION IF EXISTS %I.list_instances();
+            DROP FUNCTION IF EXISTS %I.list_executions(TEXT);
+            DROP FUNCTION IF EXISTS %I.latest_execution_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.list_instances_by_status(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_execution_info(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.get_system_metrics();
+            DROP FUNCTION IF EXISTS %I.get_queue_depths(BIGINT);
+            DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.abandon_work_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.enqueue_orchestrator_work(TEXT, TEXT, TIMESTAMPTZ, BIGINT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB);
+            DROP FUNCTION IF EXISTS %I.abandon_orchestration_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.renew_orchestration_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_history(TEXT);
+            DROP FUNCTION IF EXISTS %I.fetch_history_with_execution(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.append_history(TEXT, BIGINT, JSONB, BIGINT);
+            
+            -- Drop trigger functions (not schema-qualified, they use search_path)
+            -- CASCADE is required because triggers depend on these functions
+            DROP FUNCTION IF EXISTS notify_orch_work() CASCADE;
+            DROP FUNCTION IF EXISTS notify_worker_work() CASCADE;
+        END;
+        $cleanup$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Simple Query Procedures
+    -- ============================================================================
+
+    -- Procedure: list_instances
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.list_instances()', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.list_instances()
+        RETURNS TABLE(instance_id TEXT) AS $list_inst$
+        BEGIN
+            RETURN QUERY
+            SELECT i.instance_id
+            FROM %I.instances i
+            ORDER BY i.created_at DESC;
+        END;
+        $list_inst$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: list_executions
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.list_executions(TEXT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.list_executions(p_instance_id TEXT)
+        RETURNS TABLE(execution_id BIGINT) AS $list_exec$
+        BEGIN
+            RETURN QUERY
+            SELECT e.execution_id
+            FROM %I.executions e
+            WHERE e.instance_id = p_instance_id
+            ORDER BY e.execution_id;
+        END;
+        $list_exec$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: latest_execution_id
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.latest_execution_id(TEXT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.latest_execution_id(p_instance_id TEXT)
+        RETURNS BIGINT AS $latest_exec$
+        DECLARE
+            v_execution_id BIGINT;
+        BEGIN
+            SELECT i.current_execution_id INTO v_execution_id
+            FROM %I.instances i
+            WHERE i.instance_id = p_instance_id;
+            RETURN v_execution_id;
+        END;
+        $latest_exec$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: list_instances_by_status
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.list_instances_by_status(TEXT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.list_instances_by_status(p_status TEXT)
+        RETURNS TABLE(instance_id TEXT) AS $list_by_status$
+        BEGIN
+            RETURN QUERY
+            SELECT i.instance_id
+            FROM %I.instances i
+            JOIN %I.executions e ON i.instance_id = e.instance_id 
+              AND i.current_execution_id = e.execution_id
+            WHERE e.status = p_status
+            ORDER BY i.created_at DESC;
+        END;
+        $list_by_status$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Join and Aggregate Query Procedures
+    -- ============================================================================
+
+    -- Procedure: get_instance_info
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_instance_info(p_instance_id TEXT)
+        RETURNS TABLE(
+            instance_id TEXT,
+            orchestration_name TEXT,
+            orchestration_version TEXT,
+            current_execution_id BIGINT,
+            created_at TIMESTAMPTZ,
+            updated_at TIMESTAMPTZ,
+            status TEXT,
+            output TEXT
+        ) AS $get_inst_info$
+        BEGIN
+            RETURN QUERY
+            SELECT i.instance_id, i.orchestration_name, 
+                   COALESCE(i.orchestration_version, ''unknown'') as orchestration_version,
+                   i.current_execution_id, i.created_at, i.updated_at,
+                   e.status, e.output
+            FROM %I.instances i
+            LEFT JOIN %I.executions e ON i.instance_id = e.instance_id 
+              AND i.current_execution_id = e.execution_id
+            WHERE i.instance_id = p_instance_id;
+        END;
+        $get_inst_info$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: get_execution_info
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.get_execution_info(TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_execution_info(
+            p_instance_id TEXT,
+            p_execution_id BIGINT
+        )
+        RETURNS TABLE(
+            execution_id BIGINT,
+            status TEXT,
+            output TEXT,
+            started_at TIMESTAMPTZ,
+            completed_at TIMESTAMPTZ,
+            event_count BIGINT
+        ) AS $get_exec_info$
+        BEGIN
+            RETURN QUERY
+            SELECT e.execution_id, e.status, e.output, 
+                   e.started_at, e.completed_at,
+                   COALESCE(COUNT(h.event_id), 0)::BIGINT as event_count
+            FROM %I.executions e
+            LEFT JOIN %I.history h ON e.instance_id = h.instance_id 
+              AND e.execution_id = h.execution_id
+            WHERE e.instance_id = p_instance_id AND e.execution_id = p_execution_id
+            GROUP BY e.execution_id, e.status, e.output, e.started_at, e.completed_at;
+        END;
+        $get_exec_info$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: get_system_metrics
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.get_system_metrics()', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_system_metrics()
+        RETURNS TABLE(
+            total_instances BIGINT,
+            total_executions BIGINT,
+            running_instances BIGINT,
+            completed_instances BIGINT,
+            failed_instances BIGINT,
+            total_events BIGINT
+        ) AS $get_metrics$
+        BEGIN
+            RETURN QUERY
+            SELECT 
+                (SELECT COUNT(*)::BIGINT FROM %I.instances) as total_instances,
+                (SELECT COUNT(*)::BIGINT FROM %I.executions) as total_executions,
+                (SELECT COUNT(DISTINCT i.instance_id)::BIGINT
+                 FROM %I.instances i
+                 JOIN %I.executions e ON i.instance_id = e.instance_id 
+                   AND i.current_execution_id = e.execution_id
+                 WHERE e.status = ''Running'') as running_instances,
+                (SELECT COUNT(DISTINCT i.instance_id)::BIGINT
+                 FROM %I.instances i
+                 JOIN %I.executions e ON i.instance_id = e.instance_id 
+                   AND i.current_execution_id = e.execution_id
+                 WHERE e.status = ''Completed'') as completed_instances,
+                (SELECT COUNT(DISTINCT i.instance_id)::BIGINT
+                 FROM %I.instances i
+                 JOIN %I.executions e ON i.instance_id = e.instance_id 
+                   AND i.current_execution_id = e.execution_id
+                 WHERE e.status = ''Failed'') as failed_instances,
+                (SELECT COUNT(*)::BIGINT FROM %I.history) as total_events;
+        END;
+        $get_metrics$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: get_queue_depths
+    -- Returns count of items available for processing (visible and unlocked/lock expired)
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.get_queue_depths(BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_queue_depths(p_now_ms BIGINT)
+        RETURNS TABLE(
+            orchestrator_queue BIGINT,
+            worker_queue BIGINT
+        ) AS $get_queue_depths$
+        BEGIN
+            RETURN QUERY
+            SELECT 
+                (SELECT COUNT(*)::BIGINT FROM %I.orchestrator_queue 
+                 WHERE visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                   AND (lock_token IS NULL OR locked_until <= p_now_ms)) as orchestrator_queue,
+                (SELECT COUNT(*)::BIGINT FROM %I.worker_queue 
+                 WHERE visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                   AND (lock_token IS NULL OR locked_until <= p_now_ms)) as worker_queue;
+        END;
+        $get_queue_depths$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Queue Operation Procedures
+    -- All procedures accept p_now_ms for timestamp generation (Rust clock only)
+    -- ============================================================================
+
+    -- Procedure: enqueue_worker_work
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.enqueue_worker_work(
+            p_work_item TEXT,
+            p_now_ms BIGINT
+        )
+        RETURNS VOID AS $enq_worker$
+        DECLARE
+            v_now_ts TIMESTAMPTZ;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+            INSERT INTO %I.worker_queue (work_item, visible_at, created_at)
+            VALUES (p_work_item, v_now_ts, v_now_ts);
+        END;
+        $enq_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: ack_worker
+    -- When p_completion_json is NULL, only delete from worker_queue (no enqueue)
+    -- This is used when the orchestration is terminal or missing
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_worker(
+            p_lock_token TEXT,
+            p_instance_id TEXT,
+            p_completion_json TEXT,
+            p_now_ms BIGINT
+        )
+        RETURNS VOID AS $ack_worker$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_now_ts TIMESTAMPTZ;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+            
+            DELETE FROM %I.worker_queue WHERE lock_token = p_lock_token;
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Worker queue item not found or already processed'';
+            END IF;
+
+            -- Validate: if completion provided, instance_id must also be provided
+            IF p_completion_json IS NOT NULL AND p_instance_id IS NULL THEN
+                RAISE EXCEPTION ''instance_id required when completion_json is provided'';
+            END IF;
+
+            -- Only enqueue completion if provided (not NULL)
+            IF p_completion_json IS NOT NULL THEN
+                INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                VALUES (p_instance_id, p_completion_json, v_now_ts, v_now_ts);
+            END IF;
+        END;
+        $ack_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: renew_work_item_lock
+    -- Returns execution_status for cancellation support
+    -- Note: DROP first because return type changed from VOID to TEXT
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.renew_work_item_lock(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_extend_ms BIGINT
+        )
+        RETURNS TEXT AS $renew_lock$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_work_item_json JSONB;
+            v_instance_id TEXT;
+            v_execution_id BIGINT;
+            v_execution_status TEXT;
+        BEGIN
+            -- Get the work item before updating
+            SELECT work_item::JSONB INTO v_work_item_json
+            FROM %I.worker_queue
+            WHERE lock_token = p_lock_token
+              AND locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Lock token invalid, expired, or already acked'';
+            END IF;
+
+            -- Check execution status BEFORE extending the lock
+            -- Per provider contract: lock can only be renewed if execution is Running
+            IF v_work_item_json ? ''ActivityExecute'' THEN
+                v_instance_id := v_work_item_json->''ActivityExecute''->>''instance'';
+                v_execution_id := (v_work_item_json->''ActivityExecute''->>''execution_id'')::BIGINT;
+                
+                -- Get execution status directly from executions table
+                -- Note: We check executions table, not instances table, because:
+                -- 1. Instance record may not exist if ack_orchestration_item was called with NULL version
+                -- 2. Execution record is the authoritative source for execution state
+                SELECT e.status INTO v_execution_status
+                FROM %I.executions e
+                WHERE e.instance_id = v_instance_id AND e.execution_id = v_execution_id;
+                
+                IF v_execution_status IS NULL THEN
+                    -- Execution record missing - return NULL to signal Missing state
+                    -- Do NOT extend lock per contract
+                    RETURN NULL;
+                END IF;
+                
+                IF v_execution_status <> ''Running'' THEN
+                    -- Execution is terminal - return status but do NOT extend lock per contract
+                    RETURN v_execution_status;
+                END IF;
+            END IF;
+            
+            -- Only extend lock if execution is Running (or non-ActivityExecute item)
+            UPDATE %I.worker_queue
+            SET locked_until = GREATEST(locked_until, p_now_ms) + p_extend_ms
+            WHERE lock_token = p_lock_token
+              AND locked_until > p_now_ms;
+            
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+            
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Lock token invalid, expired, or already acked'';
+            END IF;
+            
+            RETURN v_execution_status;
+        END;
+        $renew_lock$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: fetch_work_item
+    -- Item is available if:
+    -- 1. visible_at <= now (not delayed)
+    -- 2. AND (lock_token IS NULL OR locked_until <= now) (not locked or lock expired)
+    -- Returns execution_status from the execution table for cancellation support
+    -- Note: DROP first because return type changed to include out_execution_status
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_work_item(
+            p_now_ms BIGINT,
+            p_lock_timeout_ms BIGINT
+        )
+        RETURNS TABLE(
+            out_work_item TEXT,
+            out_lock_token TEXT,
+            out_attempt_count INTEGER,
+            out_execution_status TEXT
+        ) AS $fetch_worker$
+        DECLARE
+            v_id BIGINT;
+            v_work_item_json JSONB;
+            v_instance_id TEXT;
+            v_execution_id BIGINT;
+        BEGIN
+            SELECT q.id INTO v_id
+            FROM %I.worker_queue q
+            WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+              AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms)
+            ORDER BY q.id
+            LIMIT 1
+            FOR UPDATE OF q SKIP LOCKED;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            out_lock_token := ''lock_'' || gen_random_uuid()::TEXT;
+
+            UPDATE %I.worker_queue
+            SET lock_token = out_lock_token,
+                locked_until = p_now_ms + p_lock_timeout_ms,
+                attempt_count = attempt_count + 1
+            WHERE id = v_id;
+
+            SELECT work_item, attempt_count
+            INTO out_work_item, out_attempt_count
+            FROM %I.worker_queue
+            WHERE id = v_id;
+
+            -- Parse work item to get instance and execution_id for status lookup
+            v_work_item_json := out_work_item::JSONB;
+            IF v_work_item_json ? ''ActivityExecute'' THEN
+                v_instance_id := v_work_item_json->''ActivityExecute''->>''instance'';
+                v_execution_id := (v_work_item_json->''ActivityExecute''->>''execution_id'')::BIGINT;
+                
+                SELECT e.status INTO out_execution_status
+                FROM %I.executions e
+                WHERE e.instance_id = v_instance_id AND e.execution_id = v_execution_id;
+            ELSE
+                out_execution_status := NULL;
+            END IF;
+
+            RETURN NEXT;
+        END;
+        $fetch_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: abandon_work_item
+    -- Always clear lock_token and locked_until when abandoning.
+    -- Use visible_at to control when item becomes available again.
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.abandon_work_item(TEXT, BIGINT, BIGINT, BOOLEAN)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.abandon_work_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_delay_ms BIGINT DEFAULT NULL,
+            p_ignore_attempt BOOLEAN DEFAULT FALSE
+        )
+        RETURNS VOID AS $abandon_worker$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_visible_at TIMESTAMPTZ;
+        BEGIN
+            -- Calculate visible_at based on delay using Rust-provided time
+            IF p_delay_ms IS NOT NULL AND p_delay_ms > 0 THEN
+                v_visible_at := TO_TIMESTAMP((p_now_ms + p_delay_ms) / 1000.0);
+            ELSE
+                v_visible_at := TO_TIMESTAMP(p_now_ms / 1000.0);
+            END IF;
+
+            -- Always clear lock_token and locked_until when abandoning
+            -- Use visible_at to control when item becomes available again
+            IF p_ignore_attempt THEN
+                UPDATE %I.worker_queue
+                SET lock_token = NULL,
+                    locked_until = NULL,
+                    visible_at = v_visible_at,
+                    attempt_count = GREATEST(0, attempt_count - 1)
+                WHERE lock_token = p_lock_token;
+            ELSE
+                UPDATE %I.worker_queue
+                SET lock_token = NULL,
+                    locked_until = NULL,
+                    visible_at = v_visible_at
+                WHERE lock_token = p_lock_token;
+            END IF;
+
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Invalid lock token or already acked'';
+            END IF;
+        END;
+        $abandon_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: enqueue_orchestrator_work
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.enqueue_orchestrator_work(TEXT, TEXT, TIMESTAMPTZ, BIGINT, TEXT, TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.enqueue_orchestrator_work(
+            p_instance_id TEXT,
+            p_work_item TEXT,
+            p_visible_at TIMESTAMPTZ,
+            p_now_ms BIGINT,
+            p_orchestration_name TEXT DEFAULT NULL,
+            p_orchestration_version TEXT DEFAULT NULL,
+            p_execution_id BIGINT DEFAULT NULL
+        )
+        RETURNS VOID AS $enq_orch$
+        BEGIN
+            -- Parameters p_orchestration_name, p_orchestration_version, p_execution_id are ignored
+            -- Instance creation happens ONLY via ack_orchestration_item metadata
+            INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+            VALUES (p_instance_id, p_work_item, p_visible_at, TO_TIMESTAMP(p_now_ms / 1000.0));
+        END;
+        $enq_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: fetch_orchestration_item
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_orchestration_item(
+            p_now_ms BIGINT,
+            p_lock_timeout_ms BIGINT
+        )
+        RETURNS TABLE(
+            out_instance_id TEXT,
+            out_orchestration_name TEXT,
+            out_orchestration_version TEXT,
+            out_execution_id BIGINT,
+            out_history JSONB,
+            out_messages JSONB,
+            out_lock_token TEXT,
+            out_attempt_count INTEGER
+        ) AS $fetch_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_lock_token TEXT;
+            v_locked_until BIGINT;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_current_execution_id BIGINT;
+            v_history JSONB;
+            v_messages JSONB;
+            v_lock_acquired INTEGER;
+            v_max_attempt_count INTEGER;
+        BEGIN
+            -- Phase 1: Find a candidate instance (no FOR UPDATE yet)
+            SELECT q.instance_id INTO v_instance_id
+            FROM %I.orchestrator_queue q
+            WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+              AND NOT EXISTS (
+                SELECT 1 FROM %I.instance_locks il
+                WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+              )
+            ORDER BY q.visible_at, q.id
+            LIMIT 1;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            -- Phase 2: Acquire instance-level advisory lock
+            PERFORM pg_advisory_xact_lock(hashtext(v_instance_id));
+
+            -- Phase 3: Re-verify with FOR UPDATE
+            SELECT q.instance_id INTO v_instance_id
+            FROM %I.orchestrator_queue q
+            WHERE q.instance_id = v_instance_id
+              AND q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+              AND NOT EXISTS (
+                SELECT 1 FROM %I.instance_locks il
+                WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+              )
+            FOR UPDATE OF q SKIP LOCKED;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            v_lock_token := ''lock_'' || gen_random_uuid()::TEXT;
+            v_locked_until := p_now_ms + p_lock_timeout_ms;
+
+            INSERT INTO %I.instance_locks (instance_id, lock_token, locked_until, locked_at)
+            VALUES (v_instance_id, v_lock_token, v_locked_until, p_now_ms)
+            ON CONFLICT(instance_id) DO UPDATE
+            SET lock_token = EXCLUDED.lock_token,
+                locked_until = EXCLUDED.locked_until,
+                locked_at = EXCLUDED.locked_at
+            WHERE %I.instance_locks.locked_until <= p_now_ms;
+
+            GET DIAGNOSTICS v_lock_acquired = ROW_COUNT;
+
+            IF v_lock_acquired = 0 THEN
+                RETURN;
+            END IF;
+
+            UPDATE %I.orchestrator_queue q
+            SET lock_token = v_lock_token,
+                locked_until = v_locked_until,
+                attempt_count = q.attempt_count + 1
+            WHERE q.instance_id = v_instance_id
+              AND q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+              AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms);
+
+            SELECT COALESCE(JSONB_AGG(q.work_item::JSONB ORDER BY q.id), ''[]''::JSONB),
+                   COALESCE(MAX(q.attempt_count), 1)
+            INTO v_messages, v_max_attempt_count
+            FROM %I.orchestrator_queue q
+            WHERE q.lock_token = v_lock_token;
+
+            SELECT i.orchestration_name, i.orchestration_version, i.current_execution_id
+            INTO v_orchestration_name, v_orchestration_version, v_current_execution_id
+            FROM %I.instances i
+            WHERE i.instance_id = v_instance_id;
+
+            IF FOUND THEN
+                SELECT COALESCE(JSONB_AGG(h.event_data::JSONB ORDER BY h.event_id), ''[]''::JSONB)
+                INTO v_history
+                FROM %I.history h
+                WHERE h.instance_id = v_instance_id AND h.execution_id = v_current_execution_id;
+                
+                v_orchestration_version := COALESCE(v_orchestration_version, ''unknown'');
+            ELSE
+                SELECT COALESCE(JSONB_AGG(h.event_data::JSONB ORDER BY h.execution_id, h.event_id), ''[]''::JSONB)
+                INTO v_history
+                FROM %I.history h
+                WHERE h.instance_id = v_instance_id;
+
+                IF JSONB_ARRAY_LENGTH(v_history) > 0 AND v_history->0 ? ''OrchestrationStarted'' THEN
+                    v_orchestration_name := v_history->0->''OrchestrationStarted''->>''name'';
+                    v_orchestration_version := v_history->0->''OrchestrationStarted''->>''version'';
+                    v_current_execution_id := 1;
+                ELSIF JSONB_ARRAY_LENGTH(v_messages) > 0 AND v_messages->0 ? ''StartOrchestration'' THEN
+                    v_orchestration_name := v_messages->0->''StartOrchestration''->>''orchestration'';
+                    v_orchestration_version := COALESCE(v_messages->0->''StartOrchestration''->>''version'', ''unknown'');
+                    v_current_execution_id := COALESCE((v_messages->0->''StartOrchestration''->>''execution_id'')::BIGINT, 1);
+                ELSIF JSONB_ARRAY_LENGTH(v_messages) > 0 AND v_messages->0 ? ''ContinueAsNew'' THEN
+                    v_orchestration_name := v_messages->0->''ContinueAsNew''->>''orchestration'';
+                    v_orchestration_version := COALESCE(v_messages->0->''ContinueAsNew''->>''version'', ''unknown'');
+                    v_current_execution_id := 1;
+                ELSE
+                    v_orchestration_name := ''Unknown'';
+                    v_orchestration_version := ''unknown'';
+                    v_current_execution_id := 1;
+                END IF;
+            END IF;
+
+            RETURN QUERY SELECT
+                v_instance_id,
+                v_orchestration_name,
+                v_orchestration_version,
+                v_current_execution_id,
+                v_history,
+                v_messages,
+                v_lock_token,
+                v_max_attempt_count;
+        END;
+        $fetch_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name);
+
+    -- Procedure: ack_orchestration_item
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_execution_id BIGINT,
+            p_history_delta JSONB,
+            p_worker_items JSONB,
+            p_orchestrator_items JSONB,
+            p_metadata JSONB,
+            p_cancelled_activities JSONB DEFAULT ''[]''::JSONB
+        )
+        RETURNS VOID AS $ack_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_now_ts TIMESTAMPTZ;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_status TEXT;
+            v_output TEXT;
+            v_completed_at TIMESTAMPTZ;
+            v_elem JSONB;
+            v_visible_at TIMESTAMPTZ;
+            v_fire_at_ms BIGINT;
+            v_item_instance_id TEXT;
+            v_cancelled JSONB;
+            v_cancelled_execution_id BIGINT;
+            v_cancelled_activity_id BIGINT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token AND il.locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            v_orchestration_name := p_metadata->>''orchestration_name'';
+            v_orchestration_version := p_metadata->>''orchestration_version'';
+            v_status := p_metadata->>''status'';
+            v_output := p_metadata->>''output'';
+
+            IF v_orchestration_name IS NOT NULL AND v_orchestration_version IS NOT NULL THEN
+                INSERT INTO %I.instances (instance_id, orchestration_name, orchestration_version, current_execution_id, created_at, updated_at)
+                VALUES (v_instance_id, v_orchestration_name, v_orchestration_version, p_execution_id, v_now_ts, v_now_ts)
+                ON CONFLICT (instance_id) DO NOTHING;
+
+                UPDATE %I.instances i
+                SET orchestration_name = v_orchestration_name,
+                    orchestration_version = v_orchestration_version,
+                    updated_at = v_now_ts
+                WHERE i.instance_id = v_instance_id;
+            END IF;
+
+            INSERT INTO %I.executions (instance_id, execution_id, status, started_at)
+            VALUES (v_instance_id, p_execution_id, ''Running'', v_now_ts)
+            ON CONFLICT (instance_id, execution_id) DO NOTHING;
+
+            UPDATE %I.instances i
+            SET current_execution_id = GREATEST(i.current_execution_id, p_execution_id),
+                updated_at = v_now_ts
+            WHERE i.instance_id = v_instance_id;
+
+            IF p_history_delta IS NOT NULL AND JSONB_ARRAY_LENGTH(p_history_delta) > 0 THEN
+                INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+                SELECT
+                    v_instance_id,
+                    p_execution_id,
+                    (elem->>''event_id'')::BIGINT,
+                    elem->>''event_type'',
+                    elem->>''event_data'',
+                    v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_history_delta) AS elem;
+            END IF;
+
+            IF v_status IS NOT NULL THEN
+                v_completed_at := CASE 
+                    WHEN v_status IN (''Completed'', ''Failed'') THEN v_now_ts 
+                    ELSE NULL 
+                END;
+                
+                UPDATE %I.executions e
+                SET status = v_status, output = v_output, completed_at = v_completed_at
+                WHERE e.instance_id = v_instance_id AND e.execution_id = p_execution_id;
+            END IF;
+
+            IF p_worker_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_worker_items) > 0 THEN
+                INSERT INTO %I.worker_queue (work_item, visible_at, created_at)
+                SELECT elem::TEXT, v_now_ts, v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_worker_items) AS elem;
+            END IF;
+
+            IF p_orchestrator_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_orchestrator_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_orchestrator_items) LOOP
+                    IF v_elem ? ''StartOrchestration'' THEN
+                        v_item_instance_id := v_elem->''StartOrchestration''->>''instance'';
+                    ELSIF v_elem ? ''ContinueAsNew'' THEN
+                        v_item_instance_id := v_elem->''ContinueAsNew''->>''instance'';
+                    ELSIF v_elem ? ''TimerFired'' THEN
+                        v_item_instance_id := v_elem->''TimerFired''->>''instance'';
+                        v_fire_at_ms := (v_elem->''TimerFired''->>''fire_at_ms'')::BIGINT;
+                    ELSIF v_elem ? ''ActivityCompleted'' THEN
+                        v_item_instance_id := v_elem->''ActivityCompleted''->>''instance'';
+                    ELSIF v_elem ? ''ActivityFailed'' THEN
+                        v_item_instance_id := v_elem->''ActivityFailed''->>''instance'';
+                    ELSIF v_elem ? ''ExternalRaised'' THEN
+                        v_item_instance_id := v_elem->''ExternalRaised''->>''instance'';
+                    ELSIF v_elem ? ''CancelInstance'' THEN
+                        v_item_instance_id := v_elem->''CancelInstance''->>''instance'';
+                    ELSIF v_elem ? ''SubOrchCompleted'' THEN
+                        v_item_instance_id := v_elem->''SubOrchCompleted''->>''parent_instance'';
+                    ELSIF v_elem ? ''SubOrchFailed'' THEN
+                        v_item_instance_id := v_elem->''SubOrchFailed''->>''parent_instance'';
+                    ELSE
+                        v_item_instance_id := v_instance_id;
+                    END IF;
+
+                    IF v_elem ? ''TimerFired'' AND v_fire_at_ms IS NOT NULL AND v_fire_at_ms > 0 THEN
+                        v_visible_at := TO_TIMESTAMP(v_fire_at_ms / 1000.0);
+                    ELSE
+                        v_visible_at := v_now_ts;
+                    END IF;
+
+                    INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                    VALUES (v_item_instance_id, v_elem::TEXT, v_visible_at, v_now_ts);
+                    
+                    v_fire_at_ms := NULL;
+                END LOOP;
+            END IF;
+
+            -- ================================================================
+            -- Lock-Stealing: Delete worker queue entries for cancelled activities
+            -- Uses v_instance_id (from lock_token) for instance constraint
+            -- Uses execution_id and activity_id from JSON to identify activities
+            -- ================================================================
+            IF p_cancelled_activities IS NOT NULL AND JSONB_ARRAY_LENGTH(p_cancelled_activities) > 0 THEN
+                FOR v_cancelled IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_cancelled_activities) LOOP
+                    v_cancelled_execution_id := (v_cancelled->>''execution_id'')::BIGINT;
+                    v_cancelled_activity_id := (v_cancelled->>''activity_id'')::BIGINT;
+                    
+                    -- Delete matching ActivityExecute items from worker_queue
+                    -- The work_item JSON contains ActivityExecute with instance, execution_id, and id (activity_id)
+                    DELETE FROM %I.worker_queue wq
+                    WHERE wq.work_item::JSONB ? ''ActivityExecute''
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''instance'') = v_instance_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''execution_id'')::BIGINT = v_cancelled_execution_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''id'')::BIGINT = v_cancelled_activity_id;
+                END LOOP;
+            END IF;
+
+            DELETE FROM %I.orchestrator_queue q WHERE q.lock_token = p_lock_token;
+
+            DELETE FROM %I.instance_locks il
+            WHERE il.instance_id = v_instance_id AND il.lock_token = p_lock_token;
+        END;
+        $ack_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: abandon_orchestration_item
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.abandon_orchestration_item(TEXT, BIGINT, BIGINT, BOOLEAN)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.abandon_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_delay_ms BIGINT DEFAULT NULL,
+            p_ignore_attempt BOOLEAN DEFAULT FALSE
+        )
+        RETURNS TEXT AS $abandon_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_visible_at TIMESTAMPTZ;
+        BEGIN
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            IF p_delay_ms IS NOT NULL AND p_delay_ms > 0 THEN
+                v_visible_at := TO_TIMESTAMP((p_now_ms + p_delay_ms) / 1000.0);
+                
+                IF p_ignore_attempt THEN
+                    UPDATE %I.orchestrator_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL,
+                        visible_at = v_visible_at,
+                        attempt_count = GREATEST(0, attempt_count - 1)
+                    WHERE lock_token = p_lock_token;
+                ELSE
+                    UPDATE %I.orchestrator_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL,
+                        visible_at = v_visible_at
+                    WHERE lock_token = p_lock_token;
+                END IF;
+            ELSE
+                IF p_ignore_attempt THEN
+                    UPDATE %I.orchestrator_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL,
+                        attempt_count = GREATEST(0, attempt_count - 1)
+                    WHERE lock_token = p_lock_token;
+                ELSE
+                    UPDATE %I.orchestrator_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL
+                    WHERE lock_token = p_lock_token;
+                END IF;
+            END IF;
+
+            DELETE FROM %I.instance_locks
+            WHERE lock_token = p_lock_token;
+
+            RETURN v_instance_id;
+        END;
+        $abandon_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: renew_orchestration_item_lock
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.renew_orchestration_item_lock(TEXT, BIGINT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.renew_orchestration_item_lock(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_extend_ms BIGINT
+        )
+        RETURNS VOID AS $renew_orch_lock$
+        DECLARE
+            v_rows_affected INTEGER;
+        BEGIN
+            UPDATE %I.instance_locks
+            SET locked_until = GREATEST(locked_until, p_now_ms) + p_extend_ms
+            WHERE lock_token = p_lock_token
+              AND locked_until > p_now_ms;
+            
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+            
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Lock token invalid, expired, or already released'';
+            END IF;
+
+            UPDATE %I.orchestrator_queue
+            SET locked_until = GREATEST(locked_until, p_now_ms) + p_extend_ms
+            WHERE lock_token = p_lock_token;
+        END;
+        $renew_orch_lock$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- History Procedures
+    -- ============================================================================
+
+    -- Procedure: fetch_history
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_history(TEXT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_history(
+            p_instance_id TEXT
+        )
+        RETURNS TABLE(out_event_data TEXT) AS $fetch_history$
+        DECLARE
+            v_execution_id BIGINT;
+        BEGIN
+            SELECT COALESCE(MAX(execution_id), 1)
+            INTO v_execution_id
+            FROM %I.executions
+            WHERE instance_id = p_instance_id;
+
+            RETURN QUERY
+            SELECT h.event_data
+            FROM %I.history h
+            WHERE h.instance_id = p_instance_id
+              AND h.execution_id = v_execution_id
+            ORDER BY h.event_id;
+        END;
+        $fetch_history$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- Procedure: fetch_history_with_execution
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_history_with_execution(TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_history_with_execution(
+            p_instance_id TEXT,
+            p_execution_id BIGINT
+        )
+        RETURNS TABLE(out_event_data TEXT) AS $fetch_history_exec$
+        BEGIN
+            RETURN QUERY
+            SELECT h.event_data
+            FROM %I.history h
+            WHERE h.instance_id = p_instance_id
+              AND h.execution_id = p_execution_id
+            ORDER BY h.event_id;
+        END;
+        $fetch_history_exec$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: append_history
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.append_history(TEXT, BIGINT, JSONB, BIGINT)', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.append_history(
+            p_instance_id TEXT,
+            p_execution_id BIGINT,
+            p_events JSONB,
+            p_now_ms BIGINT
+        )
+        RETURNS VOID AS $append_hist$
+        DECLARE
+            v_now_ts TIMESTAMPTZ;
+        BEGIN
+            IF p_events IS NULL OR JSONB_ARRAY_LENGTH(p_events) = 0 THEN
+                RETURN;
+            END IF;
+
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            IF EXISTS (
+                SELECT 1
+                FROM JSONB_ARRAY_ELEMENTS(p_events) elem
+                WHERE COALESCE((elem->>''event_id'')::BIGINT, 0) <= 0
+            ) THEN
+                RAISE EXCEPTION ''Invalid event_id in append_history'';
+            END IF;
+
+            INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+            SELECT
+                p_instance_id,
+                p_execution_id,
+                (elem->>''event_id'')::BIGINT,
+                elem->>''event_type'',
+                elem->>''event_data'',
+                v_now_ts
+            FROM JSONB_ARRAY_ELEMENTS(p_events) AS elem
+            ON CONFLICT (instance_id, execution_id, event_id) DO NOTHING;
+        END;
+        $append_hist$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+END $$;

--- a/sql/duroxide_upstream/0002_add_deletion_and_pruning_support.sql
+++ b/sql/duroxide_upstream/0002_add_deletion_and_pruning_support.sql
@@ -1,0 +1,429 @@
+-- Migration 0002: Add deletion and pruning support
+-- This migration adds:
+-- 1. parent_instance_id column to instances table (for cascade deletion)
+-- 2. Updates get_instance_info to include parent_instance_id
+-- 3. Updates ack_orchestration_item to store parent_instance_id from metadata
+-- 4. New stored procedures for ProviderAdmin methods:
+--    - list_children
+--    - get_parent_id
+--    - delete_instances_atomic
+--    - prune_executions
+
+-- Add parent_instance_id column to instances table
+ALTER TABLE instances ADD COLUMN IF NOT EXISTS parent_instance_id TEXT;
+
+-- Add index for efficient child lookups
+CREATE INDEX IF NOT EXISTS idx_instances_parent ON instances(parent_instance_id);
+
+-- Get the current schema name (set by migration runner)
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    -- ============================================================================
+    -- Update get_instance_info to include parent_instance_id
+    -- ============================================================================
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT)', v_schema_name);
+    
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_instance_info(p_instance_id TEXT)
+        RETURNS TABLE(
+            instance_id TEXT,
+            orchestration_name TEXT,
+            orchestration_version TEXT,
+            current_execution_id BIGINT,
+            created_at TIMESTAMPTZ,
+            updated_at TIMESTAMPTZ,
+            status TEXT,
+            output TEXT,
+            parent_instance_id TEXT
+        ) AS $get_inst_info$
+        BEGIN
+            RETURN QUERY
+            SELECT i.instance_id, i.orchestration_name, 
+                   COALESCE(i.orchestration_version, ''unknown'') as orchestration_version,
+                   i.current_execution_id, i.created_at, i.updated_at,
+                   e.status, e.output, i.parent_instance_id
+            FROM %I.instances i
+            LEFT JOIN %I.executions e ON i.instance_id = e.instance_id 
+              AND i.current_execution_id = e.execution_id
+            WHERE i.instance_id = p_instance_id;
+        END;
+        $get_inst_info$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Update ack_orchestration_item to store parent_instance_id from metadata
+    -- This is critical for hierarchy tracking (cascade deletion, list_children, etc)
+    -- ============================================================================
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_execution_id BIGINT,
+            p_history_delta JSONB,
+            p_worker_items JSONB,
+            p_orchestrator_items JSONB,
+            p_metadata JSONB,
+            p_cancelled_activities JSONB DEFAULT ''[]''::JSONB
+        )
+        RETURNS VOID AS $ack_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_now_ts TIMESTAMPTZ;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_parent_instance_id TEXT;
+            v_status TEXT;
+            v_output TEXT;
+            v_completed_at TIMESTAMPTZ;
+            v_elem JSONB;
+            v_visible_at TIMESTAMPTZ;
+            v_fire_at_ms BIGINT;
+            v_item_instance_id TEXT;
+            v_cancelled JSONB;
+            v_cancelled_execution_id BIGINT;
+            v_cancelled_activity_id BIGINT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token AND il.locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            v_orchestration_name := p_metadata->>''orchestration_name'';
+            v_orchestration_version := p_metadata->>''orchestration_version'';
+            v_parent_instance_id := p_metadata->>''parent_instance_id'';
+            v_status := p_metadata->>''status'';
+            v_output := p_metadata->>''output'';
+
+            IF v_orchestration_name IS NOT NULL AND v_orchestration_version IS NOT NULL THEN
+                INSERT INTO %I.instances (instance_id, orchestration_name, orchestration_version, current_execution_id, parent_instance_id, created_at, updated_at)
+                VALUES (v_instance_id, v_orchestration_name, v_orchestration_version, p_execution_id, v_parent_instance_id, v_now_ts, v_now_ts)
+                ON CONFLICT (instance_id) DO NOTHING;
+
+                UPDATE %I.instances i
+                SET orchestration_name = v_orchestration_name,
+                    orchestration_version = v_orchestration_version,
+                    parent_instance_id = COALESCE(i.parent_instance_id, v_parent_instance_id),
+                    updated_at = v_now_ts
+                WHERE i.instance_id = v_instance_id;
+            END IF;
+
+            INSERT INTO %I.executions (instance_id, execution_id, status, started_at)
+            VALUES (v_instance_id, p_execution_id, ''Running'', v_now_ts)
+            ON CONFLICT (instance_id, execution_id) DO NOTHING;
+
+            UPDATE %I.instances i
+            SET current_execution_id = GREATEST(i.current_execution_id, p_execution_id),
+                updated_at = v_now_ts
+            WHERE i.instance_id = v_instance_id;
+
+            IF p_history_delta IS NOT NULL AND JSONB_ARRAY_LENGTH(p_history_delta) > 0 THEN
+                INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+                SELECT
+                    v_instance_id,
+                    p_execution_id,
+                    (elem->>''event_id'')::BIGINT,
+                    elem->>''event_type'',
+                    elem->>''event_data'',
+                    v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_history_delta) AS elem;
+            END IF;
+
+            IF v_status IS NOT NULL THEN
+                v_completed_at := CASE 
+                    WHEN v_status IN (''Completed'', ''Failed'') THEN v_now_ts 
+                    ELSE NULL 
+                END;
+                
+                UPDATE %I.executions e
+                SET status = v_status, output = v_output, completed_at = v_completed_at
+                WHERE e.instance_id = v_instance_id AND e.execution_id = p_execution_id;
+            END IF;
+
+            IF p_worker_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_worker_items) > 0 THEN
+                INSERT INTO %I.worker_queue (work_item, visible_at, created_at)
+                SELECT elem::TEXT, v_now_ts, v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_worker_items) AS elem;
+            END IF;
+
+            IF p_orchestrator_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_orchestrator_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_orchestrator_items) LOOP
+                    IF v_elem ? ''StartOrchestration'' THEN
+                        v_item_instance_id := v_elem->''StartOrchestration''->>''instance'';
+                    ELSIF v_elem ? ''ContinueAsNew'' THEN
+                        v_item_instance_id := v_elem->''ContinueAsNew''->>''instance'';
+                    ELSIF v_elem ? ''TimerFired'' THEN
+                        v_item_instance_id := v_elem->''TimerFired''->>''instance'';
+                        v_fire_at_ms := (v_elem->''TimerFired''->>''fire_at_ms'')::BIGINT;
+                    ELSIF v_elem ? ''ActivityCompleted'' THEN
+                        v_item_instance_id := v_elem->''ActivityCompleted''->>''instance'';
+                    ELSIF v_elem ? ''ActivityFailed'' THEN
+                        v_item_instance_id := v_elem->''ActivityFailed''->>''instance'';
+                    ELSIF v_elem ? ''ExternalRaised'' THEN
+                        v_item_instance_id := v_elem->''ExternalRaised''->>''instance'';
+                    ELSIF v_elem ? ''CancelInstance'' THEN
+                        v_item_instance_id := v_elem->''CancelInstance''->>''instance'';
+                    ELSIF v_elem ? ''SubOrchCompleted'' THEN
+                        v_item_instance_id := v_elem->''SubOrchCompleted''->>''parent_instance'';
+                    ELSIF v_elem ? ''SubOrchFailed'' THEN
+                        v_item_instance_id := v_elem->''SubOrchFailed''->>''parent_instance'';
+                    ELSE
+                        v_item_instance_id := v_instance_id;
+                    END IF;
+
+                    IF v_elem ? ''TimerFired'' AND v_fire_at_ms IS NOT NULL AND v_fire_at_ms > 0 THEN
+                        v_visible_at := TO_TIMESTAMP(v_fire_at_ms / 1000.0);
+                    ELSE
+                        v_visible_at := v_now_ts;
+                    END IF;
+
+                    INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                    VALUES (v_item_instance_id, v_elem::TEXT, v_visible_at, v_now_ts);
+                    
+                    v_fire_at_ms := NULL;
+                END LOOP;
+            END IF;
+
+            -- Lock-Stealing: Delete worker queue entries for cancelled activities
+            IF p_cancelled_activities IS NOT NULL AND JSONB_ARRAY_LENGTH(p_cancelled_activities) > 0 THEN
+                FOR v_cancelled IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_cancelled_activities) LOOP
+                    v_cancelled_execution_id := (v_cancelled->>''execution_id'')::BIGINT;
+                    v_cancelled_activity_id := (v_cancelled->>''activity_id'')::BIGINT;
+                    
+                    DELETE FROM %I.worker_queue wq
+                    WHERE wq.work_item::JSONB ? ''ActivityExecute''
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''instance'') = v_instance_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''execution_id'')::BIGINT = v_cancelled_execution_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''id'')::BIGINT = v_cancelled_activity_id;
+                END LOOP;
+            END IF;
+
+            DELETE FROM %I.orchestrator_queue q WHERE q.lock_token = p_lock_token;
+
+            DELETE FROM %I.instance_locks il
+            WHERE il.instance_id = v_instance_id AND il.lock_token = p_lock_token;
+        END;
+        $ack_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Hierarchy Primitive Procedures
+    -- ============================================================================
+
+    -- Procedure: list_children
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.list_children(p_instance_id TEXT)
+        RETURNS TABLE(child_instance_id TEXT) AS $list_children$
+        BEGIN
+            RETURN QUERY
+            SELECT i.instance_id
+            FROM %I.instances i
+            WHERE i.parent_instance_id = p_instance_id
+            ORDER BY i.created_at;
+        END;
+        $list_children$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- Procedure: get_parent_id
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_parent_id(p_instance_id TEXT)
+        RETURNS TEXT AS $get_parent$
+        DECLARE
+            v_parent_id TEXT;
+        BEGIN
+            SELECT i.parent_instance_id
+            INTO v_parent_id
+            FROM %I.instances i
+            WHERE i.instance_id = p_instance_id;
+            
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Instance not found: %%'', p_instance_id;
+            END IF;
+            
+            RETURN v_parent_id;
+        END;
+        $get_parent$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Deletion Procedures
+    -- ============================================================================
+
+    -- Procedure: delete_instances_atomic
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.delete_instances_atomic(
+            p_instance_ids TEXT[],
+            p_force BOOLEAN
+        )
+        RETURNS TABLE(
+            instances_deleted BIGINT,
+            executions_deleted BIGINT,
+            events_deleted BIGINT,
+            queue_messages_deleted BIGINT
+        ) AS $delete_atomic$
+        DECLARE
+            v_instance_id TEXT;
+            v_orphan_id TEXT;
+            v_instances_deleted BIGINT := 0;
+            v_executions_deleted BIGINT := 0;
+            v_events_deleted BIGINT := 0;
+            v_queue_deleted BIGINT := 0;
+            v_count BIGINT;
+        BEGIN
+            IF p_instance_ids IS NULL OR array_length(p_instance_ids, 1) IS NULL THEN
+                instances_deleted := 0;
+                executions_deleted := 0;
+                events_deleted := 0;
+                queue_messages_deleted := 0;
+                RETURN NEXT;
+                RETURN;
+            END IF;
+
+            IF NOT p_force THEN
+                SELECT i.instance_id INTO v_instance_id
+                FROM %I.instances i
+                JOIN %I.executions e ON i.instance_id = e.instance_id 
+                  AND i.current_execution_id = e.execution_id
+                WHERE i.instance_id = ANY(p_instance_ids)
+                  AND e.status = ''Running''
+                LIMIT 1;
+                
+                IF v_instance_id IS NOT NULL THEN
+                    RAISE EXCEPTION ''Instance %% is Running. Use force=true to delete.'', v_instance_id;
+                END IF;
+            END IF;
+
+            PERFORM 1 FROM %I.instances
+            WHERE instance_id = ANY(p_instance_ids)
+            FOR UPDATE;
+
+            SELECT i.instance_id INTO v_orphan_id
+            FROM %I.instances i
+            WHERE i.parent_instance_id = ANY(p_instance_ids)
+              AND NOT (i.instance_id = ANY(p_instance_ids))
+            LIMIT 1;
+            
+            IF v_orphan_id IS NOT NULL THEN
+                RAISE EXCEPTION ''Orphan detected: instance %% has parent in delete list but is not included'', v_orphan_id;
+            END IF;
+
+            DELETE FROM %I.history WHERE instance_id = ANY(p_instance_ids);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_events_deleted := v_count;
+
+            DELETE FROM %I.executions WHERE instance_id = ANY(p_instance_ids);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_executions_deleted := v_count;
+
+            DELETE FROM %I.orchestrator_queue WHERE instance_id = ANY(p_instance_ids);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_queue_deleted := v_count;
+
+            DELETE FROM %I.worker_queue 
+            WHERE work_item::JSONB ? ''ActivityExecute''
+              AND (work_item::JSONB->''ActivityExecute''->>''instance'') = ANY(p_instance_ids);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_queue_deleted := v_queue_deleted + v_count;
+
+            DELETE FROM %I.instance_locks WHERE instance_id = ANY(p_instance_ids);
+
+            DELETE FROM %I.instances WHERE instance_id = ANY(p_instance_ids);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_instances_deleted := v_count;
+
+            instances_deleted := v_instances_deleted;
+            executions_deleted := v_executions_deleted;
+            events_deleted := v_events_deleted;
+            queue_messages_deleted := v_queue_deleted;
+            RETURN NEXT;
+        END;
+        $delete_atomic$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Pruning Procedures
+    -- ============================================================================
+
+    -- Procedure: prune_executions
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.prune_executions(
+            p_instance_id TEXT,
+            p_keep_last INTEGER DEFAULT NULL,
+            p_completed_before_ms BIGINT DEFAULT NULL
+        )
+        RETURNS TABLE(
+            instances_processed BIGINT,
+            executions_deleted BIGINT,
+            events_deleted BIGINT
+        ) AS $prune_exec$
+        DECLARE
+            v_current_execution_id BIGINT;
+            v_executions_deleted BIGINT := 0;
+            v_events_deleted BIGINT := 0;
+            v_count BIGINT;
+            v_exec_ids_to_delete BIGINT[];
+        BEGIN
+            SELECT i.current_execution_id INTO v_current_execution_id
+            FROM %I.instances i
+            WHERE i.instance_id = p_instance_id;
+            
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Instance %% not found'', p_instance_id;
+            END IF;
+
+            SELECT array_agg(e.execution_id) INTO v_exec_ids_to_delete
+            FROM %I.executions e
+            WHERE e.instance_id = p_instance_id
+              AND e.execution_id != v_current_execution_id
+              AND e.status != ''Running''
+              AND (p_completed_before_ms IS NULL 
+                   OR e.completed_at < TO_TIMESTAMP(p_completed_before_ms / 1000.0))
+              AND (p_keep_last IS NULL 
+                   OR e.execution_id NOT IN (
+                       SELECT e2.execution_id 
+                       FROM %I.executions e2
+                       WHERE e2.instance_id = p_instance_id
+                       ORDER BY e2.execution_id DESC
+                       LIMIT p_keep_last
+                   ));
+
+            IF v_exec_ids_to_delete IS NULL OR array_length(v_exec_ids_to_delete, 1) IS NULL THEN
+                instances_processed := 1;
+                executions_deleted := 0;
+                events_deleted := 0;
+                RETURN NEXT;
+                RETURN;
+            END IF;
+
+            DELETE FROM %I.history h
+            WHERE h.instance_id = p_instance_id
+              AND h.execution_id = ANY(v_exec_ids_to_delete);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_events_deleted := v_count;
+
+            DELETE FROM %I.executions e
+            WHERE e.instance_id = p_instance_id
+              AND e.execution_id = ANY(v_exec_ids_to_delete);
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            v_executions_deleted := v_count;
+
+            instances_processed := 1;
+            executions_deleted := v_executions_deleted;
+            events_deleted := v_events_deleted;
+            RETURN NEXT;
+        END;
+        $prune_exec$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+END $$;

--- a/sql/duroxide_upstream/0003_add_capability_filtering.sql
+++ b/sql/duroxide_upstream/0003_add_capability_filtering.sql
@@ -1,0 +1,447 @@
+-- Migration 0003: Add capability filtering support
+-- This migration adds:
+-- 1. duroxide_version_major/minor/patch columns to executions table
+-- 2. Updates fetch_orchestration_item to accept version filter parameters
+-- 3. Updates ack_orchestration_item to store pinned_duroxide_version from metadata
+-- 4. Updates cleanup_schema to drop new function signatures
+
+-- Add version columns to executions table
+ALTER TABLE executions ADD COLUMN IF NOT EXISTS duroxide_version_major INTEGER;
+ALTER TABLE executions ADD COLUMN IF NOT EXISTS duroxide_version_minor INTEGER;
+ALTER TABLE executions ADD COLUMN IF NOT EXISTS duroxide_version_patch INTEGER;
+
+-- Get the current schema name (set by migration runner)
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    -- ============================================================================
+    -- Update fetch_orchestration_item to accept version filter parameters
+    -- Drop old 2-param signature, create new 4-param signature
+    -- ============================================================================
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_orchestration_item(
+            p_now_ms BIGINT,
+            p_lock_timeout_ms BIGINT,
+            p_min_version_packed BIGINT DEFAULT NULL,
+            p_max_version_packed BIGINT DEFAULT NULL
+        )
+        RETURNS TABLE(
+            out_instance_id TEXT,
+            out_orchestration_name TEXT,
+            out_orchestration_version TEXT,
+            out_execution_id BIGINT,
+            out_history JSONB,
+            out_messages JSONB,
+            out_lock_token TEXT,
+            out_attempt_count INTEGER
+        ) AS $fetch_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_lock_token TEXT;
+            v_locked_until BIGINT;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_current_execution_id BIGINT;
+            v_history JSONB;
+            v_messages JSONB;
+            v_lock_acquired INTEGER;
+            v_max_attempt_count INTEGER;
+        BEGIN
+            -- Phase 1: Find a candidate instance (no FOR UPDATE yet)
+            IF p_min_version_packed IS NOT NULL THEN
+                -- Version-filtered path: join to instances and executions to check pinned version
+                SELECT q.instance_id INTO v_instance_id
+                FROM %I.orchestrator_queue q
+                LEFT JOIN %I.instances i ON q.instance_id = i.instance_id
+                LEFT JOIN %I.executions e ON i.instance_id = e.instance_id
+                  AND i.current_execution_id = e.execution_id
+                WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM %I.instance_locks il
+                    WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+                  )
+                  AND (
+                    e.duroxide_version_major IS NULL
+                    OR (e.duroxide_version_major * 1000000 + e.duroxide_version_minor * 1000 + e.duroxide_version_patch)
+                       BETWEEN p_min_version_packed AND p_max_version_packed
+                  )
+                ORDER BY q.visible_at, q.id
+                LIMIT 1;
+            ELSE
+                -- No filter: original behavior
+                SELECT q.instance_id INTO v_instance_id
+                FROM %I.orchestrator_queue q
+                WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM %I.instance_locks il
+                    WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+                  )
+                ORDER BY q.visible_at, q.id
+                LIMIT 1;
+            END IF;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            -- Phase 2: Acquire instance-level advisory lock
+            PERFORM pg_advisory_xact_lock(hashtext(v_instance_id));
+
+            -- Phase 3: Re-verify with FOR UPDATE (include version filter if applicable)
+            IF p_min_version_packed IS NOT NULL THEN
+                SELECT q.instance_id INTO v_instance_id
+                FROM %I.orchestrator_queue q
+                LEFT JOIN %I.instances i ON q.instance_id = i.instance_id
+                LEFT JOIN %I.executions e ON i.instance_id = e.instance_id
+                  AND i.current_execution_id = e.execution_id
+                WHERE q.instance_id = v_instance_id
+                  AND q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM %I.instance_locks il
+                    WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+                  )
+                  AND (
+                    e.duroxide_version_major IS NULL
+                    OR (e.duroxide_version_major * 1000000 + e.duroxide_version_minor * 1000 + e.duroxide_version_patch)
+                       BETWEEN p_min_version_packed AND p_max_version_packed
+                  )
+                FOR UPDATE OF q SKIP LOCKED;
+            ELSE
+                SELECT q.instance_id INTO v_instance_id
+                FROM %I.orchestrator_queue q
+                WHERE q.instance_id = v_instance_id
+                  AND q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM %I.instance_locks il
+                    WHERE il.instance_id = q.instance_id AND il.locked_until > p_now_ms
+                  )
+                FOR UPDATE OF q SKIP LOCKED;
+            END IF;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            v_lock_token := ''lock_'' || gen_random_uuid()::TEXT;
+            v_locked_until := p_now_ms + p_lock_timeout_ms;
+
+            INSERT INTO %I.instance_locks (instance_id, lock_token, locked_until, locked_at)
+            VALUES (v_instance_id, v_lock_token, v_locked_until, p_now_ms)
+            ON CONFLICT(instance_id) DO UPDATE
+            SET lock_token = EXCLUDED.lock_token,
+                locked_until = EXCLUDED.locked_until,
+                locked_at = EXCLUDED.locked_at
+            WHERE %I.instance_locks.locked_until <= p_now_ms;
+
+            GET DIAGNOSTICS v_lock_acquired = ROW_COUNT;
+
+            IF v_lock_acquired = 0 THEN
+                RETURN;
+            END IF;
+
+            UPDATE %I.orchestrator_queue q
+            SET lock_token = v_lock_token,
+                locked_until = v_locked_until,
+                attempt_count = q.attempt_count + 1
+            WHERE q.instance_id = v_instance_id
+              AND q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+              AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms);
+
+            SELECT COALESCE(JSONB_AGG(q.work_item::JSONB ORDER BY q.id), ''[]''::JSONB),
+                   COALESCE(MAX(q.attempt_count), 1)
+            INTO v_messages, v_max_attempt_count
+            FROM %I.orchestrator_queue q
+            WHERE q.lock_token = v_lock_token;
+
+            SELECT i.orchestration_name, i.orchestration_version, i.current_execution_id
+            INTO v_orchestration_name, v_orchestration_version, v_current_execution_id
+            FROM %I.instances i
+            WHERE i.instance_id = v_instance_id;
+
+            IF FOUND THEN
+                SELECT COALESCE(JSONB_AGG(h.event_data::JSONB ORDER BY h.event_id), ''[]''::JSONB)
+                INTO v_history
+                FROM %I.history h
+                WHERE h.instance_id = v_instance_id AND h.execution_id = v_current_execution_id;
+                
+                v_orchestration_version := COALESCE(v_orchestration_version, ''unknown'');
+            ELSE
+                SELECT COALESCE(JSONB_AGG(h.event_data::JSONB ORDER BY h.execution_id, h.event_id), ''[]''::JSONB)
+                INTO v_history
+                FROM %I.history h
+                WHERE h.instance_id = v_instance_id;
+
+                IF JSONB_ARRAY_LENGTH(v_history) > 0 AND v_history->0 ? ''OrchestrationStarted'' THEN
+                    v_orchestration_name := v_history->0->''OrchestrationStarted''->>''name'';
+                    v_orchestration_version := v_history->0->''OrchestrationStarted''->>''version'';
+                    v_current_execution_id := 1;
+                ELSIF JSONB_ARRAY_LENGTH(v_messages) > 0 AND v_messages->0 ? ''StartOrchestration'' THEN
+                    v_orchestration_name := v_messages->0->''StartOrchestration''->>''orchestration'';
+                    v_orchestration_version := COALESCE(v_messages->0->''StartOrchestration''->>''version'', ''unknown'');
+                    v_current_execution_id := COALESCE((v_messages->0->''StartOrchestration''->>''execution_id'')::BIGINT, 1);
+                ELSIF JSONB_ARRAY_LENGTH(v_messages) > 0 AND v_messages->0 ? ''ContinueAsNew'' THEN
+                    v_orchestration_name := v_messages->0->''ContinueAsNew''->>''orchestration'';
+                    v_orchestration_version := COALESCE(v_messages->0->''ContinueAsNew''->>''version'', ''unknown'');
+                    v_current_execution_id := 1;
+                ELSE
+                    v_orchestration_name := ''Unknown'';
+                    v_orchestration_version := ''unknown'';
+                    v_current_execution_id := 1;
+                END IF;
+            END IF;
+
+            RETURN QUERY SELECT
+                v_instance_id,
+                v_orchestration_name,
+                v_orchestration_version,
+                v_current_execution_id,
+                v_history,
+                v_messages,
+                v_lock_token,
+                v_max_attempt_count;
+        END;
+        $fetch_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Update ack_orchestration_item to handle pinned_duroxide_version
+    -- Drop old signature, create new one with version handling
+    -- ============================================================================
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_execution_id BIGINT,
+            p_history_delta JSONB,
+            p_worker_items JSONB,
+            p_orchestrator_items JSONB,
+            p_metadata JSONB,
+            p_cancelled_activities JSONB DEFAULT ''[]''::JSONB
+        )
+        RETURNS VOID AS $ack_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_now_ts TIMESTAMPTZ;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_parent_instance_id TEXT;
+            v_status TEXT;
+            v_output TEXT;
+            v_completed_at TIMESTAMPTZ;
+            v_elem JSONB;
+            v_visible_at TIMESTAMPTZ;
+            v_fire_at_ms BIGINT;
+            v_item_instance_id TEXT;
+            v_cancelled JSONB;
+            v_cancelled_execution_id BIGINT;
+            v_cancelled_activity_id BIGINT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token AND il.locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            v_orchestration_name := p_metadata->>''orchestration_name'';
+            v_orchestration_version := p_metadata->>''orchestration_version'';
+            v_parent_instance_id := p_metadata->>''parent_instance_id'';
+            v_status := p_metadata->>''status'';
+            v_output := p_metadata->>''output'';
+
+            IF v_orchestration_name IS NOT NULL AND v_orchestration_version IS NOT NULL THEN
+                INSERT INTO %I.instances (instance_id, orchestration_name, orchestration_version, current_execution_id, parent_instance_id, created_at, updated_at)
+                VALUES (v_instance_id, v_orchestration_name, v_orchestration_version, p_execution_id, v_parent_instance_id, v_now_ts, v_now_ts)
+                ON CONFLICT (instance_id) DO NOTHING;
+
+                UPDATE %I.instances i
+                SET orchestration_name = v_orchestration_name,
+                    orchestration_version = v_orchestration_version,
+                    parent_instance_id = COALESCE(i.parent_instance_id, v_parent_instance_id),
+                    updated_at = v_now_ts
+                WHERE i.instance_id = v_instance_id;
+            END IF;
+
+            INSERT INTO %I.executions (instance_id, execution_id, status, started_at)
+            VALUES (v_instance_id, p_execution_id, ''Running'', v_now_ts)
+            ON CONFLICT (instance_id, execution_id) DO NOTHING;
+
+            UPDATE %I.instances i
+            SET current_execution_id = GREATEST(i.current_execution_id, p_execution_id),
+                updated_at = v_now_ts
+            WHERE i.instance_id = v_instance_id;
+
+            IF p_history_delta IS NOT NULL AND JSONB_ARRAY_LENGTH(p_history_delta) > 0 THEN
+                INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+                SELECT
+                    v_instance_id,
+                    p_execution_id,
+                    (elem->>''event_id'')::BIGINT,
+                    elem->>''event_type'',
+                    elem->>''event_data'',
+                    v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_history_delta) AS elem;
+            END IF;
+
+            IF v_status IS NOT NULL THEN
+                v_completed_at := CASE 
+                    WHEN v_status IN (''Completed'', ''Failed'') THEN v_now_ts 
+                    ELSE NULL 
+                END;
+                
+                UPDATE %I.executions e
+                SET status = v_status, output = v_output, completed_at = v_completed_at
+                WHERE e.instance_id = v_instance_id AND e.execution_id = p_execution_id;
+            END IF;
+
+            -- Store pinned duroxide version on execution if provided
+            IF p_metadata ? ''pinned_duroxide_version'' AND p_metadata->''pinned_duroxide_version'' IS NOT NULL
+               AND p_metadata->>''pinned_duroxide_version'' != ''null'' THEN
+                UPDATE %I.executions
+                SET duroxide_version_major = (p_metadata->''pinned_duroxide_version''->>''major'')::INTEGER,
+                    duroxide_version_minor = (p_metadata->''pinned_duroxide_version''->>''minor'')::INTEGER,
+                    duroxide_version_patch = (p_metadata->''pinned_duroxide_version''->>''patch'')::INTEGER
+                WHERE instance_id = v_instance_id AND execution_id = p_execution_id;
+            END IF;
+
+            IF p_worker_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_worker_items) > 0 THEN
+                INSERT INTO %I.worker_queue (work_item, visible_at, created_at)
+                SELECT elem::TEXT, v_now_ts, v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_worker_items) AS elem;
+            END IF;
+
+            IF p_orchestrator_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_orchestrator_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_orchestrator_items) LOOP
+                    IF v_elem ? ''StartOrchestration'' THEN
+                        v_item_instance_id := v_elem->''StartOrchestration''->>''instance'';
+                    ELSIF v_elem ? ''ContinueAsNew'' THEN
+                        v_item_instance_id := v_elem->''ContinueAsNew''->>''instance'';
+                    ELSIF v_elem ? ''TimerFired'' THEN
+                        v_item_instance_id := v_elem->''TimerFired''->>''instance'';
+                        v_fire_at_ms := (v_elem->''TimerFired''->>''fire_at_ms'')::BIGINT;
+                    ELSIF v_elem ? ''ActivityCompleted'' THEN
+                        v_item_instance_id := v_elem->''ActivityCompleted''->>''instance'';
+                    ELSIF v_elem ? ''ActivityFailed'' THEN
+                        v_item_instance_id := v_elem->''ActivityFailed''->>''instance'';
+                    ELSIF v_elem ? ''ExternalRaised'' THEN
+                        v_item_instance_id := v_elem->''ExternalRaised''->>''instance'';
+                    ELSIF v_elem ? ''CancelInstance'' THEN
+                        v_item_instance_id := v_elem->''CancelInstance''->>''instance'';
+                    ELSIF v_elem ? ''SubOrchCompleted'' THEN
+                        v_item_instance_id := v_elem->''SubOrchCompleted''->>''parent_instance'';
+                    ELSIF v_elem ? ''SubOrchFailed'' THEN
+                        v_item_instance_id := v_elem->''SubOrchFailed''->>''parent_instance'';
+                    ELSE
+                        v_item_instance_id := v_instance_id;
+                    END IF;
+
+                    IF v_elem ? ''TimerFired'' AND v_fire_at_ms IS NOT NULL AND v_fire_at_ms > 0 THEN
+                        v_visible_at := TO_TIMESTAMP(v_fire_at_ms / 1000.0);
+                    ELSE
+                        v_visible_at := v_now_ts;
+                    END IF;
+
+                    INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                    VALUES (v_item_instance_id, v_elem::TEXT, v_visible_at, v_now_ts);
+                    
+                    v_fire_at_ms := NULL;
+                END LOOP;
+            END IF;
+
+            -- Lock-Stealing: Delete worker queue entries for cancelled activities
+            IF p_cancelled_activities IS NOT NULL AND JSONB_ARRAY_LENGTH(p_cancelled_activities) > 0 THEN
+                FOR v_cancelled IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_cancelled_activities) LOOP
+                    v_cancelled_execution_id := (v_cancelled->>''execution_id'')::BIGINT;
+                    v_cancelled_activity_id := (v_cancelled->>''activity_id'')::BIGINT;
+                    
+                    DELETE FROM %I.worker_queue wq
+                    WHERE wq.work_item::JSONB ? ''ActivityExecute''
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''instance'') = v_instance_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''execution_id'')::BIGINT = v_cancelled_execution_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''id'')::BIGINT = v_cancelled_activity_id;
+                END LOOP;
+            END IF;
+
+            DELETE FROM %I.orchestrator_queue q WHERE q.lock_token = p_lock_token;
+
+            DELETE FROM %I.instance_locks il
+            WHERE il.instance_id = v_instance_id AND il.lock_token = p_lock_token;
+        END;
+        $ack_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Update cleanup_schema to drop new function signatures
+    -- ============================================================================
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.cleanup_schema()', v_schema_name);
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.cleanup_schema()
+        RETURNS VOID AS $cleanup$
+        BEGIN
+            -- Drop tables first
+            DROP TABLE IF EXISTS %I.instances CASCADE;
+            DROP TABLE IF EXISTS %I.executions CASCADE;
+            DROP TABLE IF EXISTS %I.history CASCADE;
+            DROP TABLE IF EXISTS %I.orchestrator_queue CASCADE;
+            DROP TABLE IF EXISTS %I.worker_queue CASCADE;
+            DROP TABLE IF EXISTS %I.instance_locks CASCADE;
+            DROP TABLE IF EXISTS %I._duroxide_migrations CASCADE;
+            
+            -- Drop all stored procedures (required because return type changes cannot use CREATE OR REPLACE)
+            DROP FUNCTION IF EXISTS %I.cleanup_schema();
+            DROP FUNCTION IF EXISTS %I.list_instances();
+            DROP FUNCTION IF EXISTS %I.list_executions(TEXT);
+            DROP FUNCTION IF EXISTS %I.latest_execution_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.list_instances_by_status(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_execution_info(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.get_system_metrics();
+            DROP FUNCTION IF EXISTS %I.get_queue_depths(BIGINT);
+            DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.abandon_work_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.enqueue_orchestrator_work(TEXT, TEXT, TIMESTAMPTZ, BIGINT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB);
+            DROP FUNCTION IF EXISTS %I.abandon_orchestration_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.renew_orchestration_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_history(TEXT);
+            DROP FUNCTION IF EXISTS %I.fetch_history_with_execution(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.append_history(TEXT, BIGINT, JSONB, BIGINT);
+            DROP FUNCTION IF EXISTS %I.list_children(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_parent_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.delete_instances_atomic(TEXT[], BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.prune_executions(TEXT, INTEGER, BIGINT);
+            
+            -- Drop trigger functions (not schema-qualified, they use search_path)
+            -- CASCADE is required because triggers depend on these functions
+            DROP FUNCTION IF EXISTS notify_orch_work() CASCADE;
+            DROP FUNCTION IF EXISTS notify_worker_work() CASCADE;
+        END;
+        $cleanup$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, 
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name);
+
+END $$;

--- a/sql/duroxide_upstream/0004_add_session_support.sql
+++ b/sql/duroxide_upstream/0004_add_session_support.sql
@@ -1,0 +1,550 @@
+-- Migration 0004: Add session affinity support
+-- This migration adds:
+-- 1. session_id column to worker_queue
+-- 2. sessions table for tracking session ownership
+-- 3. Session-aware fetch_work_item with routing logic
+-- 4. Session piggybacking in ack_worker and renew_work_item_lock
+-- 5. renew_session_lock and cleanup_orphaned_sessions stored procedures
+-- 6. Updated enqueue_worker_work and ack_orchestration_item for session_id
+
+-- Schema changes using unqualified names (search_path set by migration runner)
+ALTER TABLE worker_queue ADD COLUMN IF NOT EXISTS session_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_worker_queue_session_id ON worker_queue(session_id);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id TEXT PRIMARY KEY,
+    worker_id TEXT NOT NULL,
+    locked_until BIGINT NOT NULL,
+    last_activity_at BIGINT NOT NULL
+);
+
+-- Stored procedure changes using schema-qualified names
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    -- ============================================================================
+    -- Part 1: Update enqueue_worker_work to accept session_id
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.enqueue_worker_work(
+            p_work_item TEXT,
+            p_now_ms BIGINT,
+            p_session_id TEXT DEFAULT NULL
+        )
+        RETURNS VOID AS $enq_worker$
+        DECLARE
+            v_now_ts TIMESTAMPTZ;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+            INSERT INTO %I.worker_queue (work_item, visible_at, created_at, session_id)
+            VALUES (p_work_item, v_now_ts, v_now_ts, p_session_id);
+        END;
+        $enq_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 2: Update fetch_work_item with session routing
+    -- Drop old 2-param version, create new 4-param version returning 3 columns
+    -- (out_execution_status removed - cancellation now via lock-stealing)
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.fetch_work_item(
+            p_now_ms BIGINT,
+            p_lock_timeout_ms BIGINT,
+            p_owner_id TEXT DEFAULT NULL,
+            p_session_lock_timeout_ms BIGINT DEFAULT NULL
+        )
+        RETURNS TABLE(
+            out_work_item TEXT,
+            out_lock_token TEXT,
+            out_attempt_count INTEGER
+        ) AS $fetch_worker$
+        DECLARE
+            v_id BIGINT;
+            v_session_id TEXT;
+            v_session_locked_until BIGINT;
+        BEGIN
+            IF p_owner_id IS NOT NULL THEN
+                -- Session-aware fetch: find eligible items considering session routing
+                -- Eligible items are:
+                -- 1. Non-session items (q.session_id IS NULL)
+                -- 2. Items for sessions owned by this worker (s.worker_id = p_owner_id AND s.locked_until > p_now_ms)
+                -- 3. Items for claimable sessions (no active session row, or expired lock)
+                SELECT q.id, q.session_id INTO v_id, v_session_id
+                FROM %I.worker_queue q
+                LEFT JOIN %I.sessions s ON s.session_id = q.session_id AND s.locked_until > p_now_ms
+                WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms)
+                  AND (
+                    q.session_id IS NULL
+                    OR s.worker_id = p_owner_id
+                    OR s.session_id IS NULL
+                  )
+                ORDER BY q.id
+                LIMIT 1
+                FOR UPDATE OF q SKIP LOCKED;
+            ELSE
+                -- Non-session fetch: only non-session items
+                SELECT q.id, q.session_id INTO v_id, v_session_id
+                FROM %I.worker_queue q
+                WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms)
+                  AND q.session_id IS NULL
+                ORDER BY q.id
+                LIMIT 1
+                FOR UPDATE OF q SKIP LOCKED;
+            END IF;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            out_lock_token := ''lock_'' || gen_random_uuid()::TEXT;
+
+            -- Increment attempt_count and lock the item
+            UPDATE %I.worker_queue
+            SET lock_token = out_lock_token,
+                locked_until = p_now_ms + p_lock_timeout_ms,
+                attempt_count = attempt_count + 1
+            WHERE id = v_id;
+
+            SELECT work_item, attempt_count
+            INTO out_work_item, out_attempt_count
+            FROM %I.worker_queue
+            WHERE id = v_id;
+
+            -- If session-bound, upsert the sessions row
+            IF v_session_id IS NOT NULL AND p_owner_id IS NOT NULL THEN
+                v_session_locked_until := p_now_ms + COALESCE(p_session_lock_timeout_ms, p_lock_timeout_ms);
+
+                INSERT INTO %I.sessions (session_id, worker_id, locked_until, last_activity_at)
+                VALUES (v_session_id, p_owner_id, v_session_locked_until, p_now_ms)
+                ON CONFLICT (session_id) DO UPDATE
+                SET worker_id = p_owner_id,
+                    locked_until = v_session_locked_until,
+                    last_activity_at = p_now_ms
+                WHERE %I.sessions.locked_until <= p_now_ms OR %I.sessions.worker_id = p_owner_id;
+
+                -- If upsert affected 0 rows, another worker owns this session.
+                -- Roll back: clear lock so item can be retried.
+                IF NOT FOUND THEN
+                    UPDATE %I.worker_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL,
+                        attempt_count = attempt_count - 1
+                    WHERE id = v_id;
+                    RETURN;
+                END IF;
+            END IF;
+
+            RETURN NEXT;
+        END;
+        $fetch_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 3: Update ack_worker to piggyback session last_activity_at
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_worker(
+            p_lock_token TEXT,
+            p_instance_id TEXT,
+            p_completion_json TEXT,
+            p_now_ms BIGINT
+        )
+        RETURNS VOID AS $ack_worker$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_now_ts TIMESTAMPTZ;
+            v_session_id TEXT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            -- Capture session_id before deleting
+            SELECT session_id INTO v_session_id
+            FROM %I.worker_queue WHERE lock_token = p_lock_token;
+
+            -- Delete the worker queue item
+            DELETE FROM %I.worker_queue WHERE lock_token = p_lock_token;
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Worker queue item not found or already processed'';
+            END IF;
+
+            -- Validate: if completion provided, instance_id must also be provided
+            IF p_completion_json IS NOT NULL AND p_instance_id IS NULL THEN
+                RAISE EXCEPTION ''instance_id required when completion_json is provided'';
+            END IF;
+
+            -- Only enqueue completion if provided (not NULL)
+            IF p_completion_json IS NOT NULL THEN
+                INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                VALUES (p_instance_id, p_completion_json, v_now_ts, v_now_ts);
+            END IF;
+
+            -- Piggyback: update session last_activity_at
+            IF v_session_id IS NOT NULL AND p_now_ms IS NOT NULL THEN
+                UPDATE %I.sessions SET last_activity_at = p_now_ms
+                WHERE session_id = v_session_id AND locked_until > p_now_ms;
+            END IF;
+        END;
+        $ack_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 4: Update renew_work_item_lock to piggyback session last_activity_at
+    -- Also change return type from TEXT to VOID (execution_status removed in 0.1.8)
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.renew_work_item_lock(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_extend_ms BIGINT
+        )
+        RETURNS VOID AS $renew_lock$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_session_id TEXT;
+        BEGIN
+            -- Read session_id before updating
+            SELECT session_id INTO v_session_id
+            FROM %I.worker_queue
+            WHERE lock_token = p_lock_token;
+
+            -- Update lock timeout only if lock is still valid
+            UPDATE %I.worker_queue
+            SET locked_until = GREATEST(locked_until, p_now_ms) + p_extend_ms
+            WHERE lock_token = p_lock_token
+              AND locked_until > p_now_ms;
+
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Lock token invalid, expired, or already acked'';
+            END IF;
+
+            -- Piggyback: update session last_activity_at
+            IF v_session_id IS NOT NULL THEN
+                UPDATE %I.sessions SET last_activity_at = p_now_ms
+                WHERE session_id = v_session_id AND locked_until > p_now_ms;
+            END IF;
+        END;
+        $renew_lock$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 5: Create renew_session_lock stored procedure
+    -- ============================================================================
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.renew_session_lock(
+            p_owner_ids TEXT[],
+            p_now_ms BIGINT,
+            p_extend_ms BIGINT,
+            p_idle_timeout_ms BIGINT
+        )
+        RETURNS BIGINT AS $renew_session$
+        DECLARE
+            v_count BIGINT;
+        BEGIN
+            UPDATE %I.sessions SET locked_until = p_now_ms + p_extend_ms
+            WHERE worker_id = ANY(p_owner_ids)
+              AND locked_until > p_now_ms
+              AND last_activity_at > (p_now_ms - p_idle_timeout_ms);
+
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            RETURN v_count;
+        END;
+        $renew_session$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 6: Create cleanup_orphaned_sessions stored procedure
+    -- ============================================================================
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.cleanup_orphaned_sessions(
+            p_now_ms BIGINT
+        )
+        RETURNS BIGINT AS $cleanup_sessions$
+        DECLARE
+            v_count BIGINT;
+        BEGIN
+            DELETE FROM %I.sessions
+            WHERE locked_until < p_now_ms
+              AND NOT EXISTS (SELECT 1 FROM %I.worker_queue WHERE worker_queue.session_id = sessions.session_id);
+
+            GET DIAGNOSTICS v_count = ROW_COUNT;
+            RETURN v_count;
+        END;
+        $cleanup_sessions$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 7: Update ack_orchestration_item to extract session_id from worker items
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_execution_id BIGINT,
+            p_history_delta JSONB,
+            p_worker_items JSONB,
+            p_orchestrator_items JSONB,
+            p_metadata JSONB,
+            p_cancelled_activities JSONB DEFAULT ''[]''::JSONB
+        )
+        RETURNS VOID AS $ack_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_now_ts TIMESTAMPTZ;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_parent_instance_id TEXT;
+            v_status TEXT;
+            v_output TEXT;
+            v_completed_at TIMESTAMPTZ;
+            v_elem JSONB;
+            v_visible_at TIMESTAMPTZ;
+            v_fire_at_ms BIGINT;
+            v_item_instance_id TEXT;
+            v_item_session_id TEXT;
+            v_cancelled JSONB;
+            v_cancelled_execution_id BIGINT;
+            v_cancelled_activity_id BIGINT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token AND il.locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            v_orchestration_name := p_metadata->>''orchestration_name'';
+            v_orchestration_version := p_metadata->>''orchestration_version'';
+            v_parent_instance_id := p_metadata->>''parent_instance_id'';
+            v_status := p_metadata->>''status'';
+            v_output := p_metadata->>''output'';
+
+            IF v_orchestration_name IS NOT NULL AND v_orchestration_version IS NOT NULL THEN
+                INSERT INTO %I.instances (instance_id, orchestration_name, orchestration_version, current_execution_id, parent_instance_id, created_at, updated_at)
+                VALUES (v_instance_id, v_orchestration_name, v_orchestration_version, p_execution_id, v_parent_instance_id, v_now_ts, v_now_ts)
+                ON CONFLICT (instance_id) DO NOTHING;
+
+                UPDATE %I.instances i
+                SET orchestration_name = v_orchestration_name,
+                    orchestration_version = v_orchestration_version,
+                    parent_instance_id = COALESCE(i.parent_instance_id, v_parent_instance_id),
+                    updated_at = v_now_ts
+                WHERE i.instance_id = v_instance_id;
+            END IF;
+
+            INSERT INTO %I.executions (instance_id, execution_id, status, started_at)
+            VALUES (v_instance_id, p_execution_id, ''Running'', v_now_ts)
+            ON CONFLICT (instance_id, execution_id) DO NOTHING;
+
+            UPDATE %I.instances i
+            SET current_execution_id = GREATEST(i.current_execution_id, p_execution_id),
+                updated_at = v_now_ts
+            WHERE i.instance_id = v_instance_id;
+
+            IF p_history_delta IS NOT NULL AND JSONB_ARRAY_LENGTH(p_history_delta) > 0 THEN
+                INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+                SELECT
+                    v_instance_id,
+                    p_execution_id,
+                    (elem->>''event_id'')::BIGINT,
+                    elem->>''event_type'',
+                    elem->>''event_data'',
+                    v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_history_delta) AS elem;
+            END IF;
+
+            IF v_status IS NOT NULL THEN
+                v_completed_at := CASE 
+                    WHEN v_status IN (''Completed'', ''Failed'') THEN v_now_ts 
+                    ELSE NULL 
+                END;
+                
+                UPDATE %I.executions e
+                SET status = v_status, output = v_output, completed_at = v_completed_at
+                WHERE e.instance_id = v_instance_id AND e.execution_id = p_execution_id;
+            END IF;
+
+            -- Store pinned duroxide version on execution if provided
+            IF p_metadata ? ''pinned_duroxide_version'' AND p_metadata->''pinned_duroxide_version'' IS NOT NULL
+               AND p_metadata->>''pinned_duroxide_version'' != ''null'' THEN
+                UPDATE %I.executions
+                SET duroxide_version_major = (p_metadata->''pinned_duroxide_version''->>''major'')::INTEGER,
+                    duroxide_version_minor = (p_metadata->''pinned_duroxide_version''->>''minor'')::INTEGER,
+                    duroxide_version_patch = (p_metadata->''pinned_duroxide_version''->>''patch'')::INTEGER
+                WHERE instance_id = v_instance_id AND execution_id = p_execution_id;
+            END IF;
+
+            -- Enqueue worker items with session_id support
+            IF p_worker_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_worker_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_worker_items) LOOP
+                    IF v_elem ? ''ActivityExecute'' THEN
+                        v_item_session_id := v_elem->''ActivityExecute''->>''session_id'';
+                    ELSE
+                        v_item_session_id := NULL;
+                    END IF;
+
+                    INSERT INTO %I.worker_queue (work_item, visible_at, created_at, session_id)
+                    VALUES (v_elem::TEXT, v_now_ts, v_now_ts, v_item_session_id);
+                END LOOP;
+            END IF;
+
+            IF p_orchestrator_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_orchestrator_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_orchestrator_items) LOOP
+                    IF v_elem ? ''StartOrchestration'' THEN
+                        v_item_instance_id := v_elem->''StartOrchestration''->>''instance'';
+                    ELSIF v_elem ? ''ContinueAsNew'' THEN
+                        v_item_instance_id := v_elem->''ContinueAsNew''->>''instance'';
+                    ELSIF v_elem ? ''TimerFired'' THEN
+                        v_item_instance_id := v_elem->''TimerFired''->>''instance'';
+                        v_fire_at_ms := (v_elem->''TimerFired''->>''fire_at_ms'')::BIGINT;
+                    ELSIF v_elem ? ''ActivityCompleted'' THEN
+                        v_item_instance_id := v_elem->''ActivityCompleted''->>''instance'';
+                    ELSIF v_elem ? ''ActivityFailed'' THEN
+                        v_item_instance_id := v_elem->''ActivityFailed''->>''instance'';
+                    ELSIF v_elem ? ''ExternalRaised'' THEN
+                        v_item_instance_id := v_elem->''ExternalRaised''->>''instance'';
+                    ELSIF v_elem ? ''CancelInstance'' THEN
+                        v_item_instance_id := v_elem->''CancelInstance''->>''instance'';
+                    ELSIF v_elem ? ''SubOrchCompleted'' THEN
+                        v_item_instance_id := v_elem->''SubOrchCompleted''->>''parent_instance'';
+                    ELSIF v_elem ? ''SubOrchFailed'' THEN
+                        v_item_instance_id := v_elem->''SubOrchFailed''->>''parent_instance'';
+                    ELSE
+                        v_item_instance_id := v_instance_id;
+                    END IF;
+
+                    IF v_elem ? ''TimerFired'' AND v_fire_at_ms IS NOT NULL AND v_fire_at_ms > 0 THEN
+                        v_visible_at := TO_TIMESTAMP(v_fire_at_ms / 1000.0);
+                    ELSE
+                        v_visible_at := v_now_ts;
+                    END IF;
+
+                    INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                    VALUES (v_item_instance_id, v_elem::TEXT, v_visible_at, v_now_ts);
+                    
+                    v_fire_at_ms := NULL;
+                END LOOP;
+            END IF;
+
+            -- Lock-Stealing: Delete worker queue entries for cancelled activities
+            IF p_cancelled_activities IS NOT NULL AND JSONB_ARRAY_LENGTH(p_cancelled_activities) > 0 THEN
+                FOR v_cancelled IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_cancelled_activities) LOOP
+                    v_cancelled_execution_id := (v_cancelled->>''execution_id'')::BIGINT;
+                    v_cancelled_activity_id := (v_cancelled->>''activity_id'')::BIGINT;
+                    
+                    DELETE FROM %I.worker_queue wq
+                    WHERE wq.work_item::JSONB ? ''ActivityExecute''
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''instance'') = v_instance_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''execution_id'')::BIGINT = v_cancelled_execution_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''id'')::BIGINT = v_cancelled_activity_id;
+                END LOOP;
+            END IF;
+
+            DELETE FROM %I.orchestrator_queue q WHERE q.lock_token = p_lock_token;
+
+            DELETE FROM %I.instance_locks il
+            WHERE il.instance_id = v_instance_id AND il.lock_token = p_lock_token;
+        END;
+        $ack_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 8: Update cleanup_schema to drop new functions and sessions table
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.cleanup_schema()', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.cleanup_schema()
+        RETURNS VOID AS $cleanup$
+        BEGIN
+            -- Drop tables first
+            DROP TABLE IF EXISTS %I.sessions CASCADE;
+            DROP TABLE IF EXISTS %I.instances CASCADE;
+            DROP TABLE IF EXISTS %I.executions CASCADE;
+            DROP TABLE IF EXISTS %I.history CASCADE;
+            DROP TABLE IF EXISTS %I.orchestrator_queue CASCADE;
+            DROP TABLE IF EXISTS %I.worker_queue CASCADE;
+            DROP TABLE IF EXISTS %I.instance_locks CASCADE;
+            DROP TABLE IF EXISTS %I._duroxide_migrations CASCADE;
+            
+            -- Drop all stored procedures
+            DROP FUNCTION IF EXISTS %I.cleanup_schema();
+            DROP FUNCTION IF EXISTS %I.list_instances();
+            DROP FUNCTION IF EXISTS %I.list_executions(TEXT);
+            DROP FUNCTION IF EXISTS %I.latest_execution_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.list_instances_by_status(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_execution_info(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.get_system_metrics();
+            DROP FUNCTION IF EXISTS %I.get_queue_depths(BIGINT);
+            DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT, TEXT);
+            DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.abandon_work_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.enqueue_orchestrator_work(TEXT, TEXT, TIMESTAMPTZ, BIGINT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB);
+            DROP FUNCTION IF EXISTS %I.abandon_orchestration_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.renew_orchestration_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_history(TEXT);
+            DROP FUNCTION IF EXISTS %I.fetch_history_with_execution(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.append_history(TEXT, BIGINT, JSONB, BIGINT);
+            DROP FUNCTION IF EXISTS %I.list_children(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_parent_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.delete_instances_atomic(TEXT[], BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.prune_executions(TEXT, INTEGER, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_session_lock(TEXT[], BIGINT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.cleanup_orphaned_sessions(BIGINT);
+            
+            -- Drop trigger functions (not schema-qualified, they use search_path)
+            DROP FUNCTION IF EXISTS notify_orch_work() CASCADE;
+            DROP FUNCTION IF EXISTS notify_worker_work() CASCADE;
+        END;
+        $cleanup$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name);
+
+    RAISE NOTICE 'Migration 0004: Added session support (sessions table, session routing in fetch, session piggybacking in ack/renew)';
+END $$;

--- a/sql/duroxide_upstream/0005_add_custom_status.sql
+++ b/sql/duroxide_upstream/0005_add_custom_status.sql
@@ -1,0 +1,371 @@
+-- Migration 0005: Add custom status support
+-- Description: Adds custom status support for orchestration instances.
+-- Adds custom_status and custom_status_version columns to instances table,
+-- updates ack_orchestration_item to handle custom status updates,
+-- and adds get_custom_status stored procedure for polling.
+
+-- Schema changes using unqualified names (search_path set by migration runner)
+ALTER TABLE instances ADD COLUMN IF NOT EXISTS custom_status TEXT;
+ALTER TABLE instances ADD COLUMN IF NOT EXISTS custom_status_version INTEGER NOT NULL DEFAULT 0;
+
+-- Stored procedure changes using schema-qualified names
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    -- ============================================================================
+    -- Part 1: Update ack_orchestration_item to handle custom_status
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_orchestration_item(
+            p_lock_token TEXT,
+            p_now_ms BIGINT,
+            p_execution_id BIGINT,
+            p_history_delta JSONB,
+            p_worker_items JSONB,
+            p_orchestrator_items JSONB,
+            p_metadata JSONB,
+            p_cancelled_activities JSONB DEFAULT ''[]''::JSONB
+        )
+        RETURNS VOID AS $ack_orch$
+        DECLARE
+            v_instance_id TEXT;
+            v_now_ts TIMESTAMPTZ;
+            v_orchestration_name TEXT;
+            v_orchestration_version TEXT;
+            v_parent_instance_id TEXT;
+            v_status TEXT;
+            v_output TEXT;
+            v_completed_at TIMESTAMPTZ;
+            v_elem JSONB;
+            v_visible_at TIMESTAMPTZ;
+            v_fire_at_ms BIGINT;
+            v_item_instance_id TEXT;
+            v_item_session_id TEXT;
+            v_cancelled JSONB;
+            v_cancelled_execution_id BIGINT;
+            v_cancelled_activity_id BIGINT;
+            v_custom_status_action TEXT;
+            v_custom_status_value TEXT;
+        BEGIN
+            v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+
+            SELECT il.instance_id INTO v_instance_id
+            FROM %I.instance_locks il
+            WHERE il.lock_token = p_lock_token AND il.locked_until > p_now_ms;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION ''Invalid lock token'';
+            END IF;
+
+            v_orchestration_name := p_metadata->>''orchestration_name'';
+            v_orchestration_version := p_metadata->>''orchestration_version'';
+            v_parent_instance_id := p_metadata->>''parent_instance_id'';
+            v_status := p_metadata->>''status'';
+            v_output := p_metadata->>''output'';
+
+            IF v_orchestration_name IS NOT NULL AND v_orchestration_version IS NOT NULL THEN
+                INSERT INTO %I.instances (instance_id, orchestration_name, orchestration_version, current_execution_id, parent_instance_id, created_at, updated_at)
+                VALUES (v_instance_id, v_orchestration_name, v_orchestration_version, p_execution_id, v_parent_instance_id, v_now_ts, v_now_ts)
+                ON CONFLICT (instance_id) DO NOTHING;
+
+                UPDATE %I.instances i
+                SET orchestration_name = v_orchestration_name,
+                    orchestration_version = v_orchestration_version,
+                    parent_instance_id = COALESCE(i.parent_instance_id, v_parent_instance_id),
+                    updated_at = v_now_ts
+                WHERE i.instance_id = v_instance_id;
+            END IF;
+
+            INSERT INTO %I.executions (instance_id, execution_id, status, started_at)
+            VALUES (v_instance_id, p_execution_id, ''Running'', v_now_ts)
+            ON CONFLICT (instance_id, execution_id) DO NOTHING;
+
+            UPDATE %I.instances i
+            SET current_execution_id = GREATEST(i.current_execution_id, p_execution_id),
+                updated_at = v_now_ts
+            WHERE i.instance_id = v_instance_id;
+
+            IF p_history_delta IS NOT NULL AND JSONB_ARRAY_LENGTH(p_history_delta) > 0 THEN
+                INSERT INTO %I.history (instance_id, execution_id, event_id, event_type, event_data, created_at)
+                SELECT
+                    v_instance_id,
+                    p_execution_id,
+                    (elem->>''event_id'')::BIGINT,
+                    elem->>''event_type'',
+                    elem->>''event_data'',
+                    v_now_ts
+                FROM JSONB_ARRAY_ELEMENTS(p_history_delta) AS elem;
+            END IF;
+
+            IF v_status IS NOT NULL THEN
+                v_completed_at := CASE 
+                    WHEN v_status IN (''Completed'', ''Failed'') THEN v_now_ts 
+                    ELSE NULL 
+                END;
+                
+                UPDATE %I.executions e
+                SET status = v_status, output = v_output, completed_at = v_completed_at
+                WHERE e.instance_id = v_instance_id AND e.execution_id = p_execution_id;
+            END IF;
+
+            -- Store pinned duroxide version on execution if provided
+            IF p_metadata ? ''pinned_duroxide_version'' AND p_metadata->''pinned_duroxide_version'' IS NOT NULL
+               AND p_metadata->>''pinned_duroxide_version'' != ''null'' THEN
+                UPDATE %I.executions
+                SET duroxide_version_major = (p_metadata->''pinned_duroxide_version''->>''major'')::INTEGER,
+                    duroxide_version_minor = (p_metadata->''pinned_duroxide_version''->>''minor'')::INTEGER,
+                    duroxide_version_patch = (p_metadata->''pinned_duroxide_version''->>''patch'')::INTEGER
+                WHERE instance_id = v_instance_id AND execution_id = p_execution_id;
+            END IF;
+
+            -- Handle custom_status update on instances table
+            v_custom_status_action := p_metadata->>''custom_status_action'';
+            IF v_custom_status_action = ''set'' THEN
+                v_custom_status_value := p_metadata->>''custom_status_value'';
+                UPDATE %I.instances
+                SET custom_status = v_custom_status_value,
+                    custom_status_version = custom_status_version + 1
+                WHERE instance_id = v_instance_id;
+            ELSIF v_custom_status_action = ''clear'' THEN
+                UPDATE %I.instances
+                SET custom_status = NULL,
+                    custom_status_version = custom_status_version + 1
+                WHERE instance_id = v_instance_id;
+            END IF;
+
+            -- Enqueue worker items with session_id support
+            IF p_worker_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_worker_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_worker_items) LOOP
+                    IF v_elem ? ''ActivityExecute'' THEN
+                        v_item_session_id := v_elem->''ActivityExecute''->>''session_id'';
+                    ELSE
+                        v_item_session_id := NULL;
+                    END IF;
+
+                    INSERT INTO %I.worker_queue (work_item, visible_at, created_at, session_id)
+                    VALUES (v_elem::TEXT, v_now_ts, v_now_ts, v_item_session_id);
+                END LOOP;
+            END IF;
+
+            IF p_orchestrator_items IS NOT NULL AND JSONB_ARRAY_LENGTH(p_orchestrator_items) > 0 THEN
+                FOR v_elem IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_orchestrator_items) LOOP
+                    IF v_elem ? ''StartOrchestration'' THEN
+                        v_item_instance_id := v_elem->''StartOrchestration''->>''instance'';
+                    ELSIF v_elem ? ''ContinueAsNew'' THEN
+                        v_item_instance_id := v_elem->''ContinueAsNew''->>''instance'';
+                    ELSIF v_elem ? ''TimerFired'' THEN
+                        v_item_instance_id := v_elem->''TimerFired''->>''instance'';
+                        v_fire_at_ms := (v_elem->''TimerFired''->>''fire_at_ms'')::BIGINT;
+                    ELSIF v_elem ? ''ActivityCompleted'' THEN
+                        v_item_instance_id := v_elem->''ActivityCompleted''->>''instance'';
+                    ELSIF v_elem ? ''ActivityFailed'' THEN
+                        v_item_instance_id := v_elem->''ActivityFailed''->>''instance'';
+                    ELSIF v_elem ? ''ExternalRaised'' THEN
+                        v_item_instance_id := v_elem->''ExternalRaised''->>''instance'';
+                    ELSIF v_elem ? ''CancelInstance'' THEN
+                        v_item_instance_id := v_elem->''CancelInstance''->>''instance'';
+                    ELSIF v_elem ? ''SubOrchCompleted'' THEN
+                        v_item_instance_id := v_elem->''SubOrchCompleted''->>''parent_instance'';
+                    ELSIF v_elem ? ''SubOrchFailed'' THEN
+                        v_item_instance_id := v_elem->''SubOrchFailed''->>''parent_instance'';
+                    ELSIF v_elem ? ''QueueMessage'' THEN
+                        v_item_instance_id := v_elem->''QueueMessage''->>''instance'';
+                    ELSE
+                        v_item_instance_id := v_instance_id;
+                    END IF;
+
+                    IF v_elem ? ''TimerFired'' AND v_fire_at_ms IS NOT NULL AND v_fire_at_ms > 0 THEN
+                        v_visible_at := TO_TIMESTAMP(v_fire_at_ms / 1000.0);
+                    ELSE
+                        v_visible_at := v_now_ts;
+                    END IF;
+
+                    INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                    VALUES (v_item_instance_id, v_elem::TEXT, v_visible_at, v_now_ts);
+                    
+                    v_fire_at_ms := NULL;
+                END LOOP;
+            END IF;
+
+            -- Lock-Stealing: Delete worker queue entries for cancelled activities
+            IF p_cancelled_activities IS NOT NULL AND JSONB_ARRAY_LENGTH(p_cancelled_activities) > 0 THEN
+                FOR v_cancelled IN SELECT value FROM JSONB_ARRAY_ELEMENTS(p_cancelled_activities) LOOP
+                    v_cancelled_execution_id := (v_cancelled->>''execution_id'')::BIGINT;
+                    v_cancelled_activity_id := (v_cancelled->>''activity_id'')::BIGINT;
+                    
+                    DELETE FROM %I.worker_queue wq
+                    WHERE wq.work_item::JSONB ? ''ActivityExecute''
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''instance'') = v_instance_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''execution_id'')::BIGINT = v_cancelled_execution_id
+                      AND (wq.work_item::JSONB->''ActivityExecute''->>''id'')::BIGINT = v_cancelled_activity_id;
+                END LOOP;
+            END IF;
+
+            DELETE FROM %I.orchestrator_queue q WHERE q.lock_token = p_lock_token;
+
+            DELETE FROM %I.instance_locks il
+            WHERE il.instance_id = v_instance_id AND il.lock_token = p_lock_token;
+        END;
+        $ack_orch$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 2: Update ack_worker to validate lock expiry
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.ack_worker(TEXT)', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.ack_worker(
+            p_lock_token TEXT,
+            p_instance_id TEXT DEFAULT NULL,
+            p_completion_json TEXT DEFAULT NULL,
+            p_now_ms BIGINT DEFAULT NULL
+        )
+        RETURNS VOID AS $ack_worker$
+        DECLARE
+            v_rows_affected INTEGER;
+            v_now_ts TIMESTAMPTZ;
+            v_session_id TEXT;
+        BEGIN
+            -- Capture session_id before deleting
+            SELECT session_id INTO v_session_id
+            FROM %I.worker_queue WHERE lock_token = p_lock_token;
+
+            -- Delete the worker queue item, only if lock is still valid
+            IF p_now_ms IS NOT NULL THEN
+                DELETE FROM %I.worker_queue WHERE lock_token = p_lock_token AND locked_until > p_now_ms;
+            ELSE
+                DELETE FROM %I.worker_queue WHERE lock_token = p_lock_token;
+            END IF;
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION ''Worker queue item not found or already processed'';
+            END IF;
+
+            -- Only enqueue completion if provided (NULL means cancelled activity)
+            IF p_completion_json IS NOT NULL THEN
+                -- Validate required parameters for completion
+                IF p_instance_id IS NULL THEN
+                    RAISE EXCEPTION ''p_instance_id is required when p_completion_json is provided'';
+                END IF;
+                IF p_now_ms IS NULL THEN
+                    RAISE EXCEPTION ''p_now_ms is required when p_completion_json is provided'';
+                END IF;
+                
+                v_now_ts := TO_TIMESTAMP(p_now_ms / 1000.0);
+                INSERT INTO %I.orchestrator_queue (instance_id, work_item, visible_at, created_at)
+                VALUES (p_instance_id, p_completion_json, v_now_ts, v_now_ts);
+            END IF;
+
+            -- Piggyback: update session last_activity_at
+            IF v_session_id IS NOT NULL AND p_now_ms IS NOT NULL THEN
+                UPDATE %I.sessions SET last_activity_at = p_now_ms
+                WHERE session_id = v_session_id AND locked_until > p_now_ms;
+            END IF;
+        END;
+        $ack_worker$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 3: Create get_custom_status stored procedure
+    -- ============================================================================
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.get_custom_status(
+            p_instance_id TEXT,
+            p_last_seen_version BIGINT
+        )
+        RETURNS TABLE(
+            out_custom_status TEXT,
+            out_custom_status_version BIGINT
+        ) AS $get_cs$
+        BEGIN
+            RETURN QUERY
+            SELECT i.custom_status, i.custom_status_version::BIGINT
+            FROM %I.instances i
+            WHERE i.instance_id = p_instance_id
+              AND i.custom_status_version > p_last_seen_version;
+        END;
+        $get_cs$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name);
+
+    -- ============================================================================
+    -- Part 4: Update cleanup_schema to drop new function
+    -- ============================================================================
+
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.cleanup_schema()', v_schema_name);
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I.cleanup_schema()
+        RETURNS VOID AS $cleanup$
+        BEGIN
+            -- Drop tables first
+            DROP TABLE IF EXISTS %I.sessions CASCADE;
+            DROP TABLE IF EXISTS %I.instances CASCADE;
+            DROP TABLE IF EXISTS %I.executions CASCADE;
+            DROP TABLE IF EXISTS %I.history CASCADE;
+            DROP TABLE IF EXISTS %I.orchestrator_queue CASCADE;
+            DROP TABLE IF EXISTS %I.worker_queue CASCADE;
+            DROP TABLE IF EXISTS %I.instance_locks CASCADE;
+            DROP TABLE IF EXISTS %I._duroxide_migrations CASCADE;
+            
+            -- Drop all stored procedures
+            DROP FUNCTION IF EXISTS %I.cleanup_schema();
+            DROP FUNCTION IF EXISTS %I.list_instances();
+            DROP FUNCTION IF EXISTS %I.list_executions(TEXT);
+            DROP FUNCTION IF EXISTS %I.latest_execution_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.list_instances_by_status(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_instance_info(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_execution_info(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.get_system_metrics();
+            DROP FUNCTION IF EXISTS %I.get_queue_depths(BIGINT);
+            DROP FUNCTION IF EXISTS %I.enqueue_worker_work(TEXT, BIGINT, TEXT);
+            DROP FUNCTION IF EXISTS %I.ack_worker(TEXT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_work_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_work_item(BIGINT, BIGINT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.abandon_work_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.enqueue_orchestrator_work(TEXT, TEXT, TIMESTAMPTZ, BIGINT, TEXT, TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_orchestration_item(BIGINT, BIGINT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.ack_orchestration_item(TEXT, BIGINT, BIGINT, JSONB, JSONB, JSONB, JSONB, JSONB);
+            DROP FUNCTION IF EXISTS %I.abandon_orchestration_item(TEXT, BIGINT, BIGINT, BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.renew_orchestration_item_lock(TEXT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.fetch_history(TEXT);
+            DROP FUNCTION IF EXISTS %I.fetch_history_with_execution(TEXT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.append_history(TEXT, BIGINT, JSONB, BIGINT);
+            DROP FUNCTION IF EXISTS %I.list_children(TEXT);
+            DROP FUNCTION IF EXISTS %I.get_parent_id(TEXT);
+            DROP FUNCTION IF EXISTS %I.delete_instances_atomic(TEXT[], BOOLEAN);
+            DROP FUNCTION IF EXISTS %I.prune_executions(TEXT, INTEGER, BIGINT);
+            DROP FUNCTION IF EXISTS %I.renew_session_lock(TEXT[], BIGINT, BIGINT, BIGINT);
+            DROP FUNCTION IF EXISTS %I.cleanup_orphaned_sessions(BIGINT);
+            DROP FUNCTION IF EXISTS %I.get_custom_status(TEXT, BIGINT);
+            
+            -- Drop trigger functions (not schema-qualified, they use search_path)
+            DROP FUNCTION IF EXISTS notify_orch_work() CASCADE;
+            DROP FUNCTION IF EXISTS notify_worker_work() CASCADE;
+        END;
+        $cleanup$ LANGUAGE plpgsql;
+    ', v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name, v_schema_name,
+       v_schema_name, v_schema_name, v_schema_name);
+
+    RAISE NOTICE 'Migration 0005: Added custom status support (custom_status/custom_status_version columns, get_custom_status function, updated ack_orchestration_item)';
+END $$;

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,7 @@ use duroxide_pg_opt::PostgresProvider;
 use pgrx::prelude::*;
 use tokio::runtime::Runtime;
 
-use crate::types::{postgres_connection_string, DUROXIDE_SCHEMA};
+use crate::types::{backend_provider_config, postgres_connection_string};
 
 /// Cached tokio runtime for client operations.
 static CLIENT_RUNTIME: OnceLock<Runtime> = OnceLock::new();
@@ -39,7 +39,7 @@ fn get_duroxide_client() -> Result<&'static Client, String> {
 
     rt.block_on(async {
         let store = Arc::new(
-            PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA))
+            PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
                 .await
                 .map_err(|e| format!("Failed to connect to duroxide store: {e}"))?,
         );

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -124,7 +124,7 @@ fn explain_instance(instance_id: &str) -> String {
 
 /// Get instance info from Duroxide store
 fn get_duroxide_instance_info(instance_id: &str) -> (String, Option<String>) {
-    use crate::types::{postgres_connection_string, DUROXIDE_SCHEMA};
+    use crate::types::{backend_provider_config, postgres_connection_string};
     use duroxide::Client;
     use duroxide_pg_opt::PostgresProvider;
     use std::sync::Arc;
@@ -140,11 +140,12 @@ fn get_duroxide_instance_info(instance_id: &str) -> (String, Option<String>) {
     };
 
     rt.block_on(async {
-        let store =
-            match PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA)).await {
-                Ok(s) => Arc::new(s),
-                Err(_) => return (String::new(), None),
-            };
+        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
+            .await
+        {
+            Ok(s) => Arc::new(s),
+            Err(_) => return (String::new(), None),
+        };
 
         let client = Client::new(store);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,69 @@ CREATE TABLE IF NOT EXISTS df.vars (
 );
 
 // ============================================================================
+// Extension Validation (must run before duroxide schema creation)
+// ============================================================================
+
+// In production builds, validate that the extension is created in the database
+// the background worker will connect to.  In pgrx test builds the test database
+// name is chosen by pgrx and won't match the worker's target database, so we
+// skip the check (unit tests don't need the background worker).
+
+#[cfg(not(any(test, feature = "pg_test")))]
+extension_sql!(
+    r#"
+-- Validate that CREATE EXTENSION is run in the correct database
+-- The background worker connects to one specific database (determined by
+-- POSTGRES_DB or PGDATABASE environment variable). The extension must be
+-- created in that database for workflows to execute.
+DO $$
+DECLARE
+    current_db TEXT;
+    target_db TEXT;
+BEGIN
+    -- Get the current database
+    SELECT current_database() INTO current_db;
+    
+    -- Get the target database that the background worker will connect to
+    SELECT df.target_database() INTO target_db;
+    
+    IF current_db != target_db THEN
+        RAISE EXCEPTION 'pg_durable extension must be created in database "%" (currently in "%"). The background worker only processes functions in the database specified by POSTGRES_DB or PGDATABASE environment variable (defaults to "postgres").', target_db, current_db
+            USING HINT = 'Connect to the correct database and run: CREATE EXTENSION pg_durable;';
+    END IF;
+END $$;
+"#,
+    name = "validate_database",
+    requires = [df, target_database]
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+extension_sql!(
+    r#"
+-- Test build: skip database validation.
+-- pgrx creates a test database whose name differs from the background worker's
+-- target database.  The worker won't run in the test database; unit tests that
+-- exercise duroxide use direct tokio runtimes instead.
+DO $$
+BEGIN
+    RAISE NOTICE 'pg_durable: database validation skipped (test build)';
+END $$;
+"#,
+    name = "validate_database",
+    requires = [df]
+);
+
+// ============================================================================
+// Duroxide Schema (experimental hand-over)
+// ============================================================================
+
+extension_sql_file!(
+    "../sql/duroxide_install.sql",
+    name = "duroxide_migrations_install",
+    requires = ["validate_database"]
+);
+
+// ============================================================================
 // SQL Operators
 // ============================================================================
 
@@ -247,7 +310,7 @@ mod tests {
 
     /// Ensure the Duroxide store exists and is ready
     fn ensure_store_ready() -> Result<String, String> {
-        use crate::types::{postgres_connection_string, DUROXIDE_SCHEMA};
+        use crate::types::{backend_provider_config, postgres_connection_string, DUROXIDE_SCHEMA};
         use duroxide_pg_opt::PostgresProvider;
         use std::time::{Duration, Instant};
 
@@ -263,8 +326,10 @@ mod tests {
             let start = Instant::now();
             let timeout = Duration::from_secs(10);
 
+            let config = backend_provider_config();
+
             loop {
-                match PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA)).await {
+                match PostgresProvider::new_with_config(&pg_conn_str, config.clone()).await {
                     Ok(_) => return Ok(format!("{pg_conn_str} (schema: {DUROXIDE_SCHEMA})")),
                     Err(e) => {
                         if start.elapsed() > timeout {
@@ -283,7 +348,7 @@ mod tests {
 
     /// Wait for a durable function to complete, polling Duroxide status
     fn wait_for_completion(instance_id: &str, timeout_secs: u64) -> Result<String, String> {
-        use crate::types::{postgres_connection_string, DUROXIDE_SCHEMA};
+        use crate::types::{backend_provider_config, postgres_connection_string};
         use duroxide::Client;
         use duroxide_pg_opt::PostgresProvider;
         use std::time::{Duration, Instant};
@@ -302,7 +367,7 @@ mod tests {
 
         rt.block_on(async {
             let store = Arc::new(
-                PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA))
+                PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
                     .await
                     .map_err(|e| format!("Failed to connect to store: {e}"))?,
             );
@@ -345,7 +410,7 @@ mod tests {
 
     /// Get the current status from Duroxide
     fn get_duroxide_status(instance_id: &str) -> Option<String> {
-        use crate::types::{postgres_connection_string, DUROXIDE_SCHEMA};
+        use crate::types::{backend_provider_config, postgres_connection_string};
         use duroxide::Client;
         use duroxide_pg_opt::PostgresProvider;
 
@@ -359,7 +424,7 @@ mod tests {
 
         rt.block_on(async {
             let store = Arc::new(
-                PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA))
+                PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
                     .await
                     .ok()?,
             );

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -6,7 +6,7 @@ use duroxide::Client;
 use pgrx::prelude::*;
 use std::sync::Arc;
 
-use crate::types::{postgres_connection_string, DUROXIDE_SCHEMA};
+use crate::types::{backend_provider_config, postgres_connection_string};
 use duroxide_pg_opt::PostgresProvider;
 
 // ============================================================================
@@ -54,11 +54,12 @@ pub fn list_instances(
     };
 
     let results = rt.block_on(async {
-        let store =
-            match PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA)).await {
-                Ok(s) => Arc::new(s),
-                Err(_) => return vec![],
-            };
+        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
+            .await
+        {
+            Ok(s) => Arc::new(s),
+            Err(_) => return vec![],
+        };
 
         let client = Client::new(store);
 
@@ -131,11 +132,12 @@ pub fn instance_info(
     };
 
     let results = rt.block_on(async {
-        let store =
-            match PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA)).await {
-                Ok(s) => Arc::new(s),
-                Err(_) => return vec![],
-            };
+        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
+            .await
+        {
+            Ok(s) => Arc::new(s),
+            Err(_) => return vec![],
+        };
 
         let client = Client::new(store);
 
@@ -183,11 +185,12 @@ pub fn instance_executions(
     };
 
     let results = rt.block_on(async {
-        let store =
-            match PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA)).await {
-                Ok(s) => Arc::new(s),
-                Err(_) => return vec![],
-            };
+        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
+            .await
+        {
+            Ok(s) => Arc::new(s),
+            Err(_) => return vec![],
+        };
 
         let client = Client::new(store);
 
@@ -247,11 +250,12 @@ pub fn metrics() -> TableIterator<
     };
 
     let results = rt.block_on(async {
-        let store =
-            match PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA)).await {
-                Ok(s) => Arc::new(s),
-                Err(_) => return vec![],
-            };
+        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
+            .await
+        {
+            Ok(s) => Arc::new(s),
+            Err(_) => return vec![],
+        };
 
         let client = Client::new(store);
 
@@ -350,11 +354,12 @@ pub fn instance_nodes(
     };
 
     let results = rt.block_on(async {
-        let store =
-            match PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA)).await {
-                Ok(s) => Arc::new(s),
-                Err(_) => return vec![],
-            };
+        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
+            .await
+        {
+            Ok(s) => Arc::new(s),
+            Err(_) => return vec![],
+        };
 
         let client = Client::new(store);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,8 +49,45 @@ pub fn postgres_connection_string() -> String {
     format!("postgres://{user}@{host}:{port}/{database}")
 }
 
+/// Get the target database name that the background worker will connect to
+/// This matches the logic in postgres_connection_string() for database selection
+#[pg_extern(immutable, parallel_safe, schema = "df")]
+pub fn target_database() -> String {
+    std::env::var("POSTGRES_DB")
+        .or_else(|_| std::env::var("PGDATABASE"))
+        .unwrap_or_else(|_| "postgres".to_string())
+}
+
 /// Schema name for Duroxide internal tables
 pub const DUROXIDE_SCHEMA: &str = "duroxide";
+
+/// Create a `ProviderConfig` for backend (request/response) operations.
+///
+/// - `VerifyOnly`: never create schema/tables
+/// - `long_poll` disabled: avoid a dedicated listener connection per backend session
+/// - `reject_unknown_migrations`: fail if schema is ahead of code
+pub fn backend_provider_config() -> duroxide_pg_opt::ProviderConfig {
+    let mut config = duroxide_pg_opt::ProviderConfig::default();
+    config.schema_name = Some(DUROXIDE_SCHEMA.to_string());
+    config.migration_policy = duroxide_pg_opt::MigrationPolicy::VerifyOnly;
+    config.long_poll.enabled = false;
+    config.reject_unknown_migrations = true;
+    config
+}
+
+/// Create a `ProviderConfig` for the background worker runtime.
+///
+/// - `VerifyOnly`: never create schema/tables
+/// - Long-polling intentionally left enabled (default) for the BGW runtime,
+///   unlike backend sessions where it's disabled to save resources.
+/// - `reject_unknown_migrations`: fail if schema is ahead of code
+pub fn worker_provider_config() -> duroxide_pg_opt::ProviderConfig {
+    let mut config = duroxide_pg_opt::ProviderConfig::default();
+    config.schema_name = Some(DUROXIDE_SCHEMA.to_string());
+    config.migration_policy = duroxide_pg_opt::MigrationPolicy::VerifyOnly;
+    config.reject_unknown_migrations = true;
+    config
+}
 
 /// Calculate the duration until the next cron schedule match
 pub fn calculate_cron_wait(cron_expr: &str) -> Result<Duration, String> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -63,29 +63,25 @@ pub const DUROXIDE_SCHEMA: &str = "duroxide";
 
 /// Create a `ProviderConfig` for backend (request/response) operations.
 ///
-/// - `VerifyOnly`: never create schema/tables
+/// - `VerifyOnly`: never create schema/tables, reject unknown migrations
 /// - `long_poll` disabled: avoid a dedicated listener connection per backend session
-/// - `reject_unknown_migrations`: fail if schema is ahead of code
 pub fn backend_provider_config() -> duroxide_pg_opt::ProviderConfig {
     let mut config = duroxide_pg_opt::ProviderConfig::default();
     config.schema_name = Some(DUROXIDE_SCHEMA.to_string());
     config.migration_policy = duroxide_pg_opt::MigrationPolicy::VerifyOnly;
     config.long_poll.enabled = false;
-    config.reject_unknown_migrations = true;
     config
 }
 
 /// Create a `ProviderConfig` for the background worker runtime.
 ///
-/// - `VerifyOnly`: never create schema/tables
+/// - `VerifyOnly`: never create schema/tables, reject unknown migrations
 /// - Long-polling intentionally left enabled (default) for the BGW runtime,
 ///   unlike backend sessions where it's disabled to save resources.
-/// - `reject_unknown_migrations`: fail if schema is ahead of code
 pub fn worker_provider_config() -> duroxide_pg_opt::ProviderConfig {
     let mut config = duroxide_pg_opt::ProviderConfig::default();
     config.schema_name = Some(DUROXIDE_SCHEMA.to_string());
     config.migration_policy = duroxide_pg_opt::MigrationPolicy::VerifyOnly;
-    config.reject_unknown_migrations = true;
     config
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -14,7 +14,7 @@ use sqlx::postgres::PgPoolOptions;
 use tracing_subscriber::EnvFilter;
 
 use crate::registry::{create_activity_registry, create_orchestration_registry};
-use crate::types::{postgres_connection_string, DUROXIDE_SCHEMA};
+use crate::types::{postgres_connection_string, worker_provider_config, DUROXIDE_SCHEMA};
 
 /// Initialize tracing subscriber for duroxide logs.
 /// Must be called before Runtime::start_with_store() to capture all logs.
@@ -80,106 +80,183 @@ pub extern "C-unwind" fn duroxide_worker_main(_arg: pg_sys::Datum) {
 
 /// Run the duroxide runtime with proper shutdown handling
 async fn run_duroxide_runtime() {
-    log!("pg_durable: initializing duroxide runtime with PostgreSQL store...");
+    const WAIT_FOR_EXTENSION_POLL_INTERVAL: Duration = Duration::from_secs(5);
+    const EXTENSION_DROP_POLL_INTERVAL: Duration = Duration::from_secs(5);
+    const INIT_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+    const SHUTDOWN_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
     let pg_conn_str = postgres_connection_string();
     log!(
-        "pg_durable: connecting to PostgreSQL at {} (schema: {})",
+        "pg_durable: background worker connected to PostgreSQL at {} (schema: {})",
         pg_conn_str,
         DUROXIDE_SCHEMA
     );
 
-    // Retry connection with exponential backoff (useful for pg_regress tests where database may not exist yet)
-    let store = loop {
-        match PostgresProvider::new_with_schema(&pg_conn_str, Some(DUROXIDE_SCHEMA)).await {
-            Ok(s) => break Arc::new(s),
-            Err(e) => {
-                log!(
-                    "pg_durable: failed to create PostgreSQL store (will retry): {}",
-                    e
-                );
-
-                // Check for shutdown before retrying
-                if tokio::task::spawn_blocking(is_shutdown_requested)
-                    .await
-                    .unwrap_or(false)
-                {
-                    log!("pg_durable: shutdown requested during connection retry, exiting");
-                    return;
-                }
-
-                // Retry after 5 seconds
-                tokio::time::sleep(Duration::from_secs(5)).await;
-            }
+    // Single-connection pool reused for all extension-existence polling, avoiding
+    // the overhead of opening/closing a TCP connection on every check.
+    let poll_pool = match sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&pg_conn_str)
+        .await
+    {
+        Ok(pool) => pool,
+        Err(e) => {
+            log!(
+                "pg_durable: failed to create polling pool (will retry via restart): {}",
+                e
+            );
+            return;
         }
     };
 
-    log!(
-        "pg_durable: PostgreSQL store created in schema '{}'",
-        DUROXIDE_SCHEMA
-    );
+    loop {
+        if is_shutdown_requested() {
+            log!("pg_durable: shutdown requested, exiting");
+            break;
+        }
 
-    // Create connection pool with session variable marking workflow context
-    let pg_pool = loop {
-        match PgPoolOptions::new()
+        if !wait_for_extension_creation(&poll_pool, WAIT_FOR_EXTENSION_POLL_INTERVAL).await {
+            break;
+        }
+
+        let Some(duroxide_runtime) =
+            initialize_duroxide_runtime(&pg_conn_str, INIT_RETRY_INTERVAL, &poll_pool).await
+        else {
+            // Shutdown requested or extension dropped while initializing.
+            continue;
+        };
+
+        run_until_extension_dropped_or_shutdown(
+            &poll_pool,
+            duroxide_runtime,
+            EXTENSION_DROP_POLL_INTERVAL,
+            SHUTDOWN_CHECK_INTERVAL,
+        )
+        .await;
+    }
+
+    poll_pool.close().await;
+}
+
+async fn wait_for_extension_creation(poll_pool: &sqlx::PgPool, poll_interval: Duration) -> bool {
+    log!("pg_durable: waiting for CREATE EXTENSION pg_durable...");
+
+    loop {
+        if is_shutdown_requested() {
+            log!("pg_durable: shutdown requested while waiting for extension");
+            return false;
+        }
+
+        if check_extension_exists(poll_pool).await {
+            log!("pg_durable: extension detected, proceeding with initialization");
+            return true;
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+async fn check_extension_exists(pool: &sqlx::PgPool) -> bool {
+    let result: Result<(bool,), sqlx::Error> =
+        sqlx::query_as("SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pg_durable')")
+            .fetch_one(pool)
+            .await;
+
+    result.map(|(exists,)| exists).unwrap_or(false)
+}
+
+async fn initialize_duroxide_runtime(
+    pg_conn_str: &str,
+    retry_interval: Duration,
+    poll_pool: &sqlx::PgPool,
+) -> Option<Arc<runtime::Runtime>> {
+    log!("pg_durable: initializing duroxide runtime...");
+
+    loop {
+        if is_shutdown_requested() {
+            log!("pg_durable: shutdown requested during initialization");
+            return None;
+        }
+
+        if !check_extension_exists(poll_pool).await {
+            log!("pg_durable: extension no longer exists; returning to wait state");
+            return None;
+        }
+
+        let store =
+            match PostgresProvider::new_with_config(pg_conn_str, worker_provider_config()).await {
+                Ok(s) => Arc::new(s),
+                Err(e) => {
+                    log!(
+                        "pg_durable: failed to create PostgreSQL store (will retry): {}",
+                        e
+                    );
+                    tokio::time::sleep(retry_interval).await;
+                    continue;
+                }
+            };
+
+        let pg_pool = match PgPoolOptions::new()
             .max_connections(5)
             .after_connect(|conn, _meta| {
                 Box::pin(async move {
-                    // Mark this connection as being used by the workflow runtime
                     sqlx::query("SET df.in_workflow = 'true'")
                         .execute(&mut *conn)
                         .await?;
                     Ok(())
                 })
             })
-            .connect(&pg_conn_str)
+            .connect(pg_conn_str)
             .await
         {
-            Ok(pool) => {
-                log!("pg_durable: PostgreSQL connection pool created");
-                break Arc::new(pool);
-            }
+            Ok(pool) => Arc::new(pool),
             Err(e) => {
                 log!(
                     "pg_durable: failed to create PostgreSQL pool (will retry): {}",
                     e
                 );
-
-                // Check for shutdown before retrying
-                if tokio::task::spawn_blocking(is_shutdown_requested)
-                    .await
-                    .unwrap_or(false)
-                {
-                    log!("pg_durable: shutdown requested during pool creation, exiting");
-                    return;
-                }
-
-                // Retry after 5 seconds
-                tokio::time::sleep(Duration::from_secs(5)).await;
+                tokio::time::sleep(retry_interval).await;
+                continue;
             }
-        }
-    };
+        };
 
-    // Create registries
-    let activities = create_activity_registry(pg_pool);
-    let orchestrations = create_orchestration_registry();
+        let activities = create_activity_registry(pg_pool);
+        let orchestrations = create_orchestration_registry();
 
-    let duroxide_runtime =
-        runtime::Runtime::start_with_store(store.clone(), activities, orchestrations).await;
+        let duroxide_runtime =
+            runtime::Runtime::start_with_store(store, activities, orchestrations).await;
 
-    log!("pg_durable: duroxide runtime started, processing durable functions...");
+        log!("pg_durable: duroxide runtime started");
+        return Some(duroxide_runtime);
+    }
+}
 
-    // Keep runtime alive until shutdown signal
+async fn run_until_extension_dropped_or_shutdown(
+    poll_pool: &sqlx::PgPool,
+    duroxide_runtime: Arc<runtime::Runtime>,
+    drop_poll_interval: Duration,
+    shutdown_check_interval: Duration,
+) {
+    log!("pg_durable: processing durable functions...");
+
+    let mut drop_check = tokio::time::interval(drop_poll_interval);
+    drop_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
     loop {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        let should_shutdown = tokio::task::spawn_blocking(is_shutdown_requested)
-            .await
-            .unwrap_or(false);
-
-        if should_shutdown {
-            log!("pg_durable: shutdown signal received, stopping duroxide runtime...");
-            break;
+        tokio::select! {
+            _ = tokio::time::sleep(shutdown_check_interval) => {
+                // is_shutdown_requested reads a volatile atomic; no spawn_blocking needed.
+                if is_shutdown_requested() {
+                    log!("pg_durable: shutdown signal received");
+                    break;
+                }
+            }
+            _ = drop_check.tick() => {
+                if !check_extension_exists(poll_pool).await {
+                    log!("pg_durable: extension has been dropped");
+                    break;
+                }
+            }
         }
     }
 

--- a/tests/e2e/sql/26_bgw_lifecycle.sql
+++ b/tests/e2e/sql/26_bgw_lifecycle.sql
@@ -1,0 +1,126 @@
+-- Test: Background worker lifecycle (wait for extension + detect drop)
+--
+-- Validates MVP behavior:
+-- 1) With pg_durable preloaded but extension not created, BGW should not create duroxide schema.
+-- 2) After CREATE EXTENSION, workflows execute.
+-- 3) After DROP EXTENSION, duroxide schema is removed and BGW returns to waiting.
+-- 4) After re-create, workflows execute again.
+
+-- Ensure a clean starting point
+DROP EXTENSION IF EXISTS pg_durable CASCADE;
+
+-- 1) Verify BGW does not create duroxide schema pre-extension
+DO $$
+DECLARE
+    exists_before BOOLEAN;
+    exists_after BOOLEAN;
+BEGIN
+    SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = 'duroxide') INTO exists_before;
+    IF exists_before THEN
+        RAISE EXCEPTION 'TEST FAILED: duroxide schema exists before CREATE EXTENSION';
+    END IF;
+
+    -- Give BGW time to do the wrong thing (it should remain idle)
+    PERFORM pg_sleep(6);
+
+    SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = 'duroxide') INTO exists_after;
+    IF exists_after THEN
+        RAISE EXCEPTION 'TEST FAILED: duroxide schema was created before CREATE EXTENSION';
+    END IF;
+
+    RAISE NOTICE 'PASSED: BGW did not create duroxide schema pre-extension';
+END $$;
+
+-- 2) Create extension and run a simple workflow
+CREATE EXTENSION pg_durable;
+
+CREATE TEMP TABLE _test_state (instance_id TEXT);
+INSERT INTO _test_state
+SELECT df.start('SELECT 42 as answer', 'test-bgw-lifecycle-1');
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    result TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED: expected completed, got %', status;
+    END IF;
+
+    SELECT r INTO result FROM df.result(inst_id) r;
+    IF result NOT LIKE '%42%' THEN
+        RAISE EXCEPTION 'TEST FAILED: result should contain 42, got %', result;
+    END IF;
+
+    RAISE NOTICE 'PASSED: workflow completed after CREATE EXTENSION';
+END $$;
+
+DROP TABLE _test_state;
+
+-- 3) Drop extension and verify schema removed
+DROP EXTENSION pg_durable CASCADE;
+
+DO $$
+DECLARE
+    schema_exists BOOLEAN;
+BEGIN
+    -- DDL is synchronous; schema should be gone immediately
+    SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = 'duroxide') INTO schema_exists;
+    IF schema_exists THEN
+        RAISE EXCEPTION 'TEST FAILED: duroxide schema still exists after DROP EXTENSION';
+    END IF;
+
+    -- Give BGW time to detect drop and return to waiting
+    PERFORM pg_sleep(6);
+
+    RAISE NOTICE 'PASSED: DROP EXTENSION removed duroxide schema';
+END $$;
+
+-- 4) Re-create extension and run another workflow
+CREATE EXTENSION pg_durable;
+
+CREATE TEMP TABLE _test_state2 (instance_id TEXT);
+INSERT INTO _test_state2
+SELECT df.start('SELECT 43 as answer', 'test-bgw-lifecycle-2');
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    result TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state2;
+
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED: expected completed after recreate, got %', status;
+    END IF;
+
+    SELECT r INTO result FROM df.result(inst_id) r;
+    IF result NOT LIKE '%43%' THEN
+        RAISE EXCEPTION 'TEST FAILED: result should contain 43, got %', result;
+    END IF;
+
+    RAISE NOTICE 'PASSED: workflow completed after re-create';
+END $$;
+
+DROP TABLE _test_state2;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/27_database_validation.sql
+++ b/tests/e2e/sql/27_database_validation.sql
@@ -1,0 +1,127 @@
+-- Test: Database validation during CREATE EXTENSION
+--
+-- Validates that CREATE EXTENSION fails when run in a database that doesn't
+-- match the one the background worker connects to.
+--
+-- The background worker connects to ONE database (specified by POSTGRES_DB or
+-- PGDATABASE environment variable, defaulting to 'postgres'). The extension
+-- must be created in that exact database.
+--
+-- This test validates that:
+-- 1) CREATE EXTENSION succeeds in the correct database
+-- 2) Workflows execute in the correct database
+-- 3) CREATE EXTENSION actually fails with a clear error in a wrong database
+--
+-- NOTE: Test 00_requires_shared_preload.sql already validates the
+--       shared_preload_libraries requirement.
+
+-- We use dblink to attempt CREATE EXTENSION in a different database
+CREATE EXTENSION IF NOT EXISTS dblink;
+
+-- First, verify we're running in the correct database
+-- (This test assumes it's running in the database the BGW connects to)
+DO $$
+DECLARE
+    current_db TEXT;
+    target_db TEXT;
+BEGIN
+    SELECT current_database() INTO current_db;
+    SELECT df.target_database() INTO target_db;
+    
+    IF current_db != target_db THEN
+        RAISE EXCEPTION 'TEST SETUP ERROR: This test must run in database "%" (currently in "%")', target_db, current_db;
+    END IF;
+    
+    RAISE NOTICE 'Test running in correct database: %', current_db;
+END $$;
+
+-- ============================================================================
+-- Test 1: CREATE EXTENSION should succeed in the correct database
+-- ============================================================================
+DROP EXTENSION IF EXISTS pg_durable CASCADE;
+CREATE EXTENSION pg_durable;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_durable') THEN
+        RAISE EXCEPTION 'TEST FAILED: Extension should exist in correct database';
+    END IF;
+    RAISE NOTICE 'PASSED: CREATE EXTENSION succeeded in correct database';
+END $$;
+
+-- ============================================================================
+-- Test 2: Verify workflows can execute (BGW is connected to this database)
+-- ============================================================================
+CREATE TEMP TABLE _test_state (instance_id TEXT);
+INSERT INTO _test_state
+SELECT df.start('SELECT 42 as answer', 'test-correct-db');
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+    
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+    
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED: Workflow should complete in correct database, got status: %', status;
+    END IF;
+    
+    RAISE NOTICE 'PASSED: Workflow executed successfully in correct database';
+END $$;
+
+DROP TABLE _test_state;
+
+-- ============================================================================
+-- Test 3: CREATE EXTENSION must fail in a wrong database
+-- ============================================================================
+-- Create a throwaway database, connect to it via dblink, and verify that
+-- CREATE EXTENSION pg_durable is rejected with the expected error message.
+
+DROP DATABASE IF EXISTS _test_wrong_db;
+CREATE DATABASE _test_wrong_db;
+
+DO $$
+DECLARE
+    connstr TEXT;
+    err_msg TEXT;
+BEGIN
+    connstr := format(
+        'host=localhost dbname=_test_wrong_db port=%s',
+        current_setting('port')
+    );
+
+    -- Attempt CREATE EXTENSION in the wrong database via dblink
+    BEGIN
+        PERFORM dblink_exec(connstr, 'CREATE EXTENSION pg_durable;');
+        -- If we get here, the guard did not fire
+        RAISE EXCEPTION 'TEST FAILED: CREATE EXTENSION should have been rejected in wrong database';
+    EXCEPTION WHEN OTHERS THEN
+        err_msg := SQLERRM;
+    END;
+
+    -- Verify the error message mentions the expected keywords
+    IF err_msg NOT ILIKE '%must be created in database%' THEN
+        RAISE EXCEPTION 'TEST FAILED: Expected "must be created in database" in error, got: %', err_msg;
+    END IF;
+    IF err_msg NOT ILIKE '%_test_wrong_db%' THEN
+        RAISE EXCEPTION 'TEST FAILED: Expected wrong db name in error, got: %', err_msg;
+    END IF;
+
+    RAISE NOTICE 'PASSED: CREATE EXTENSION correctly rejected in wrong database';
+    RAISE NOTICE 'Error was: %', err_msg;
+END $$;
+
+-- Cleanup
+DROP DATABASE IF EXISTS _test_wrong_db;
+
+SELECT 'TEST PASSED' AS result;
+


### PR DESCRIPTION
## Extension lifecycle management and duroxide schema ownership

Implements proper PostgreSQL extension lifecycle for pg_durable: the duroxide schema is now created by `CREATE EXTENSION` (not imperatively by the background worker), and the background worker waits for the extension to exist before initializing.

### Key changes

#### Extension-managed schema (duroxide DDL as extension SQL)

- Duroxide provider schema DDL is shipped as extension SQL, executed by PostgreSQL during `CREATE EXTENSION pg_durable`
- Schema objects are registered as extension members — `DROP EXTENSION pg_durable CASCADE` removes them cleanly
- Upstream migration SQL is checked into `sql/duroxide_upstream/` and combined into `sql/duroxide_install.sql` via `scripts/gen-duroxide-install-sql.sh`
- CI verifies checked-in copies match upstream via `scripts/verify-duroxide-migrations.sh`

#### Background worker lifecycle state machine

- BGW polls `pg_extension` until `pg_durable` exists, then initializes the duroxide runtime
- While running, polls for extension drop every 5s; on drop, shuts down and returns to waiting
- Uses a single reusable `sqlx::PgPool(max_connections=1)` for polling
- All code paths use `MigrationPolicy::VerifyOnly` — no implicit DDL anywhere

#### `CREATE EXTENSION` prerequisite validation

- Fails if `pg_durable` is not in `shared_preload_libraries`
- Fails if run in the wrong database (BGW connects to one database only, determined by `POSTGRES_DB`/`PGDATABASE` env var)

#### Backend sessions: no implicit DDL, no long-polling

- `backend_provider_config()` and `worker_provider_config()` in `src/types.rs` centralize `ProviderConfig` construction
- Backend calls (`src/client.rs`, `src/monitoring.rs`, `src/explain.rs`) use `VerifyOnly` + `long_poll.enabled = false`
- BGW keeps long-polling enabled for work dispatch

### New files

| File | Purpose |
|------|---------|
| `sql/duroxide_upstream/0001..0005_*.sql` | Verbatim copies of duroxide-pg-opt migrations |
| `sql/duroxide_install.sql` | Generated combined install SQL (do not edit manually) |
| `scripts/gen-duroxide-install-sql.sh` | Generates `duroxide_install.sql` from upstream copies |
| `scripts/verify-duroxide-migrations.sh` | Verifies upstream copies match duroxide-pg-opt |
| `src/types.rs` | `worker_provider_config()` / `backend_provider_config()` helpers |
| `tests/e2e/sql/26_bgw_lifecycle.sql` | E2E: BGW waits for extension, initializes after CREATE, re-initializes after DROP+CREATE |
| `tests/e2e/sql/27_database_validation.sql` | E2E: CREATE EXTENSION fails in wrong database with clear error |
| `docs/extension_lifecycle.md` | Full design document |

### Testing

- Unit tests via `cargo pgrx test pg17`
- E2E tests: `26_bgw_lifecycle.sql` (lifecycle state machine) and `27_database_validation.sql` (wrong-database validation)
- CI: migration verification step added to `.github/workflows/ci.yml`

### Design document

See [`docs/extension_lifecycle.md`](docs/extension_lifecycle.md) for the full design, rationale, state machine diagram, and future work (utility hooks, multi-database support, extension upgrades).
