### PR TITLE
Add pg_durable.worker_role GUC and use -U postgres consistently

### DIFF
--- a/scripts/pg-start.sh
+++ b/scripts/pg-start.sh
@@ -33,14 +33,18 @@ cargo pgrx install --pg-config "$PG_CONFIG" 2>&1 | grep -v "^warning:" || true
 # Initialize data directory if it doesn't exist
 if [ ! -d "$DATA_DIR" ]; then
     echo -e "\033[0;33mInitializing PostgreSQL data directory...\033[0m"
-    "$PGRX_BIN_DIR/initdb" -D "$DATA_DIR" 2>/dev/null || true
+    "$PGRX_BIN_DIR/initdb" -D "$DATA_DIR" -U postgres 2>/dev/null || true
 fi
 
-# Configure shared_preload_libraries for background worker
+# Configure shared_preload_libraries for background worker and pg_durable.worker_role
 if [ -f "$PG_CONF" ]; then
     if ! grep -q "shared_preload_libraries.*pg_durable" "$PG_CONF"; then
         echo -e "\033[0;33mConfiguring shared_preload_libraries...\033[0m"
         echo "shared_preload_libraries = 'pg_durable'" >> "$PG_CONF"
+    fi
+    if ! grep -q "^pg_durable.worker_role" "$PG_CONF"; then
+        echo -e "\033[0;33mConfiguring pg_durable.worker_role...\033[0m"
+        echo "pg_durable.worker_role = 'postgres'" >> "$PG_CONF"
     fi
 fi
 
@@ -55,16 +59,13 @@ for i in {1..30}; do
     sleep 0.2
 done
 
-# Create extension if needed
-"$PGRX_BIN_DIR/psql" -h localhost -p 28817 -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_durable;" 2>/dev/null || true
-
 # Show version
-VERSION=$("$PGRX_BIN_DIR/psql" -h localhost -p 28817 -d postgres -t -c "SELECT df.version();" 2>/dev/null | tr -d ' \n')
+VERSION=$("$PGRX_BIN_DIR/psql" -h localhost -p 28817 -U postgres -d postgres -t -c "SELECT df.version();" 2>/dev/null | tr -d ' \n')
 echo -e "\033[0;32mPostgreSQL started with pg_durable $VERSION\033[0m"
 
 echo ""
 echo -e "\033[0;36mConnect:\033[0m"
-echo "  $PGRX_BIN_DIR/psql -h localhost -p 28817 -d postgres"
+echo "  $PGRX_BIN_DIR/psql -h localhost -p 28817 -U postgres -d postgres"
 echo ""
 echo -e "\033[0;36mLogs:\033[0m"
 echo "  tail -f ~/.pgrx/17.log"

--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -79,7 +79,7 @@ done
 # pgrx settings
 PGRX_HOME="$HOME/.pgrx"
 PG_PORT="$((28800 + PG_VERSION))"
-PG_USER="$USER"
+PG_USER="postgres"
 PG_DB="postgres"
 
 # Default non-privileged role for E2E tests (created by 00_setup_playground.sql)
@@ -149,6 +149,11 @@ ensure_config() {
             sed -i.bak '/^#*shared_preload_libraries/d' "$DATA_DIR/postgresql.conf"
             echo "shared_preload_libraries = 'pg_durable'" >> "$DATA_DIR/postgresql.conf"
         fi
+        # Ensure worker_role is set
+        if ! grep -q "^pg_durable.worker_role" "$DATA_DIR/postgresql.conf" 2>/dev/null; then
+            echo "Configuring pg_durable.worker_role..."
+            echo "pg_durable.worker_role = 'postgres'" >> "$DATA_DIR/postgresql.conf"
+        fi
         # Ensure port is set
         if ! grep -q "^port = $PG_PORT" "$DATA_DIR/postgresql.conf" 2>/dev/null; then
             sed -i.bak '/^#*port = /d' "$DATA_DIR/postgresql.conf"
@@ -187,7 +192,7 @@ start_server() {
     # Initialize if needed
     if [ ! -d "$DATA_DIR" ]; then
         echo "Initializing database..."
-        "$PGRX_BIN/initdb" -D "$DATA_DIR" --no-locale -E UTF8 >/dev/null 2>&1
+        "$PGRX_BIN/initdb" -D "$DATA_DIR" -U postgres --no-locale -E UTF8 >/dev/null 2>&1
     fi
     
     # Ensure config is correct (with or without preload)
@@ -202,7 +207,7 @@ start_server() {
     # 2. Restart server (so background worker reconnects with fresh cached plans)
     if "$PG_ISREADY" -h localhost -p $PG_PORT &>/dev/null; then
         # Drop schemas before restart (background worker will recreate on reconnect)
-        "$PSQL" -h localhost -p $PG_PORT -d $PG_DB -c "DROP SCHEMA IF EXISTS duroxide CASCADE; DROP EXTENSION IF EXISTS pg_durable CASCADE;" >/dev/null 2>&1
+        "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -c "DROP SCHEMA IF EXISTS duroxide CASCADE; DROP EXTENSION IF EXISTS pg_durable CASCADE;" >/dev/null 2>&1
         echo -e "${YELLOW}Restarting PostgreSQL to reload extension...${NC}"
         stop_server
     fi
@@ -215,10 +220,10 @@ start_server() {
     if [ "$NO_PRELOAD" = true ]; then
         # Drop extension if it exists from a previous run (e.g., unit tests)
         # so the no-preload test can verify CREATE EXTENSION fails correctly
-        "$PSQL" -h localhost -p $PG_PORT -d $PG_DB -c "DROP EXTENSION IF EXISTS pg_durable CASCADE; DROP SCHEMA IF EXISTS duroxide CASCADE;" >/dev/null 2>&1
+        "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -c "DROP EXTENSION IF EXISTS pg_durable CASCADE; DROP SCHEMA IF EXISTS duroxide CASCADE;" >/dev/null 2>&1
     else
         # Create extension (duroxide schema will be created by background worker on first connect)
-        "$PSQL" -h localhost -p $PG_PORT -d $PG_DB -c "CREATE EXTENSION IF NOT EXISTS pg_durable;" >/dev/null 2>&1
+        "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -c "CREATE EXTENSION IF NOT EXISTS pg_durable;" >/dev/null 2>&1
     fi
 }
 
@@ -242,7 +247,7 @@ start_server
 # Show version and run setup (only when extension is loaded, not in --no-preload mode)
 if [ "$NO_PRELOAD" = false ]; then
     echo -n "pg_durable version: "
-    "$PSQL" -h localhost -p $PG_PORT -d $PG_DB -t -c "SELECT df.version();" 2>/dev/null | tr -d ' \n'
+    "$PSQL" -h localhost -p $PG_PORT -U $PG_USER -d $PG_DB -t -c "SELECT df.version();" 2>/dev/null | tr -d ' \n'
     echo ""
     echo ""
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,16 @@
 //! This extension provides durable, fault-tolerant function execution within PostgreSQL
 //! using the Duroxide runtime for persistence.
 
+use pgrx::guc::*;
 use pgrx::prelude::*;
+use std::ffi::CString;
+
+// ============================================================================
+// GUC Definitions
+// ============================================================================
+
+pub static WORKER_ROLE: GucSetting<Option<CString>> =
+    GucSetting::<Option<CString>>::new(Some(c"azuresu"));
 
 // Module declarations
 pub mod activities;
@@ -32,6 +41,15 @@ pub extern "C-unwind" fn _PG_init() {
             "pg_durable must be loaded via shared_preload_libraries.\n\nHINT: Add 'pg_durable' to shared_preload_libraries in postgresql.conf and restart the server."
         );
     }
+    GucRegistry::define_string_guc(
+        c"pg_durable.worker_role",
+        c"PostgreSQL role used by the pg_durable background worker",
+        c"",
+        &WORKER_ROLE,
+        GucContext::Postmaster,
+        GucFlags::default(),
+    );
+
     worker::register_background_worker();
 }
 
@@ -1554,6 +1572,9 @@ pub mod pg_test {
 
     #[must_use]
     pub fn postgresql_conf_options() -> Vec<&'static str> {
-        vec!["shared_preload_libraries = 'pg_durable'"]
+        vec![
+            "shared_preload_libraries = 'pg_durable'",
+            "pg_durable.worker_role = 'postgres'",
+        ]
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use cron::Schedule as CronSchedule;
 use pgrx::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::ffi::CString;
 use std::str::FromStr;
 use std::time::Duration;
 use uuid::Uuid;
@@ -11,6 +12,15 @@ use uuid::Uuid;
 // ============================================================================
 // Configuration Functions
 // ============================================================================
+
+/// Get the worker role from the `pg_durable.worker_role` GUC.
+/// Falls back to `"azuresu"` if the GUC is not set.
+pub fn get_worker_role() -> String {
+    crate::WORKER_ROLE
+        .get()
+        .map(|cs: CString| cs.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "azuresu".to_string())
+}
 
 /// Generate a short 8-character instance ID from a UUID
 pub fn short_id() -> String {
@@ -29,9 +39,7 @@ pub fn short_id() -> String {
 pub fn postgres_connection_string() -> String {
     let host = std::env::var("PGHOST").unwrap_or_else(|_| "127.0.0.1".to_string());
     let port = unsafe { pgrx::pg_sys::PostPortNumber };
-    let user = std::env::var("PGUSER")
-        .or_else(|_| std::env::var("USER"))
-        .unwrap_or_else(|_| "postgres".to_string());
+    let user = get_worker_role();
     let database = std::env::var("POSTGRES_DB")
         .or_else(|_| std::env::var("PGDATABASE"))
         .unwrap_or_else(|_| "postgres".to_string());

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -82,7 +82,7 @@ pub extern "C-unwind" fn duroxide_worker_main(_arg: pg_sys::Datum) {
 async fn run_duroxide_runtime() {
     const WAIT_FOR_EXTENSION_POLL_INTERVAL: Duration = Duration::from_secs(5);
     const EXTENSION_DROP_POLL_INTERVAL: Duration = Duration::from_secs(5);
-    const INIT_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+    const INIT_RETRY_INTERVAL: Duration = Duration::from_secs(1);
     const SHUTDOWN_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
     let pg_conn_str = postgres_connection_string();

--- a/tests/e2e/sql/22_cross_connection.sql
+++ b/tests/e2e/sql/22_cross_connection.sql
@@ -18,7 +18,7 @@ CREATE TABLE cross_conn_log (
 -- This simulates an external system or different user session
 -- Use host=localhost to force TCP connection instead of socket
 CREATE TEMP TABLE _dblink_conn AS 
-SELECT format('host=localhost dbname=postgres port=%s', current_setting('port')) AS connstr;
+SELECT format('host=localhost dbname=postgres port=%s user=postgres', current_setting('port')) AS connstr;
 
 -- ============================================================================
 -- Test 1: Signal from Different Connection

--- a/tests/e2e/sql/23_transactions.sql
+++ b/tests/e2e/sql/23_transactions.sql
@@ -173,7 +173,7 @@ END $$;
 
 DO $$
 DECLARE
-    connstr TEXT := 'host=localhost dbname=postgres port=28817';
+    connstr TEXT := format('host=localhost dbname=postgres port=%s user=postgres', current_setting('port'));
     result TEXT;
     instance_count INT;
 BEGIN

--- a/tests/e2e/sql/29_database_validation.sql
+++ b/tests/e2e/sql/29_database_validation.sql
@@ -95,7 +95,7 @@ DECLARE
     err_msg TEXT;
 BEGIN
     connstr := format(
-        'host=localhost dbname=_test_wrong_db port=%s',
+        'host=localhost dbname=_test_wrong_db port=%s user=postgres',
         current_setting('port')
     );
 


### PR DESCRIPTION
Replace PGUSER/USER env var detection with a Postmaster-context GUC (default: `azuresu`). Scripts and e2e tests updated to connect as `postgres` and include `user=` in dblink connection strings.

### Changes
- **src/lib.rs**: Add `WORKER_ROLE` static GUC, register in `_PG_init()`, add to `pg_test::postgresql_conf_options()`
- **src/types.rs**: Add `get_worker_role()` reading the GUC; replace env var logic in `postgres_connection_string()`
- **src/worker.rs**: Reduce `INIT_RETRY_INTERVAL` from 5s to 1s
- **scripts/pg-start.sh**: `-U postgres` on initdb, add worker_role config, remove CREATE EXTENSION, update connect help
- **scripts/test-e2e-local.sh**: `PG_USER=postgres`, `-U postgres` on initdb and psql, add worker_role config
- **tests/e2e/sql/22,23,29**: Add `user=postgres` to dblink connection strings