### PR TITLE
ci: optimize caching and guard pgrx setup steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,23 +98,46 @@ jobs:
               libxslt1-dev \
               libicu-dev
 
-      - name: Cache cargo registry
+      - name: Cache cargo dependencies
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.pgrx
+            ~/.cargo/bin/cargo-pgrx
             target
-          key: ${{ runner.os }}-cargo-pgrx-pg${{ matrix.pg_version }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-pg${{ matrix.pg_version }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-pgrx-pg${{ matrix.pg_version }}-
+            ${{ runner.os }}-cargo-pg${{ matrix.pg_version }}-
+
+      - name: Cache PostgreSQL build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pgrx/config.toml
+            ~/.pgrx/${{ matrix.pg_version }}.*
+          key: ${{ runner.os }}-pgrx-pg${{ matrix.pg_version }}
+
+      # Always remove stale data directories to prevent flaky tests
+      # from leftover state. The data dir is cheap to recreate (~1s).
+      - name: Remove cached data directory
+        run: rm -rf "$HOME/.pgrx/data-${{ matrix.pg_version }}"
 
       - name: Install cargo-pgrx
-        run: cargo install cargo-pgrx --version 0.16.1 --locked
+        run: |
+          if ! command -v cargo-pgrx &> /dev/null || ! cargo pgrx --version | grep -q "0.16.1"; then
+            cargo install cargo-pgrx --version 0.16.1 --locked
+          else
+            echo "cargo-pgrx 0.16.1 already installed, skipping"
+          fi
 
       - name: Initialize pgrx
-        run: cargo pgrx init --pg${{ matrix.pg_version }} download
+        run: |
+          if [ ! -d "$HOME/.pgrx/${{ matrix.pg_version }}."* ]; then
+            cargo pgrx init --pg${{ matrix.pg_version }} download
+          else
+            echo "PostgreSQL ${{ matrix.pg_version }} already initialized, skipping download"
+          fi
 
       - name: Configure git credentials for private repos
         run: |


### PR DESCRIPTION
## Changes

- **Split single cache into two separate caches:**
  - **Cargo dependencies** (`~/.cargo/registry`, `~/.cargo/git`, `cargo-pgrx`, `target`) — keyed on `Cargo.lock` hash + PG version
  - **PostgreSQL build** (`~/.pgrx/config.toml`, `~/.pgrx/$PG_VERSION.*`) — keyed on PG version only (stable across dependency changes)

- **Exclude data directory from cache** — `~/.pgrx/data-*` (66 MB) was being cached with stale PG state, causing flaky tests. It only takes ~1s to recreate via `initdb`. An explicit removal step ensures no stale data leaks through.

- **Guard `cargo-pgrx` install** — skip if version 0.16.1 is already installed from cache (~30-60s saved)

- **Guard `pgrx init`** — skip PG download+compile if the build directory already exists (~2-5min saved)

## Why

Caching the PG data directory was the root cause of sporadic CI test failures. The `--clean` flag in E2E scripts was a workaround, but unit tests (`cargo pgrx test`) could still hit stale state. This eliminates the problem at the source.