### PR TITLE
[DO NOT MERGE] Implement RLS and use SPI for PG backend interaction with duroxide

### DIFF
--- a/docs/design-backend-spi.md
+++ b/docs/design-backend-spi.md
@@ -1,0 +1,356 @@
+# Backend SPI: Eliminate sqlx from PostgreSQL Backend Processes
+
+**Status:** In progress — SPI code done, permissions/RLS design needed
+**Branch:** `pinodeca/backend-spi`
+
+## Motivation
+
+pg_durable runs inside the PostgreSQL server as an extension. When a user calls
+`df.start()`, `df.status()`, or any other `df.*` function, that code executes in
+the user's PostgreSQL backend process.
+
+Previously, these backend functions created **TCP connections back to the same
+PostgreSQL instance** via sqlx connection pools, plus a tokio async runtime, just
+to perform simple enqueue or query operations. This was because the code shared
+the same `duroxide::Client` / `duroxide_pg_opt::PostgresProvider` abstraction
+used by the background worker. Those sqlx connections authenticated as the
+superuser worker role, bypassing any permission checks on the duroxide schema.
+
+| Problem | Impact |
+|---------|--------|
+| Each backend creates a tokio runtime | Unnecessary memory and thread overhead per session |
+| Each backend opens sqlx TCP connections | Loopback TCP to the same server, authentication overhead |
+| `OnceLock<Runtime>` + `OnceLock<Client>` cached per process | Process-lifetime resource leak |
+| Simple INSERT/SELECT wrapped in async | Conceptual complexity for synchronous operations |
+| sqlx connections run as superuser | All users implicitly get superuser access to duroxide tables |
+
+**Solution:** Use PostgreSQL's native SPI (Server Programming Interface) for all
+backend operations. SPI calls run in-process with the caller's identity — no
+network connections, no authentication, and no async runtime. The duroxide stored
+procedures (`duroxide.enqueue_orchestrator_work()`, `duroxide.get_instance_info()`,
+etc.) are already installed as part of `CREATE EXTENSION pg_durable`.
+
+Because SPI runs as the calling user (not the superuser), this change requires
+explicit GRANT and RLS policies on both the `df` and `duroxide` schemas to
+ensure users can only access their own data.
+
+The background worker continues to use sqlx/TCP as the superuser role, since
+the Duroxide runtime requires an async `Provider` trait implementation
+(`Send + Sync`) which SPI cannot satisfy, and the superuser bypasses RLS.
+
+---
+
+## Code Changes
+
+### client.rs — Client Operations via SPI
+
+**Before:** `df.start()`, `df.cancel()`, `df.signal()` created a cached
+`tokio::Runtime` + `duroxide::Client` (backed by sqlx pool) and called
+`client.start_orchestration()` / `client.cancel_instance()` /
+`client.raise_event()` via `block_on()`.
+
+**After:** A single `enqueue_orchestrator_work()` helper builds the WorkItem JSON
+using `serde_json::json!` and calls `duroxide.enqueue_orchestrator_work()` via
+`Spi::connect()`. No async runtime, no connection pool, no TCP.
+
+**Removed dependencies (from backend path):**
+- `duroxide::Client`
+- `duroxide_pg_opt::PostgresProvider`
+- `tokio::Runtime` / `OnceLock<Runtime>`
+- `std::sync::Arc`
+
+### monitoring.rs — Monitoring via SPI
+
+**Before:** Each monitoring function (`list_instances`, `instance_info`,
+`instance_executions`, `metrics`, `instance_nodes`) created a tokio runtime +
+PostgresProvider and called `duroxide::Client` methods via `block_on()`.
+
+**After:** Direct SPI queries against duroxide stored procedures
+(`list_instances()`, `get_instance_info()`, `get_execution_info()`,
+`get_system_metrics()`, `list_executions()`).
+
+### explain.rs — Instance Info Lookup via SPI
+
+**Before:** `get_duroxide_instance_info()` created a tokio runtime +
+PostgresProvider to call `client.get_instance_info()`.
+
+**After:** Direct SPI query against `duroxide.get_instance_info()`.
+
+### Why SPI Cannot Replace the BGW Provider
+
+The background worker runs the Duroxide runtime, which requires a `Provider`
+implementation that is `Send + Sync` and supports concurrent async calls from
+multiple `tokio::spawn` tasks (orchestration dispatchers, lock renewal, session
+management). PostgreSQL's SPI is `!Send + !Sync`, synchronous, and bound to
+the PostgreSQL backend thread — fundamentally incompatible with the `Provider`
+trait. The BGW correctly continues to use `duroxide-pg-opt` via sqlx.
+
+---
+
+## Permission & RLS Design
+
+### The Problem
+
+With sqlx, backend calls ran as the superuser (worker role), so no permissions
+were needed on duroxide objects. With SPI, calls run as the calling user.
+The duroxide schema functions are all `SECURITY INVOKER` (the plpgsql default)
+and do direct DML on duroxide tables, so the calling user needs:
+
+1. `USAGE` on the `duroxide` schema
+2. `EXECUTE` on the duroxide functions called by SPI
+3. Table-level privileges matching what those functions do internally
+4. Row-level security so users only see/modify their own data
+
+### Schema Inventory
+
+**`df` schema** (pg_durable's own tables):
+
+| Table | User-facing columns | User-identity column |
+|-------|-------------------|---------------------|
+| `df.instances` | id, label, root_node, status, ... | `submitted_by REGROLE` |
+| `df.nodes` | id, instance_id, node_type, query, status, result, ... | `submitted_by REGROLE` |
+| `df.vars` | name, value | _(none — session-scoped)_ |
+| `df._worker_epoch` | epoch_id, started_at | _(internal — BGW only)_ |
+
+**`duroxide` schema** (runtime engine tables):
+
+| Table | User access needed | User-identity column |
+|-------|-------------------|---------------------|
+| `instances` | SELECT (monitoring) | _(none)_ |
+| `executions` | SELECT (monitoring) | _(none)_ |
+| `history` | SELECT (execution info counts events) | _(none)_ |
+| `orchestrator_queue` | INSERT (start/cancel/signal) | _(none)_ |
+| `worker_queue` | _(BGW only)_ | _(none)_ |
+| `instance_locks` | _(BGW only)_ | _(none)_ |
+| `sessions` | _(BGW only)_ | _(none)_ |
+
+**Key challenge:** Duroxide tables have no user-identity column. RLS policies
+must JOIN to `df.instances.submitted_by` to determine ownership.
+
+### What Each SPI Call Needs
+
+**Client operations** (client.rs):
+
+| df function | Duroxide function called | Table access needed |
+|-------------|------------------------|-------------------|
+| `df.start()` | `duroxide.enqueue_orchestrator_work()` | INSERT on `orchestrator_queue` |
+| `df.cancel()` | `duroxide.enqueue_orchestrator_work()` | INSERT on `orchestrator_queue` |
+| `df.signal()` | `duroxide.enqueue_orchestrator_work()` | INSERT on `orchestrator_queue` |
+
+**Monitoring operations** (monitoring.rs):
+
+| df function | Duroxide functions called | Table access needed |
+|-------------|-------------------------|-------------------|
+| `df.list_instances()` | `list_instances()`, `list_instances_by_status()`, `get_instance_info()` | SELECT on `instances`, `executions` |
+| `df.instance_info()` | `get_instance_info()` | SELECT on `instances`, `executions` |
+| `df.instance_executions()` | `list_executions()`, `get_execution_info()` | SELECT on `executions`, `history` |
+| `df.metrics()` | `get_system_metrics()` | SELECT on `instances`, `executions`, `history` |
+| `df.instance_nodes()` | `list_executions()` | SELECT on `executions` |
+
+**Explain** (explain.rs):
+
+| df function | Duroxide function called | Table access needed |
+|-------------|------------------------|-------------------|
+| `df.explain()` | `get_instance_info()` | SELECT on `instances`, `executions` |
+
+### GRANTs Required
+
+Added to the extension SQL (runs at `CREATE EXTENSION` time):
+
+```sql
+-- Schema access
+GRANT USAGE ON SCHEMA duroxide TO PUBLIC;
+
+-- Function access (only the functions called by user-facing SPI)
+GRANT EXECUTE ON FUNCTION duroxide.enqueue_orchestrator_work TO PUBLIC;
+GRANT EXECUTE ON FUNCTION duroxide.list_instances TO PUBLIC;
+GRANT EXECUTE ON FUNCTION duroxide.list_instances_by_status TO PUBLIC;
+GRANT EXECUTE ON FUNCTION duroxide.get_instance_info TO PUBLIC;
+GRANT EXECUTE ON FUNCTION duroxide.list_executions TO PUBLIC;
+GRANT EXECUTE ON FUNCTION duroxide.get_execution_info TO PUBLIC;
+GRANT EXECUTE ON FUNCTION duroxide.get_system_metrics TO PUBLIC;
+
+-- Table access (minimum privileges for the functions above)
+GRANT INSERT ON duroxide.orchestrator_queue TO PUBLIC;
+GRANT SELECT ON duroxide.instances TO PUBLIC;
+GRANT SELECT ON duroxide.executions TO PUBLIC;
+GRANT SELECT ON duroxide.history TO PUBLIC;
+
+-- df schema tables (already needed for DSL operations)
+GRANT USAGE ON SCHEMA df TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE ON df.instances TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE ON df.nodes TO PUBLIC;
+GRANT SELECT, INSERT, DELETE ON df.vars TO PUBLIC;
+```
+
+> **Note:** Granting to `PUBLIC` is the simplest starting point. In
+> production, a dedicated `df_user` role could be used instead. RLS
+> (below) ensures that broad GRANTs don't leak data across users.
+
+### RLS Policies
+
+#### Design Principles
+
+1. **The BGW (superuser) bypasses RLS** — PostgreSQL does not enforce RLS on
+   superusers unless `ALTER TABLE ... FORCE ROW LEVEL SECURITY` is used. Since
+   the BGW connects as the superuser worker role, it is unaffected.
+
+2. **Ownership is determined by `df.instances.submitted_by`** — this column
+   stores the `REGROLE` of the user who called `df.start()`. All duroxide
+   tables are keyed by `instance_id`, allowing a JOIN to `df.instances`.
+
+3. **Unlinked nodes** (created by DSL operators before `df.start()`) have
+   `submitted_by IS NULL` and `instance_id IS NULL`. These are transient,
+   session-local rows. The RLS policy permits access to NULL-submitted nodes
+   so the DSL can build graphs before linking.
+
+#### `df.instances`
+
+```sql
+ALTER TABLE df.instances ENABLE ROW LEVEL SECURITY;
+
+-- Users see only instances they submitted
+CREATE POLICY df_instances_user ON df.instances
+    USING (submitted_by = current_user::regrole);
+
+-- Users can insert instances (submitted_by is set by df.start())
+CREATE POLICY df_instances_insert ON df.instances
+    FOR INSERT WITH CHECK (submitted_by = current_user::regrole);
+
+-- Users can update only their own instances
+CREATE POLICY df_instances_update ON df.instances
+    FOR UPDATE USING (submitted_by = current_user::regrole);
+```
+
+#### `df.nodes`
+
+```sql
+ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
+
+-- Users see their own nodes AND unlinked nodes (submitted_by IS NULL)
+CREATE POLICY df_nodes_user ON df.nodes
+    USING (submitted_by IS NULL OR submitted_by = current_user::regrole);
+
+-- Anyone can insert nodes (submitted_by is NULL at creation, set by df.start())
+CREATE POLICY df_nodes_insert ON df.nodes
+    FOR INSERT WITH CHECK (TRUE);
+
+-- Users can update their own nodes or unlinked nodes
+CREATE POLICY df_nodes_update ON df.nodes
+    FOR UPDATE USING (submitted_by IS NULL OR submitted_by = current_user::regrole);
+```
+
+#### `df.vars`
+
+`df.vars` is a session-scoped key-value store with no user column. Variables
+are set before `df.start()` and captured into the instance at start time.
+Since vars have no ownership tracking, no RLS is applied. This is acceptable
+because vars are ephemeral (set and read within a single session) and do not
+contain results or execution state.
+
+#### `duroxide.instances`
+
+```sql
+ALTER TABLE duroxide.instances ENABLE ROW LEVEL SECURITY;
+
+-- Users can only see duroxide instances that correspond to their df.instances
+CREATE POLICY duroxide_instances_user ON duroxide.instances
+    USING (instance_id IN (
+        SELECT id FROM df.instances WHERE submitted_by = current_user::regrole
+    ));
+```
+
+#### `duroxide.executions`
+
+```sql
+ALTER TABLE duroxide.executions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY duroxide_executions_user ON duroxide.executions
+    USING (instance_id IN (
+        SELECT id FROM df.instances WHERE submitted_by = current_user::regrole
+    ));
+```
+
+#### `duroxide.history`
+
+```sql
+ALTER TABLE duroxide.history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY duroxide_history_user ON duroxide.history
+    USING (instance_id IN (
+        SELECT id FROM df.instances WHERE submitted_by = current_user::regrole
+    ));
+```
+
+#### `duroxide.orchestrator_queue`
+
+```sql
+ALTER TABLE duroxide.orchestrator_queue ENABLE ROW LEVEL SECURITY;
+
+-- Users can insert work items only for their own instances
+CREATE POLICY duroxide_orch_queue_insert ON duroxide.orchestrator_queue
+    FOR INSERT WITH CHECK (instance_id IN (
+        SELECT id FROM df.instances WHERE submitted_by = current_user::regrole
+    ));
+```
+
+> Users do not need SELECT on `orchestrator_queue` — they never read from it.
+> The BGW (superuser) reads, locks, and deletes queue items.
+
+#### Tables with no user RLS needed
+
+| Table | Reason |
+|-------|--------|
+| `duroxide.worker_queue` | No GRANT to users — BGW only |
+| `duroxide.instance_locks` | No GRANT to users — BGW only |
+| `duroxide.sessions` | No GRANT to users — BGW only |
+| `df._worker_epoch` | No GRANT to users — BGW only |
+
+### Effect on `df.metrics()`
+
+`duroxide.get_system_metrics()` aggregates across ALL instances/executions/
+history. With RLS enabled, a non-superuser calling this function will only
+see counts for their own instances — the RLS policies filter the underlying
+table scans. This is **desirable behavior**: users should see metrics for
+their own workloads only.
+
+If a superuser calls `df.metrics()`, they see system-wide totals (RLS is
+bypassed for superusers).
+
+### Performance Considerations
+
+The RLS policies on duroxide tables use a subquery against `df.instances`:
+
+```sql
+instance_id IN (SELECT id FROM df.instances WHERE submitted_by = current_user::regrole)
+```
+
+This pattern is well-optimized by PostgreSQL's planner (semi-join). The
+existing `df.instances(id)` PRIMARY KEY index makes the lookup efficient.
+For workloads with many instances per user, an additional index may help:
+
+```sql
+CREATE INDEX idx_instances_submitted_by ON df.instances(submitted_by);
+```
+
+This index should be added with the RLS policies.
+
+### Implementation Order
+
+1. **Add GRANTs and RLS policies** to extension SQL (`src/lib.rs`)
+2. **Add `idx_instances_submitted_by` index** for RLS query performance
+3. **Update E2E setup** (`00_setup_playground.sql`) — remove manual GRANTs
+   that are now handled by extension SQL
+4. **Run full test suite** to verify
+
+---
+
+## Testing
+
+The existing E2E test suite validates all affected code paths:
+- `01_simple_sql.sql` through `08_loop_cancel.sql` — exercise `df.start()` (client.rs)
+- `09_monitoring.sql` — exercises `list_instances`, `instance_info`, `status`, `result`
+- `10_explain.sql` — exercises `df.explain()` with live instance lookup
+- `21_signals.sql` — exercises `df.signal()` (client.rs)
+- `22_cross_connection.sql` — exercises status/cancel across connections
+- `27_user_isolation.sql` — exercises multi-user isolation (will validate RLS)

--- a/docs/design-native-provider.md
+++ b/docs/design-native-provider.md
@@ -1,0 +1,558 @@
+# pg_durable Native Duroxide Provider — Design & POC
+
+**Status:** POC Complete — All 3 phases implemented, builds and passes clippy  
+**Created:** 2026-03-02  
+**Author:** GitHub Copilot (AI-assisted design exploration)  
+**Goal:** Evaluate replacing `duroxide-pg-opt` with a pg_durable-native Provider.
+
+## Table of Contents
+
+1. [Motivation](#motivation)
+2. [Architecture Analysis](#architecture-analysis)
+3. [Key Constraints](#key-constraints)
+4. [Approaches Evaluated](#approaches-evaluated)
+5. [Recommended Architecture](#recommended-architecture)
+6. [POC Plan](#poc-plan)
+7. [Learnings & Discarded Approaches](#learnings--discarded-approaches)
+8. [Open Questions](#open-questions)
+9. [Appendix: Provider Trait Summary](#appendix-provider-trait-summary)
+
+---
+
+## Motivation
+
+pg_durable currently depends on `duroxide-pg-opt` (an external crate) to implement the
+Duroxide `Provider` trait. This crate was designed for **applications** that store
+duroxide engine state in PostgreSQL via `sqlx` TCP connections.
+
+pg_durable is a **PostgreSQL extension** — it runs *inside* the database server. Using
+`duroxide-pg-opt` means:
+
+| Concern | Current Situation |
+|---------|------------------|
+| **Efficiency** | Both BGW and user sessions open TCP connections back to the same PG instance they're running inside |
+| **Security** | TCP connections require authentication; the extension connects to itself |
+| **Dependencies** | `sqlx`, `tokio`, and `duroxide-pg-opt` required in user sessions just for simple enqueue/status operations |
+| **Latency** | Every `df.start()`, `df.status()` call goes through TCP serialization/deserialization |
+| **Resource usage** | User sessions create connection pools (sqlx) + async runtimes (tokio) for operations that could be synchronous SPI calls |
+| **Schema coupling** | Must keep `sql/duroxide_upstream/` in sync with `duroxide-pg-opt` migrations manually |
+
+A native provider could address all of these — but the Duroxide runtime architecture
+imposes constraints that make a *simple* "replace everything with SPI" approach infeasible.
+
+---
+
+## Architecture Analysis
+
+### Execution Contexts in pg_durable
+
+pg_durable operates in **two distinct contexts**:
+
+#### 1. Backend Processes (User Sessions)
+
+These are regular PostgreSQL backend processes handling user SQL. Functions live in
+`src/dsl.rs`, `src/client.rs`, `src/monitoring.rs`, `src/explain.rs`.
+
+**Operations performed:**
+- `df.start()` → enqueue a `StartOrchestration` work item to the orchestrator queue
+- `df.cancel()` → enqueue a `CancelInstance` work item
+- `df.signal()` → enqueue an `ExternalRaised` work item
+- `df.status()` → read instance status from `duroxide.instances`
+- `df.list_instances()` → query instances table + metadata
+- `df.instance_info()` → query specific instance
+- `df.metrics()` → aggregate statistics
+- `df.explain()` → mixed SPI + async Client calls
+
+**Key property:** These are **request/response** — call a function, get a result, return.
+There is no long-running async work in user sessions.
+
+**Current implementation:** Creates a `tokio::Runtime` + `PostgresProvider` (sqlx pool)
+per session, uses `block_on()` for async calls.
+
+#### 2. Background Worker (BGW)
+
+A single PostgreSQL-managed background worker process (`src/worker.rs`).
+
+**Operations performed:**
+- Runs the Duroxide runtime (`Runtime::start_with_store`)
+- The runtime spawns multiple `tokio::spawn` tasks:
+  - Orchestration dispatchers (default: 2 concurrent)
+  - Activity dispatchers (default: 2 concurrent)
+  - Lock renewal tasks (1 per in-flight item)
+  - Session manager
+- All tasks share `Arc<dyn Provider>` and call Provider methods concurrently
+
+**Key property:** The Provider must be `Send + Sync` and handle concurrent async calls.
+
+**Current implementation:** `tokio::runtime::Builder::new_current_thread()` with
+`PostgresProvider` (sqlx pool over TCP).
+
+### Provider Trait Requirements
+
+The Duroxide `Provider` trait (from `duroxide::providers::Provider`) requires:
+- `#[async_trait] impl Provider for T where T: Any + Send + Sync`
+- ~15 required async methods, plus `ProviderAdmin` for management
+- Concurrent calls from multiple `tokio::spawn` tasks
+- Atomic transactions (especially `ack_orchestration_item`)
+
+### Why SPI Cannot Implement Provider Directly
+
+| Requirement | SPI Reality |
+|---|---|
+| `Send + Sync` | `SpiClient` is `!Send + !Sync` |
+| Concurrent async calls | SPI is single-threaded, synchronous |
+| Long-poll `fetch_*` (blocks 30s) | Would block the BGW OS thread |
+| Lock renewal runs in parallel | Cannot interleave with blocked fetch |
+| Must work from `tokio::spawn` | SPI requires PostgreSQL backend thread |
+
+**Even with `concurrency=1`**, the Duroxide runtime spawns lock renewal tasks via
+`tokio::spawn` that call Provider methods concurrently with the main dispatcher loop.
+A synchronous SPI call blocks the thread entirely, preventing any other tokio task
+from progressing.
+
+### PostgreSQL Low-Level Table APIs
+
+pgrx exposes `pg_sys::table_open()`, `heap_getnext()`, etc. However:
+- These also require a valid transaction context
+- They are synchronous, blocking C functions
+- They use process-local palloc memory — not safe across async task boundaries
+- **Same fundamental problem as SPI**
+
+---
+
+## Key Constraints
+
+1. **Provider trait is async + Send + Sync** — mandated by Duroxide runtime
+2. **BGW uses single-threaded tokio** — can't use `spawn_blocking` for SPI (SPI must
+   run on the BGW thread itself, and `spawn_blocking` uses a thread pool)
+3. **Duroxide runtime spawns concurrent tasks** — even at concurrency=1
+4. **SPI requires PostgreSQL backend thread** — cannot be called from spawned threads
+5. **Activities already use sqlx** — `execute_sql` activity needs network access to PG
+   (it runs user-supplied SQL in a workflow context with `df.in_workflow` set)
+
+---
+
+## Approaches Evaluated
+
+### Approach A: Full SPI Provider (Discarded)
+
+**Idea:** Implement all Provider methods using pgrx SPI inside `BackgroundWorker::transaction()`.
+
+**Why discarded:**
+- Provider methods called from `tokio::spawn` tasks — SPI cannot work from spawned tasks
+- `fetch_orchestration_item` does long-poll (blocks for poll_timeout) — would block
+  the single BGW thread, preventing lock renewals
+- Would need to serialize all Provider calls through a channel to a dedicated SPI thread
+- That SPI thread can't be the BGW thread (it's running tokio) and can't be a worker
+  thread (SPI requires the backend thread with `BackgroundWorkerInitializeConnection`)
+- **Fundamental architecture mismatch**
+
+### Approach B: Low-Level Table Access Provider (Discarded)
+
+**Idea:** Use `pg_sys::table_open()` etc. instead of SPI.
+
+**Why discarded:** Same constraints as SPI — requires transaction context, synchronous,
+cannot work from async tasks.
+
+### Approach C: Full Custom Provider with sqlx (High Risk)
+
+**Idea:** Implement the Duroxide Provider trait entirely in pg_durable using sqlx, calling
+the same stored procedures already in the duroxide schema.
+
+**Feasibility:** Technically possible but:
+- ~2,200 lines in duroxide-pg-opt to replicate
+- ~30 Provider methods with complex semantics
+- Ongoing maintenance burden tracking Duroxide Provider contract changes
+- Must replicate retry logic, long-poll infrastructure, error classification
+- Risk of subtle bugs in lock management / atomicity
+- **No access to duroxide-pg-opt's stress tests and validation suite** without
+  maintaining the dependency anyway
+
+**Verdict:** Not recommended unless duroxide-pg-opt becomes unmaintainable.
+
+### Approach D: Hybrid — SPI for Client/Monitoring + sqlx for BGW (Recommended ✅)
+
+**Idea:** Split the approach by execution context:
+
+| Context | Current | Proposed |
+|---------|---------|----------|
+| **BGW Provider** | duroxide-pg-opt via sqlx/TCP | duroxide-pg-opt via sqlx/**UDS** |
+| **Client ops** (`df.start/cancel/signal`) | duroxide-pg-opt via sqlx/TCP | **Direct SPI** |
+| **Monitoring** (`df.status/list_instances/metrics`) | duroxide-pg-opt via sqlx/TCP | **Direct SPI** |
+| **Activities** (`execute_sql`) | sqlx/TCP pool | sqlx/**UDS** pool |
+
+This eliminates `duroxide-pg-opt`, `sqlx`, and `tokio` from user sessions entirely.
+
+---
+
+## Recommended Architecture
+
+### Phase 1: Immediate Wins (Low Risk)
+
+#### 1a. Switch sqlx connections to Unix Domain Sockets
+
+Change `postgres_connection_string()` to prefer UDS when available:
+
+```rust
+pub fn postgres_connection_string() -> String {
+    // If PGHOST is a directory or not set, use UDS
+    let host = std::env::var("PGHOST").unwrap_or_else(|_| {
+        // Check for pgrx development environment
+        if let Ok(pgdata) = std::env::var("PGDATA") {
+            if pgdata.contains(".pgrx") {
+                return "/tmp".to_string(); // pgrx uses /tmp for sockets
+            }
+        }
+        // Production: try standard PG socket directory
+        "/var/run/postgresql".to_string()
+    });
+    // ... format connection string with host as socket directory
+}
+```
+
+**Impact:** ~30-50% latency reduction for all sqlx operations. Zero API changes.
+
+#### 1b. Client Operations via SPI
+
+Replace `src/client.rs` async+sqlx pattern with direct SPI calls:
+
+```rust
+pub fn start_durable_function(
+    function_name: &str,
+    instance_id: &str,
+    input: &str,
+) -> Result<(), String> {
+    // Build the WorkItem::StartOrchestration as JSON
+    let work_item = serde_json::json!({
+        "StartOrchestration": {
+            "orchestration": function_name,
+            "instance": instance_id,
+            "input": input,
+            "version": ""
+        }
+    });
+
+    // Call the stored procedure directly via SPI
+    Spi::connect(|client| {
+        client.update(
+            &format!(
+                "SELECT duroxide.enqueue_orchestrator_work($1, $2, NULL, NULL, NULL, NULL, NULL)",
+            ),
+            None,
+            &[
+                (PgBuiltInOids::TEXTOID.oid(), instance_id.into_datum()),
+                (PgBuiltInOids::TEXTOID.oid(), work_item.to_string().into_datum()),
+            ],
+        ).map_err(|e| format!("Failed to start: {e:?}"))?;
+        Ok::<_, String>(())
+    })?;
+
+    Ok(())
+}
+```
+
+**Impact:** Eliminates `tokio::Runtime` + `PostgresProvider` + sqlx pool from every
+user session. No TCP connections. No authentication overhead. Sub-millisecond latency.
+
+**What's removed from user sessions:**
+- `static CLIENT_RUNTIME: OnceLock<Runtime>` — gone
+- `static DUROXIDE_CLIENT: OnceLock<Client>` — gone
+- `duroxide::Client` usage — gone
+- `duroxide_pg_opt::PostgresProvider` in backend — gone
+
+#### 1c. Monitoring via SPI
+
+Replace `src/monitoring.rs` async pattern with direct SPI queries:
+
+```rust
+#[pg_extern(schema = "df")]
+pub fn status(instance_id: &str) -> Option<String> {
+    Spi::get_one_with_args(
+        "SELECT status FROM duroxide.instances WHERE instance_id = $1",
+        vec![(PgBuiltInOids::TEXTOID.oid(), instance_id.into_datum())],
+    ).ok().flatten()
+}
+```
+
+**Impact:** All monitoring functions become simple SPI queries. No async runtime needed.
+
+### Phase 2: Evaluate Full Provider Replacement (If Needed)
+
+Only if duroxide-pg-opt proves problematic (maintenance burden, API drift, bugs), consider:
+
+#### 2a. pg_durable-native Provider (sqlx-based)
+
+Implement `Provider` trait using sqlx queries against the duroxide schema stored procedures.
+This keeps the async/Send+Sync requirement satisfied while owning the implementation.
+
+**Key consideration:** The stored procedures are already shipped as part of pg_durable's
+extension SQL (`sql/duroxide_install.sql`). The Provider just needs to call them with the
+right parameters.
+
+```rust
+pub struct PgDurableProvider {
+    pool: Arc<PgPool>,
+    schema: String,
+    // Long-poll notifier (optional)
+    orch_notify: Option<Arc<Notify>>,
+    worker_notify: Option<Arc<Notify>>,
+}
+
+#[async_trait]
+impl Provider for PgDurableProvider {
+    async fn fetch_orchestration_item(&self, ...) -> Result<...> {
+        // Call duroxide.fetch_orchestration_item() stored procedure
+        sqlx::query_as(&format!("SELECT * FROM {}.fetch_orchestration_item($1, $2, $3, $4)", self.schema))
+            .bind(now_ms).bind(lock_timeout_ms).bind(min_packed).bind(max_packed)
+            .fetch_optional(&*self.pool).await
+            // ... deserialize and return
+    }
+    // ... ~30 more methods following the same pattern
+}
+```
+
+**Effort:** ~800-1000 lines (the stored procs do the heavy lifting).
+
+#### 2b. Dual-Path Provider (SPI for Simple Ops, sqlx for Complex)
+
+A Provider implementation that tries SPI for simple operations (when running on the BGW
+thread) and falls back to sqlx for operations called from spawned tasks.
+
+**Not recommended** — too complex, fragile, and the sqlx-only path is sufficient.
+
+---
+
+## POC Plan
+
+### POC Phase 1: Client Operations via SPI ✅ COMPLETED
+
+**Goal:** Replace `df.start()`, `df.cancel()`, `df.signal()` with direct SPI calls.
+
+**Files modified:**
+- `src/client.rs` — fully rewritten from async/sqlx/Client to direct SPI.
+  Removed: `OnceLock<Runtime>`, `OnceLock<Client>`, `PostgresProvider`, `tokio::Runtime`.
+  Added: `enqueue_orchestrator_work()` helper calling `duroxide.enqueue_orchestrator_work()`
+  stored procedure via `Spi::connect()` + `client.select()`.
+- `src/dsl.rs` — no changes needed (same function signatures).
+- `src/lib.rs` — not modified yet (test helpers still use the old pattern).
+
+**Result:** `cargo check --features pg17` and `cargo clippy --features pg17` both pass.
+The core `enqueue_orchestrator_work()` function builds WorkItem JSON using
+`serde_json::json!` macro (matching duroxide's externally-tagged serde format)
+and calls the stored procedure directly — no async runtime, no connection pool.
+
+### POC Phase 2: Status Monitoring via SPI ✅ COMPLETED
+
+**Goal:** Replace all monitoring/explain functions with SPI queries.
+
+**Files modified:**
+- `src/monitoring.rs` — all 5 functions (`list_instances`, `instance_info`,
+  `instance_executions`, `metrics`, `instance_nodes`) rewritten from
+  async/tokio/PostgresProvider/Client to direct SPI calls against duroxide
+  stored procedures (`list_instances()`, `list_instances_by_status()`,
+  `get_instance_info()`, `get_execution_info()`, `get_system_metrics()`,
+  `list_executions()`).
+  Removed: `duroxide::Client`, `duroxide_pg_opt::PostgresProvider`, `std::sync::Arc`,
+  `tokio::runtime`, `postgres_connection_string()`, `backend_provider_config()`.
+- `src/explain.rs` — `get_duroxide_instance_info()` rewritten from async/Provider
+  to SPI query against `duroxide.get_instance_info()`.
+
+**Result:** Builds and passes clippy cleanly.
+
+### POC Phase 3: Unix Domain Socket for BGW ✅ COMPLETED
+
+**Goal:** Switch BGW sqlx connections from TCP to UDS when available.
+
+**Files modified:**
+- `src/types.rs` — `postgres_connection_string()` updated to:
+  1. Detect `PGHOST` as directory path → use UDS format
+  2. Auto-detect UDS when PGHOST is localhost by checking
+     `/var/run/postgresql/.s.PGSQL.<port>` and `/tmp/.s.PGSQL.<port>`
+  3. Fall back to TCP connection string
+
+**Result:** Builds and passes clippy. The BGW will now prefer UDS automatically
+when a PostgreSQL socket is present, avoiding TCP overhead for same-host connections.
+
+### Validation
+
+After each POC phase:
+1. `cargo build --features pg17` — no warnings ✅
+2. `cargo clippy --features pg17` — clean ✅
+3. `./scripts/test-unit.sh` — TODO: run after full build
+4. `./scripts/test-e2e-local.sh` — TODO: run after full build
+5. Performance comparison (optional): measure `df.start()` + `df.status()` latency
+
+### POC Summary: Lines of Code Impact
+
+| Module | Before (LOC) | After (LOC) | Dependencies Removed |
+|--------|-------------|-------------|---------------------|
+| `client.rs` | 97 | 96 | `duroxide::Client`, `duroxide_pg_opt::PostgresProvider`, `tokio::Runtime`, `OnceLock`, `Arc` |
+| `monitoring.rs` | 442 | ~310 | `duroxide::Client`, `duroxide_pg_opt::PostgresProvider`, `tokio::runtime`, `Arc`, `postgres_connection_string`, `backend_provider_config` |
+| `explain.rs` | 663 (fn only) | 663 (~20 lines changed) | `duroxide::Client`, `duroxide_pg_opt::PostgresProvider`, `tokio::runtime`, `Arc` |
+| `types.rs` | 440 | ~455 | (added UDS detection logic) |
+
+**Key observation:** The backend-side code paths (user sessions calling `df.start()`,
+`df.status()`, `df.list_instances()`, etc.) **no longer need** `duroxide::Client`,
+`duroxide_pg_opt::PostgresProvider`, `tokio::runtime`, or `std::sync::Arc`. These are
+only still needed in `src/worker.rs` (BGW runtime) and `src/lib.rs` (test helpers).
+
+---
+
+## Learnings & Discarded Approaches
+
+### Learning 1: SPI is Thread-Bound
+
+PostgreSQL's SPI (Server Programming Interface) uses process-global state
+(`SPI_tuptable`, `SPI_processed`). The `SpiClient` type in pgrx is correctly
+marked `!Send + !Sync`. This means:
+
+- SPI cannot be called from `tokio::spawn`'d tasks
+- SPI cannot implement `Send + Sync` traits like `Provider`
+- SPI is fundamentally single-threaded and synchronous
+
+**Implication:** Any Provider implementation must use a network-based PostgreSQL
+client (sqlx, libpq) for the BGW context. SPI is only viable for user session
+operations that run on the PostgreSQL backend thread.
+
+### Learning 2: Duroxide Runtime Spawns Concurrent Tasks
+
+Even with `orchestration_concurrency=1` and `worker_concurrency=1`, the Duroxide
+runtime spawns additional `tokio::spawn` tasks for:
+- Lock renewal (1 per in-flight orchestration/activity)
+- Session management
+- Observability gauges
+
+These call Provider methods concurrently. A Provider implementation must handle
+this safely.
+
+### Learning 3: BGW Can Use Both SPI and sqlx
+
+A background worker can call `BackgroundWorker::connect_worker_to_spi()` for
+SPI access AND maintain sqlx connections simultaneously. These are independent
+paths — SPI uses the process-internal backend, sqlx opens external TCP/UDS
+connections.
+
+However, using SPI in a BGW running tokio requires careful bridging (e.g.,
+`block_on` in `BackgroundWorker::transaction()`). This is fragile and not
+recommended when the tokio event loop needs to remain responsive.
+
+### Learning 4: Stored Procedures Are Already Shipped
+
+pg_durable already ships the duroxide schema stored procedures as extension SQL
+(`sql/duroxide_install.sql`). These include:
+- `duroxide.enqueue_orchestrator_work()` — used by client ops
+- `duroxide.fetch_orchestration_item()` — used by BGW
+- `duroxide.ack_orchestration_item()` — the critical atomic commit
+- `duroxide.get_instance_info()` — used by monitoring
+
+This means a native Provider or SPI-based client can call these directly without
+reimplementing any SQL logic.
+
+### Learning 5: Backend Sessions Don't Need Provider
+
+User session operations (`df.start`, `df.cancel`, `df.signal`, `df.status`,
+monitoring) are simple enqueue or query operations. They don't need the full
+Provider abstraction — they just need to call stored procedures or query tables.
+
+The current architecture creates a full `PostgresProvider` (including connection
+pool, migration verification, long-poll infrastructure) just to call
+`client.start_orchestration()`, which is a single INSERT.
+
+### Discarded: Channel-Based SPI Serialization
+
+**Idea:** Funnel all Provider calls through an `mpsc` channel to a dedicated SPI
+handler that runs on the BGW thread.
+
+**Why discarded:**
+- The BGW thread is running `tokio::block_on()` — it's occupied by the event loop
+- SPI calls must run on the thread that called `BackgroundWorkerInitializeConnection`
+- Can't run SPI on a separate thread (it's the backend thread that has the connection)
+- Would need to periodically yield from tokio to process SPI requests — breaks the
+  event loop model
+- Long-poll fetches (30s blocking) would starve the SPI handler
+
+### Discarded: Shared Memory Provider
+
+**Idea:** Use PostgreSQL shared memory (`PgSharedMem`) for Provider data.
+
+**Why discarded:**
+- Types must be `Copy + Clone` — no `String`, `Vec`, `HashMap`
+- Provider data (WorkItems, Events) is complex, variable-size JSON
+- Can't implement atomicity guarantees with shared memory alone
+- Would essentially build a custom database in shared memory
+
+---
+
+## Open Questions
+
+1. **Should we keep duroxide-pg-opt as a dependency at all?**
+   - If client/monitoring move to SPI, only the BGW uses it
+   - Could we eventually replace it with a simpler sqlx-based Provider in pg_durable?
+   - Key risk: tracking upstream Provider trait changes
+
+2. **WorkItem JSON format compatibility**
+   - Direct SPI calls must produce WorkItem JSON matching what duroxide expects
+   - Need to verify the serialization format (serde_json derives on WorkItem)
+   - **Mitigation:** Use `duroxide::providers::WorkItem` for serialization in tests
+
+3. **UDS availability in Docker/container environments**
+   - Some container setups may not have standard PG socket directories
+   - Need fallback to TCP loopback
+   - **Mitigation:** Check for socket existence, fall back gracefully
+
+4. **Instance creation semantics**
+   - `enqueue_orchestrator_work()` does NOT create instances (by design)
+   - Instance creation happens in `ack_orchestration_item()` during the first turn
+   - SPI client ops must not try to create instances — just enqueue
+
+5. **Error handling parity**
+   - SPI errors have different types than sqlx errors
+   - Need to ensure error messages are actionable for users
+   - May need to handle "extension not installed" differently from "connection failed"
+
+6. **Custom status polling**
+   - `df.status()` currently uses `client.wait_for_status_change()` which does
+     polling internally via Provider
+   - SPI version would be a single `SELECT` — simpler but no long-poll
+   - Acceptable trade-off for user sessions
+
+---
+
+## Appendix: Provider Trait Summary
+
+### Methods Called by Client/Monitoring (Candidates for SPI)
+
+| Operation | Current Call Path | SPI Replacement |
+|-----------|------------------|-----------------|
+| `df.start()` | `client.start_orchestration()` → `enqueue_for_orchestrator()` | `SELECT duroxide.enqueue_orchestrator_work(...)` |
+| `df.cancel()` | `client.cancel_instance()` → `enqueue_for_orchestrator()` | `SELECT duroxide.enqueue_orchestrator_work(...)` |
+| `df.signal()` | `client.raise_event()` → `enqueue_for_orchestrator()` | `SELECT duroxide.enqueue_orchestrator_work(...)` |
+| `df.status()` | `client.get_instance_info()` | `SELECT * FROM duroxide.instances WHERE instance_id = $1` |
+| `df.list_instances()` | `client.list_all_instances()` | `SELECT * FROM duroxide.instances` |
+| `df.metrics()` | `client.get_system_metrics()` | `SELECT duroxide.get_system_metrics()` |
+
+### Methods Used Only by BGW Runtime (Keep in Provider)
+
+| Method | Purpose |
+|--------|---------|
+| `fetch_orchestration_item()` | Dequeue + lock orchestration turn |
+| `ack_orchestration_item()` | Atomic commit of turn results |
+| `abandon_orchestration_item()` | Release lock on failure |
+| `fetch_work_item()` | Dequeue + lock activity |
+| `ack_work_item()` | Ack activity completion |
+| `renew_*_lock()` | Extend locks for long-running items |
+| `read()` | Load history during replay |
+| `enqueue_for_worker()` | Enqueue activities |
+| Session methods | Session affinity management |
+
+---
+
+## Decision Log
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-03-02 | Full SPI Provider is not feasible | Provider trait requires Send+Sync+async; SPI is !Send+!Sync+sync |
+| 2026-03-02 | Low-level table access also not feasible | Same thread-safety and transaction-context constraints as SPI |
+| 2026-03-02 | Hybrid approach is best | SPI for simple client/monitoring ops; keep sqlx Provider for BGW |
+| 2026-03-02 | UDS > TCP for sqlx connections | Same-host optimization, trivial change |
+| 2026-03-02 | Full Provider replacement deferred | High effort (~2000 LOC), high risk, low incremental value |

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,57 +1,44 @@
-//! Cached client infrastructure for user session calls
+//! Client operations for user session calls — SPI-based
 //!
-//! This module provides cached Tokio runtime and Duroxide client for efficient
-//! df.start(), df.signal(), and df.cancel() calls from user sessions.
+//! This module provides direct SPI-based calls for df.start(), df.signal(),
+//! and df.cancel(). Operations are executed synchronously within the current
+//! PostgreSQL backend process — no TCP connections, no async runtime, no
+//! connection pools.
+//!
+//! All operations enqueue WorkItems to the duroxide orchestrator queue via
+//! the `duroxide.enqueue_orchestrator_work()` stored procedure.
 
-use std::sync::{Arc, OnceLock};
-
-use duroxide::Client;
-use duroxide_pg_opt::PostgresProvider;
 use pgrx::prelude::*;
-use tokio::runtime::Runtime;
 
-use crate::types::{backend_provider_config, postgres_connection_string};
+use crate::types::DUROXIDE_SCHEMA;
 
-/// Cached tokio runtime for client operations.
-static CLIENT_RUNTIME: OnceLock<Runtime> = OnceLock::new();
+/// Enqueue a WorkItem to the duroxide orchestrator queue via SPI.
+///
+/// This is the core primitive used by start/cancel/signal operations.
+/// It calls the `duroxide.enqueue_orchestrator_work()` stored procedure
+/// that was installed as part of `CREATE EXTENSION pg_durable`.
+fn enqueue_orchestrator_work(instance_id: &str, work_item_json: &str) -> Result<(), String> {
+    let safe_id = instance_id.replace('\'', "''");
+    let safe_json = work_item_json.replace('\'', "''");
 
-/// Cached Duroxide client with connection pool.
-static DUROXIDE_CLIENT: OnceLock<Client> = OnceLock::new();
+    let sql = format!(
+        "SELECT {DUROXIDE_SCHEMA}.enqueue_orchestrator_work(\
+         '{safe_id}', '{safe_json}', NOW(), \
+         (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT)"
+    );
 
-/// Get or create the cached tokio runtime.
-fn get_client_runtime() -> &'static Runtime {
-    CLIENT_RUNTIME.get_or_init(|| {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Failed to create tokio runtime")
+    Spi::connect(|client| {
+        client
+            .select(&sql, None, &[])
+            .map_err(|e| format!("Failed to enqueue work item: {e:?}"))?;
+        Ok(())
     })
 }
 
-/// Get or create the cached Duroxide client.
-fn get_duroxide_client() -> Result<&'static Client, String> {
-    if let Some(client) = DUROXIDE_CLIENT.get() {
-        return Ok(client);
-    }
-
-    let rt = get_client_runtime();
-    let pg_conn_str = postgres_connection_string();
-
-    rt.block_on(async {
-        let store = Arc::new(
-            PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
-                .await
-                .map_err(|e| format!("Failed to connect to duroxide store: {e}"))?,
-        );
-
-        let _ = DUROXIDE_CLIENT.set(Client::new(store));
-        DUROXIDE_CLIENT
-            .get()
-            .ok_or_else(|| "Failed to initialize client".to_string())
-    })
-}
-
-/// Start a durable function via the shared PostgreSQL store.
+/// Start a durable function by enqueuing a StartOrchestration work item.
+///
+/// This directly inserts into the duroxide orchestrator queue via SPI,
+/// bypassing the need for any async runtime or TCP connection.
 pub fn start_durable_function(
     function_name: &str,
     instance_id: &str,
@@ -62,42 +49,43 @@ pub fn start_durable_function(
         instance_id
     );
 
-    let rt = get_client_runtime();
-    let client = get_duroxide_client()?;
+    // Build the WorkItem::StartOrchestration JSON (serde externally-tagged format)
+    let work_item = serde_json::json!({
+        "StartOrchestration": {
+            "instance": instance_id,
+            "orchestration": function_name,
+            "input": input,
+            "version": null,
+            "parent_instance": null,
+            "parent_id": null,
+            "execution_id": 1
+        }
+    });
 
-    rt.block_on(async {
-        client
-            .start_orchestration(instance_id, function_name, input)
-            .await
-            .map_err(|e| format!("Failed to start durable function: {e:?}"))?;
-        Ok(())
-    })
+    enqueue_orchestrator_work(instance_id, &work_item.to_string())
 }
 
-/// Cancel a durable function.
+/// Cancel a durable function by enqueuing a CancelInstance work item.
 pub fn cancel_durable_function(instance_id: &str, reason: &str) -> Result<(), String> {
-    let rt = get_client_runtime();
-    let client = get_duroxide_client()?;
+    let work_item = serde_json::json!({
+        "CancelInstance": {
+            "instance": instance_id,
+            "reason": reason
+        }
+    });
 
-    rt.block_on(async {
-        client
-            .cancel_instance(instance_id, reason)
-            .await
-            .map_err(|e| format!("Failed to cancel durable function: {e:?}"))?;
-        Ok(())
-    })
+    enqueue_orchestrator_work(instance_id, &work_item.to_string())
 }
 
 /// Raise an external event (signal) to a running orchestration.
 pub fn raise_external_event(instance_id: &str, event_name: &str, data: &str) -> Result<(), String> {
-    let rt = get_client_runtime();
-    let client = get_duroxide_client()?;
+    let work_item = serde_json::json!({
+        "ExternalRaised": {
+            "instance": instance_id,
+            "name": event_name,
+            "data": data
+        }
+    });
 
-    rt.block_on(async {
-        client
-            .raise_event(instance_id, event_name, data)
-            .await
-            .map_err(|e| format!("Failed to raise event: {e:?}"))?;
-        Ok(())
-    })
+    enqueue_orchestrator_work(instance_id, &work_item.to_string())
 }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -122,35 +122,25 @@ fn explain_instance(instance_id: &str) -> String {
     result
 }
 
-/// Get instance info from Duroxide store
+/// Get instance info from Duroxide store via SPI
 fn get_duroxide_instance_info(instance_id: &str) -> (String, Option<String>) {
-    use crate::types::{backend_provider_config, postgres_connection_string};
-    use duroxide::Client;
-    use duroxide_pg_opt::PostgresProvider;
-    use std::sync::Arc;
+    use crate::types::DUROXIDE_SCHEMA;
 
-    let pg_conn_str = postgres_connection_string();
+    let safe_id = instance_id.replace('\'', "''");
 
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(_) => return (String::new(), None),
-    };
+    Spi::connect(|client| {
+        let sql =
+            format!("SELECT status, output FROM {DUROXIDE_SCHEMA}.get_instance_info('{safe_id}')");
 
-    rt.block_on(async {
-        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
-            .await
-        {
-            Ok(s) => Arc::new(s),
-            Err(_) => return (String::new(), None),
-        };
-
-        let client = Client::new(store);
-
-        match client.get_instance_info(instance_id).await {
-            Ok(info) => (info.status, info.output),
+        match client.select(&sql, None, &[]) {
+            Ok(mut table) => {
+                if let Some(row) = table.next() {
+                    let status: String = row.get::<String>(1).ok().flatten().unwrap_or_default();
+                    let output: Option<String> = row.get(2).ok().flatten();
+                    return (status, output);
+                }
+                (String::new(), None)
+            }
             Err(_) => (String::new(), None),
         }
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,102 @@ extension_sql_file!(
 );
 
 // ============================================================================
+// Permissions & Row-Level Security
+// ============================================================================
+
+extension_sql!(
+    r#"
+-- ============================================================================
+-- GRANTs: Allow non-superusers to call df functions via SPI
+-- ============================================================================
+
+-- df schema access
+GRANT USAGE ON SCHEMA df TO PUBLIC;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE ON df.instances TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE ON df.nodes TO PUBLIC;
+GRANT SELECT, INSERT, DELETE ON df.vars TO PUBLIC;
+
+-- duroxide schema access (only functions/tables needed by user-facing SPI)
+GRANT USAGE ON SCHEMA duroxide TO PUBLIC;
+GRANT SELECT ON duroxide.instances TO PUBLIC;
+GRANT SELECT ON duroxide.executions TO PUBLIC;
+GRANT SELECT ON duroxide.history TO PUBLIC;
+GRANT INSERT ON duroxide.orchestrator_queue TO PUBLIC;
+GRANT USAGE ON SEQUENCE duroxide.orchestrator_queue_id_seq TO PUBLIC;
+
+-- Performance index for RLS ownership lookups
+CREATE INDEX IF NOT EXISTS idx_instances_submitted_by ON df.instances(submitted_by);
+
+-- ============================================================================
+-- Row-Level Security: users see only their own data
+-- ============================================================================
+-- Superusers (including the BGW worker role) bypass RLS by default.
+
+-- df.instances: users see/modify only instances they submitted
+ALTER TABLE df.instances ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY df_instances_select ON df.instances
+    FOR SELECT USING (submitted_by = current_user::regrole);
+
+CREATE POLICY df_instances_insert ON df.instances
+    FOR INSERT WITH CHECK (submitted_by = current_user::regrole);
+
+CREATE POLICY df_instances_update ON df.instances
+    FOR UPDATE USING (submitted_by = current_user::regrole);
+
+-- df.nodes: users see their own nodes + unlinked nodes (submitted_by IS NULL).
+-- Unlinked nodes are transient rows created by DSL operators before df.start()
+-- links them to an instance. A separate effort will eliminate unlinked nodes
+-- entirely by deferring INSERT to df.start() time.
+ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY df_nodes_select ON df.nodes
+    FOR SELECT USING (submitted_by IS NULL OR submitted_by = current_user::regrole);
+
+CREATE POLICY df_nodes_insert ON df.nodes
+    FOR INSERT WITH CHECK (TRUE);
+
+CREATE POLICY df_nodes_update ON df.nodes
+    FOR UPDATE USING (submitted_by IS NULL OR submitted_by = current_user::regrole);
+
+-- duroxide.instances: filtered to user's own instances via df.instances
+ALTER TABLE duroxide.instances ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY duroxide_instances_select ON duroxide.instances
+    FOR SELECT USING (instance_id IN (
+        SELECT id FROM df.instances WHERE submitted_by = current_user::regrole
+    ));
+
+-- duroxide.executions: filtered via df.instances ownership
+ALTER TABLE duroxide.executions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY duroxide_executions_select ON duroxide.executions
+    FOR SELECT USING (instance_id IN (
+        SELECT id FROM df.instances WHERE submitted_by = current_user::regrole
+    ));
+
+-- duroxide.history: filtered via df.instances ownership
+ALTER TABLE duroxide.history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY duroxide_history_select ON duroxide.history
+    FOR SELECT USING (instance_id IN (
+        SELECT id FROM df.instances WHERE submitted_by = current_user::regrole
+    ));
+
+-- duroxide.orchestrator_queue: users can only enqueue for their own instances
+ALTER TABLE duroxide.orchestrator_queue ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY duroxide_orch_queue_insert ON duroxide.orchestrator_queue
+    FOR INSERT WITH CHECK (instance_id IN (
+        SELECT id FROM df.instances WHERE submitted_by = current_user::regrole
+    ));
+"#,
+    name = "permissions_and_rls",
+    requires = ["create_tables", "duroxide_migrations_install"]
+);
+
+// ============================================================================
 // SQL Operators
 // ============================================================================
 

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -1,13 +1,14 @@
-//! Monitoring functions for pg_durable - using Duroxide Client Management API
+//! Monitoring functions for pg_durable — SPI-based
+//!
+//! All monitoring queries run synchronously via SPI against the duroxide
+//! stored procedures and pg_durable's own tables. No async runtime, no TCP
+//! connections, no connection pools.
 
 #![allow(clippy::type_complexity)] // Required for pgrx TableIterator return types
 
-use duroxide::Client;
 use pgrx::prelude::*;
-use std::sync::Arc;
 
-use crate::types::{backend_provider_config, postgres_connection_string};
-use duroxide_pg_opt::PostgresProvider;
+use crate::types::DUROXIDE_SCHEMA;
 
 // ============================================================================
 // Monitoring Functions
@@ -29,66 +30,60 @@ pub fn list_instances(
         name!(output, Option<String>),
     ),
 > {
-    let pg_conn_str = postgres_connection_string();
+    let results = Spi::connect(|client| {
+        // 1. Get instance IDs from duroxide (filtered or all)
+        let list_sql = if let Some(status) = status_filter {
+            format!(
+                "SELECT instance_id FROM {DUROXIDE_SCHEMA}.list_instances_by_status('{}') LIMIT {}",
+                status.replace('\'', "''"),
+                limit_count
+            )
+        } else {
+            format!(
+                "SELECT instance_id FROM {DUROXIDE_SCHEMA}.list_instances() LIMIT {limit_count}"
+            )
+        };
 
-    // Fetch labels from PostgreSQL
-    let labels: std::collections::HashMap<String, Option<String>> = Spi::connect(|client| {
-        let mut map = std::collections::HashMap::new();
-        if let Ok(table) = client.select("SELECT id, label FROM df.instances", None, &[]) {
-            for row in table {
-                if let Ok(Some(id)) = row.get::<String>(1) {
-                    let label: Option<String> = row.get(2).ok().flatten();
-                    map.insert(id, label);
-                }
-            }
-        }
-        map
-    });
-
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(_) => return TableIterator::new(vec![]),
-    };
-
-    let results = rt.block_on(async {
-        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
-            .await
-        {
-            Ok(s) => Arc::new(s),
+        let instance_ids: Vec<String> = match client.select(&list_sql, None, &[]) {
+            Ok(table) => table
+                .filter_map(|row| row.get::<String>(1).ok().flatten())
+                .collect(),
             Err(_) => return vec![],
         };
 
-        let client = Client::new(store);
-
-        let instance_ids = if let Some(status) = status_filter {
-            client
-                .list_instances_by_status(status)
-                .await
-                .unwrap_or_default()
-        } else {
-            client.list_all_instances().await.unwrap_or_default()
-        };
-
-        let limited: Vec<_> = instance_ids
-            .into_iter()
-            .take(limit_count as usize)
-            .collect();
-
+        // 2. For each instance, get info from duroxide + label from df.instances
         let mut rows = Vec::new();
-        for id in limited {
-            if let Ok(info) = client.get_instance_info(&id).await {
-                let label = labels.get(&info.instance_id).cloned().flatten();
-                rows.push((
-                    info.instance_id,
-                    label,
-                    info.orchestration_name,
-                    info.status,
-                    info.current_execution_id as i64,
-                    info.output,
-                ));
+        for id in instance_ids {
+            let info_sql = format!(
+                "SELECT instance_id, orchestration_name, status, current_execution_id, output \
+                 FROM {DUROXIDE_SCHEMA}.get_instance_info('{}')",
+                id.replace('\'', "''")
+            );
+            if let Ok(table) = client.select(&info_sql, None, &[]) {
+                for row in table {
+                    let inst_id: String = match row.get(1).ok().flatten() {
+                        Some(v) => v,
+                        None => continue,
+                    };
+                    let function_name: String =
+                        row.get::<String>(2).ok().flatten().unwrap_or_default();
+                    let status: String = row.get::<String>(3).ok().flatten().unwrap_or_default();
+                    let exec_id: i64 = row.get::<i64>(4).ok().flatten().unwrap_or(0);
+                    let output: Option<String> = row.get(5).ok().flatten();
+
+                    // Get label from df.instances
+                    let label_sql = format!(
+                        "SELECT label FROM df.instances WHERE id = '{}'",
+                        inst_id.replace('\'', "''")
+                    );
+                    let label: Option<String> = client
+                        .select(&label_sql, None, &[])
+                        .ok()
+                        .and_then(|t| t.into_iter().next())
+                        .and_then(|r| r.get(1).ok().flatten());
+
+                    rows.push((inst_id, label, function_name, status, exec_id, output));
+                }
             }
         }
         rows
@@ -113,44 +108,55 @@ pub fn instance_info(
         name!(output, Option<String>),
     ),
 > {
-    let pg_conn_str = postgres_connection_string();
-    let instance_id_str = instance_id.to_string();
+    let safe_id = instance_id.replace('\'', "''");
 
-    let label: Option<String> = Spi::get_one(&format!(
-        "SELECT label FROM df.instances WHERE id = '{}'",
-        instance_id.replace('\'', "''")
-    ))
-    .ok()
-    .flatten();
+    let results = Spi::connect(|client| {
+        // Get label from df.instances
+        let label: Option<String> = client
+            .select(
+                &format!("SELECT label FROM df.instances WHERE id = '{safe_id}'"),
+                None,
+                &[],
+            )
+            .ok()
+            .and_then(|t| t.into_iter().next())
+            .and_then(|r| r.get(1).ok().flatten());
 
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(_) => return TableIterator::new(vec![]),
-    };
+        // Get instance info from duroxide stored procedure
+        let info_sql = format!(
+            "SELECT instance_id, orchestration_name, orchestration_version, \
+             current_execution_id, status, output \
+             FROM {DUROXIDE_SCHEMA}.get_instance_info('{safe_id}')"
+        );
 
-    let results = rt.block_on(async {
-        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
-            .await
-        {
-            Ok(s) => Arc::new(s),
-            Err(_) => return vec![],
-        };
+        match client.select(&info_sql, None, &[]) {
+            Ok(table) => {
+                let mut rows = Vec::new();
+                for row in table {
+                    let inst_id: String = match row.get(1).ok().flatten() {
+                        Some(v) => v,
+                        None => continue,
+                    };
+                    let function_name: String =
+                        row.get::<String>(2).ok().flatten().unwrap_or_default();
+                    let function_version: String =
+                        row.get::<String>(3).ok().flatten().unwrap_or_default();
+                    let exec_id: i64 = row.get::<i64>(4).ok().flatten().unwrap_or(0);
+                    let status: String = row.get::<String>(5).ok().flatten().unwrap_or_default();
+                    let output: Option<String> = row.get(6).ok().flatten();
 
-        let client = Client::new(store);
-
-        match client.get_instance_info(&instance_id_str).await {
-            Ok(info) => vec![(
-                info.instance_id,
-                label,
-                info.orchestration_name,
-                info.orchestration_version,
-                info.current_execution_id as i64,
-                info.status,
-                info.output,
-            )],
+                    rows.push((
+                        inst_id,
+                        label.clone(),
+                        function_name,
+                        function_version,
+                        exec_id,
+                        status,
+                        output,
+                    ));
+                }
+                rows
+            }
             Err(_) => vec![],
         }
     });
@@ -173,51 +179,41 @@ pub fn instance_executions(
         name!(output, Option<String>),
     ),
 > {
-    let pg_conn_str = postgres_connection_string();
-    let instance_id = instance_id.to_string();
+    let safe_id = instance_id.replace('\'', "''");
 
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(_) => return TableIterator::new(vec![]),
-    };
+    let results = Spi::connect(|client| {
+        // Get execution IDs (sorted descending, limited)
+        let list_sql = format!(
+            "SELECT execution_id FROM {DUROXIDE_SCHEMA}.list_executions('{safe_id}') \
+             ORDER BY execution_id DESC LIMIT {limit_count}"
+        );
 
-    let results = rt.block_on(async {
-        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
-            .await
-        {
-            Ok(s) => Arc::new(s),
+        let exec_ids: Vec<i64> = match client.select(&list_sql, None, &[]) {
+            Ok(table) => table
+                .filter_map(|row| row.get::<i64>(1).ok().flatten())
+                .collect(),
             Err(_) => return vec![],
         };
-
-        let client = Client::new(store);
-
-        let execution_ids = match client.list_executions(&instance_id).await {
-            Ok(ids) => ids,
-            Err(_) => return vec![],
-        };
-
-        let mut sorted_ids: Vec<_> = execution_ids.into_iter().collect();
-        sorted_ids.sort_by(|a, b| b.cmp(a));
-        let limited: Vec<_> = sorted_ids.into_iter().take(limit_count as usize).collect();
 
         let mut rows = Vec::new();
-        for exec_id in limited {
-            if let Ok(info) = client.get_execution_info(&instance_id, exec_id).await {
-                let duration_ms = info
-                    .completed_at
-                    .map(|end| end.saturating_sub(info.started_at))
-                    .unwrap_or(0);
+        for exec_id in exec_ids {
+            let info_sql = format!(
+                "SELECT execution_id, status, event_count, \
+                 EXTRACT(EPOCH FROM (completed_at - started_at))::BIGINT * 1000 AS duration_ms, \
+                 output \
+                 FROM {DUROXIDE_SCHEMA}.get_execution_info('{safe_id}', {exec_id})"
+            );
 
-                rows.push((
-                    info.execution_id as i64,
-                    info.status,
-                    info.event_count as i64,
-                    duration_ms as i64,
-                    info.output,
-                ));
+            if let Ok(table) = client.select(&info_sql, None, &[]) {
+                for row in table {
+                    let eid: i64 = row.get::<i64>(1).ok().flatten().unwrap_or(0);
+                    let status: String = row.get::<String>(2).ok().flatten().unwrap_or_default();
+                    let event_count: i64 = row.get::<i64>(3).ok().flatten().unwrap_or(0);
+                    let duration_ms: i64 = row.get::<i64>(4).ok().flatten().unwrap_or(0);
+                    let output: Option<String> = row.get(5).ok().flatten();
+
+                    rows.push((eid, status, event_count, duration_ms, output));
+                }
             }
         }
         rows
@@ -239,35 +235,35 @@ pub fn metrics() -> TableIterator<
         name!(total_events, i64),
     ),
 > {
-    let pg_conn_str = postgres_connection_string();
+    let results = Spi::connect(|client| {
+        let sql = format!(
+            "SELECT total_instances, running_instances, completed_instances, \
+             failed_instances, total_executions, total_events \
+             FROM {DUROXIDE_SCHEMA}.get_system_metrics()"
+        );
 
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(_) => return TableIterator::new(vec![]),
-    };
+        match client.select(&sql, None, &[]) {
+            Ok(table) => {
+                let mut rows = Vec::new();
+                for row in table {
+                    let total_instances: i64 = row.get::<i64>(1).ok().flatten().unwrap_or(0);
+                    let running: i64 = row.get::<i64>(2).ok().flatten().unwrap_or(0);
+                    let completed: i64 = row.get::<i64>(3).ok().flatten().unwrap_or(0);
+                    let failed: i64 = row.get::<i64>(4).ok().flatten().unwrap_or(0);
+                    let total_executions: i64 = row.get::<i64>(5).ok().flatten().unwrap_or(0);
+                    let total_events: i64 = row.get::<i64>(6).ok().flatten().unwrap_or(0);
 
-    let results = rt.block_on(async {
-        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
-            .await
-        {
-            Ok(s) => Arc::new(s),
-            Err(_) => return vec![],
-        };
-
-        let client = Client::new(store);
-
-        match client.get_system_metrics().await {
-            Ok(m) => vec![(
-                m.total_instances as i64,
-                m.running_instances as i64,
-                m.completed_instances as i64,
-                m.failed_instances as i64,
-                m.total_executions as i64,
-                m.total_events as i64,
-            )],
+                    rows.push((
+                        total_instances,
+                        running,
+                        completed,
+                        failed,
+                        total_executions,
+                        total_events,
+                    ));
+                }
+                rows
+            }
             Err(_) => vec![],
         }
     });
@@ -297,116 +293,76 @@ pub fn instance_nodes(
 > {
     use pgrx::datum::TimestampWithTimeZone;
 
-    let instance_id = instance_id_param.to_string();
-    let pg_conn_str = postgres_connection_string();
+    let safe_id = instance_id_param.replace('\'', "''");
 
-    // Get node definitions from PostgreSQL (including status, result and updated_at)
-    let node_defs: Vec<(
-        String,
-        String,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<TimestampWithTimeZone>,
-    )> = Spi::connect(|client| {
-        let sql = format!(
-            r#"SELECT id, node_type, query, result_name, left_node, right_node, status, result::text, updated_at
-                   FROM df.nodes WHERE instance_id = '{instance_id}'"#
+    let results = Spi::connect(|client| {
+        // Get node definitions from df.nodes (including status, result and updated_at)
+        let node_sql = format!(
+            r#"SELECT id, node_type, query, result_name, left_node, right_node,
+                      status, result::text, updated_at
+               FROM df.nodes WHERE instance_id = '{safe_id}'"#
         );
-        let mut nodes = Vec::new();
-        if let Ok(table) = client.select(&sql, None, &[]) {
-            for row in table {
-                if let Ok(Some(id)) = row.get::<String>(1) {
-                    let node_type: String = row.get(2).ok().flatten().unwrap_or_default();
-                    let query: Option<String> = row.get(3).ok().flatten();
-                    let result_name: Option<String> = row.get(4).ok().flatten();
-                    let left_node: Option<String> = row.get(5).ok().flatten();
-                    let right_node: Option<String> = row.get(6).ok().flatten();
-                    let node_status: Option<String> = row.get(7).ok().flatten();
-                    let node_result: Option<String> = row.get(8).ok().flatten();
-                    let updated_at: Option<TimestampWithTimeZone> = row.get(9).ok().flatten();
-                    nodes.push((
-                        id,
-                        node_type,
-                        query,
-                        result_name,
-                        left_node,
-                        right_node,
-                        node_status,
-                        node_result,
-                        updated_at,
-                    ));
+
+        let node_defs: Vec<(
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<TimestampWithTimeZone>,
+        )> = match client.select(&node_sql, None, &[]) {
+            Ok(table) => {
+                let mut nodes = Vec::new();
+                for row in table {
+                    if let Ok(Some(id)) = row.get::<String>(1) {
+                        let node_type: String = row.get(2).ok().flatten().unwrap_or_default();
+                        let query: Option<String> = row.get(3).ok().flatten();
+                        let result_name: Option<String> = row.get(4).ok().flatten();
+                        let left_node: Option<String> = row.get(5).ok().flatten();
+                        let right_node: Option<String> = row.get(6).ok().flatten();
+                        let node_status: Option<String> = row.get(7).ok().flatten();
+                        let node_result: Option<String> = row.get(8).ok().flatten();
+                        let updated_at: Option<TimestampWithTimeZone> = row.get(9).ok().flatten();
+                        nodes.push((
+                            id,
+                            node_type,
+                            query,
+                            result_name,
+                            left_node,
+                            right_node,
+                            node_status,
+                            node_result,
+                            updated_at,
+                        ));
+                    }
                 }
+                nodes
             }
-        }
-        nodes
-    });
-
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(_) => return TableIterator::new(vec![]),
-    };
-
-    let results = rt.block_on(async {
-        let store = match PostgresProvider::new_with_config(&pg_conn_str, backend_provider_config())
-            .await
-        {
-            Ok(s) => Arc::new(s),
-            Err(_) => return vec![],
+            Err(_) => vec![],
         };
 
-        let client = Client::new(store);
+        // Get execution IDs from duroxide (sorted descending, limited)
+        let exec_sql = format!(
+            "SELECT execution_id FROM {DUROXIDE_SCHEMA}.list_executions('{safe_id}') \
+             ORDER BY execution_id DESC LIMIT {last_n_executions}"
+        );
 
-        let execution_ids = match client.list_executions(&instance_id).await {
-            Ok(ids) => ids,
-            Err(_) => return vec![],
-        };
-
-        let mut sorted_ids: Vec<_> = execution_ids.into_iter().collect();
-        sorted_ids.sort_by(|a, b| b.cmp(a));
-        let limited: Vec<_> = sorted_ids
-            .into_iter()
-            .take(last_n_executions as usize)
-            .collect();
+        let exec_ids: Vec<i64> = client
+            .select(&exec_sql, None, &[])
+            .ok()
+            .map(|t| {
+                t.filter_map(|row| row.get::<i64>(1).ok().flatten())
+                    .collect()
+            })
+            .unwrap_or_default();
 
         let mut rows = Vec::new();
 
-        for exec_id in limited {
-            for (
-                node_id,
-                node_type,
-                query,
-                result_name,
-                left_node,
-                right_node,
-                node_status,
-                node_result,
-                updated_at,
-            ) in &node_defs
-            {
-                rows.push((
-                    exec_id as i64,
-                    node_id.clone(),
-                    node_type.clone(),
-                    query.clone(),
-                    result_name.clone(),
-                    left_node.clone(),
-                    right_node.clone(),
-                    node_status.clone(),
-                    node_result.clone(),
-                    *updated_at,
-                ));
-            }
-        }
-
-        // If no executions found, return static node definitions
-        if rows.is_empty() {
+        if exec_ids.is_empty() {
+            // No executions found — return static node definitions
             for (
                 node_id,
                 node_type,
@@ -431,6 +387,34 @@ pub fn instance_nodes(
                     node_result,
                     updated_at,
                 ));
+            }
+        } else {
+            for exec_id in exec_ids {
+                for (
+                    node_id,
+                    node_type,
+                    query,
+                    result_name,
+                    left_node,
+                    right_node,
+                    node_status,
+                    node_result,
+                    updated_at,
+                ) in &node_defs
+                {
+                    rows.push((
+                        exec_id,
+                        node_id.clone(),
+                        node_type.clone(),
+                        query.clone(),
+                        result_name.clone(),
+                        left_node.clone(),
+                        right_node.clone(),
+                        node_status.clone(),
+                        node_result.clone(),
+                        *updated_at,
+                    ));
+                }
             }
         }
 

--- a/tests/e2e/sql/21_signals.sql
+++ b/tests/e2e/sql/21_signals.sql
@@ -159,15 +159,24 @@ INSERT INTO _test_signal_data SELECT df.start(
 
 SELECT pg_sleep(1);
 
+-- Send signal in its own transaction so the BGW can see it immediately.
+-- (SPI INSERT into orchestrator_queue is only visible to other sessions after commit.)
+DO $$
+DECLARE
+    inst_id TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_signal_data;
+    PERFORM df.signal(inst_id, 'approval', '{"approved": true, "approver": "jane@acme.com"}');
+    RAISE NOTICE 'Sent signal with data to %', inst_id;
+END $$;
+
+-- Wait for completion in a separate transaction
 DO $$
 DECLARE
     inst_id TEXT;
     status TEXT;
 BEGIN
     SELECT instance_id INTO inst_id FROM _test_signal_data;
-    
-    -- Send signal with data
-    PERFORM df.signal(inst_id, 'approval', '{"approved": true, "approver": "jane@acme.com"}');
     RAISE NOTICE 'Testing signal with data: %', inst_id;
 
     SELECT df.wait_for_completion(inst_id, 10) INTO status;


### PR DESCRIPTION
Replace async sqlx/tokio calls with direct SPI in PostgreSQL backend
processes (user sessions). This eliminates TCP connection pools and
async runtime overhead for client, monitoring, and explain operations.
The background worker continues to use sqlx via duroxide-pg-opt since
the Provider trait requires Send + Sync + async.

This work builds on the POC in docs/design-native-provider.md, which
explored three phases: SPI for client ops, SPI for monitoring, and UDS
for BGW connections. This branch isolates the first two phases (SPI).

## Changes
- Rewrite `src/client.rs` to enqueue work items via SPI instead of async Client/Provider
- Rewrite `src/monitoring.rs` to query duroxide stored procedures via SPI
- Rewrite `src/explain.rs` `get_duroxide_instance_info()` to use SPI
- Add GRANTs on `df` and `duroxide` schema objects so non-superusers can call functions through SPI (which runs as the calling user)
- Enable Row-Level Security on `df.instances`, `df.nodes`, `duroxide.instances`, `duroxide.executions`, `duroxide.history`, and `duroxide.orchestrator_queue` so users only see/modify their own data
- Fix `21_signals` test: split signal+wait into separate transactions for SPI transaction visibility
- Add `docs/design-backend-spi.md` design document