### PR TITLE
feat: add multi-database support via df.start() database parameter

### DIFF
--- a/docs/multi-database.md
+++ b/docs/multi-database.md
@@ -1,0 +1,253 @@
+# Multi-Database Support
+
+**Status:** Draft  
+**Date:** 2026-03-06
+
+## Summary
+
+Allow durable functions to execute SQL in any database on the same PostgreSQL cluster, not just the database where the extension is installed. A single function always runs against one database; cross-database workflows are deferred to a future enhancement.
+
+## Motivation
+
+Today, pg_durable can only execute SQL in the database configured by `pg_durable.database` (the same database the background worker connects to). Users with multiple databases in the same cluster—e.g., multi-tenant setups, or separate `analytics` / `app` databases—cannot use pg_durable to run durable functions against those databases.
+
+pg_cron solved the same problem: it stores all metadata in one database but can schedule jobs against any database via `cron.schedule_in_database()`. We adopt a similar approach.
+
+## Design Principles
+
+1. **Extension lives in one database.** The `df` and `duroxide` schemas, background worker connection, and all metadata tables (`df.instances`, `df.nodes`) remain in the database specified by `pg_durable.database`. The extension is created (`CREATE EXTENSION pg_durable`) in only that one database.
+
+2. **One database per function invocation.** A single `df.start()` call targets exactly one database. All SQL nodes in that invocation execute against that database. We explicitly do not support functions that span multiple databases in this iteration—it would complicate the DSL and orchestration for limited benefit. Users needing cross-database work can use `dblink` or `postgres_fdw` inside their SQL queries, or start separate durable functions per database.
+
+3. **DSL is database-agnostic.** The DSL (`df.sql()`, `~>`, `&`, etc.) has no concept of "database." Database is purely a property of the *instance*, set at `df.start()` time. This keeps the DSL simple and avoids a combinatorial explosion of database-aware operators.
+
+4. **Backwards compatible.** Omitting the database parameter defaults to `pg_durable.database` (today's behavior). No existing queries break.
+
+## API Design
+
+### Option Considered: New Function `df.start_in_database()`
+
+pg_cron uses a separate function (`cron.schedule_in_database()`). This has the advantage of zero risk of breaking changes, but adds a parallel function that must be maintained in lockstep with `df.start()`.
+
+### Chosen Approach: Optional Parameter on `df.start()`
+
+Add an optional `database` parameter to `df.start()`:
+
+```sql
+-- Existing signature (unchanged behavior):
+SELECT df.start(df.sql('SELECT 1'));
+SELECT df.start(df.sql('SELECT 1'), 'my-label');
+
+-- New: specify target database
+SELECT df.start(df.sql('SELECT 1'), database => 'analytics');
+SELECT df.start(df.sql('SELECT 1'), 'my-label', 'analytics');
+```
+
+The current signature is:
+
+```sql
+df.start(fut text, label text DEFAULT NULL) → text
+```
+
+The new signature becomes:
+
+```sql
+df.start(fut text, label text DEFAULT NULL, database text DEFAULT NULL) → text
+```
+
+**Why this is not a breaking change:**
+- The new parameter has a `DEFAULT NULL` value, so all existing calls continue to work unchanged.
+- PostgreSQL supports named parameter syntax (`database => 'analytics'`), so users can skip `label` and specify only `database`.
+- pgrx supports `default!()` for optional parameters, which maps to SQL `DEFAULT`.
+
+**Why we prefer this over a separate function:**
+- One function to learn and document.
+- No risk of the two functions drifting apart.
+- Matches PostgreSQL's general convention of optional parameters over function proliferation.
+- `database => NULL` means "use the default" — clean and intuitive.
+
+### Querying from Other Databases
+
+Users calling `df.start()` from a *different* database than where the extension is installed need to use `dblink` or `postgres_fdw` to call into the extension database. The extension functions (`df.start`, `df.status`, `df.result`, etc.) only exist in the extension database.
+
+**Alternative considered:** Installing stub functions in other databases that proxy via `dblink`. Rejected as over-engineering for now; advanced users can set this up themselves.
+
+## Schema Changes
+
+### `df.instances` Table
+
+Add a `database` column:
+
+```sql
+ALTER TABLE df.instances ADD COLUMN database TEXT;
+```
+
+- `NULL` means "the extension database" (i.e., the database where `df.instances` itself lives). This is always unambiguous: the table only exists in the extension database, so NULL can only refer to that database. Even if `pg_durable.database` were later changed, the old tables would be gone (extension dropped) or still in the original database.
+- Non-NULL values name a different database on the same cluster.
+- Populated by `df.start()` from the `database` parameter.
+
+### `df.nodes` Table
+
+Add a `database` column:
+
+```sql
+ALTER TABLE df.nodes ADD COLUMN database TEXT;
+```
+
+Like `submitted_by` and `login_role`, this is denormalized from the instance for convenience—the `execute_sql` activity reads from `df.nodes` and should not need to join with `df.instances` to determine the target database. NULL means "the extension database," same as on `df.instances`.
+
+### No Changes to DSL / `Durofut`
+
+The `Durofut` struct (and by extension `df.sql()`, operators, etc.) does not need a database field. The database is an *instance-level* property, set once at `df.start()` and stamped onto all nodes at insertion time—exactly like `submitted_by` and `login_role` today.
+
+## Implementation Changes
+
+### 1. `df.start()` — [src/dsl.rs](../src/dsl.rs)
+
+- Add `database: default!(Option<&str>, "NULL")` parameter.
+- When `database` is `Some(db)`, validate it exists (see [Validation](#validation) below).
+- Pass `database` value (or NULL) to `insert_nodes()` and include it in the `INSERT INTO df.nodes` statement.
+- Include `database` in the `INSERT INTO df.instances` statement.
+
+### 2. `FunctionNode` — [src/types.rs](../src/types.rs)
+
+- Add `pub database: Option<String>` field.
+- Serialized/deserialized naturally with serde.
+
+### 3. `load_function_graph` Activity — [src/activities/load_function_graph.rs](../src/activities/load_function_graph.rs)
+
+- Include `database` in the SELECT from `df.nodes`.
+- Populate `FunctionNode.database`.
+
+### 4. `execute_sql` Activity — [src/activities/execute_sql.rs](../src/activities/execute_sql.rs)
+
+- Add `database: Option<String>` to `ExecuteSqlInput`.
+- Pass it to `connect_as_user()`.
+
+### 5. `connect_as_user()` — [src/types.rs](../src/types.rs)
+
+- Add `database: Option<&str>` parameter.
+- Use `database.unwrap_or_else(|| &target_database())` for connection options instead of hard-coding `target_database()`.
+
+### 6. Orchestration — [src/orchestrations/execute_function_graph.rs](../src/orchestrations/execute_function_graph.rs)
+
+- When building the `ExecuteSqlInput` JSON, include `node.database`.
+- No other changes needed—the orchestration itself doesn't care about the database.
+
+### 7. Schema DDL — [src/lib.rs](../src/lib.rs)
+
+- Add `database TEXT` column to both `CREATE TABLE` statements.
+
+### 8. `execute_http` Activity
+
+- No changes needed. HTTP requests don't target a database.
+
+## Validation
+
+When `df.start()` receives a non-NULL `database` parameter, we should validate that the database exists. This can be done via:
+
+```sql
+SELECT 1 FROM pg_database WHERE datname = $1
+```
+
+If the database doesn't exist, raise an error immediately rather than letting the background worker fail later with a confusing connection error.
+
+**Role validation:** We do *not* need to validate that `login_role` can connect to the target database at `df.start()` time. The existing behavior already defers connection errors to activity execution time, which is appropriate for durable functions (the role/database might be created between `df.start()` and actual execution).
+
+## Security Considerations
+
+- **Role isolation is preserved.** The existing `login_role` / `submitted_by` / `SET ROLE` mechanism works identically regardless of target database. The user who calls `df.start()` determines the execution role, not the target database.
+- **`pg_hba.conf` applies.** The background worker's `login_role` connection to a different database is subject to the same `pg_hba.conf` rules as any other connection. If the role can't connect to that database, the activity fails with a clear error.
+- **No privilege escalation.** Targeting a different database doesn't grant additional privileges. The `SET ROLE` still constrains execution to the `submitted_by` role's permissions *in that database*.
+
+## Observability
+
+- `df.instances` and `df.nodes` gain a `database` column visible in `SELECT * FROM df.instances`.
+- Background worker logs already include the SQL being executed; adding the database name to log messages in `execute_sql` would be helpful.
+- `df.status()` and `df.result()` work unchanged—they query `df.instances`/`df.nodes` which are always in the extension database.
+
+## Migration
+
+- Existing rows in `df.instances` and `df.nodes` will have `database = NULL`, which correctly means "the extension database." No data migration needed.
+- The schema change is additive (`ADD COLUMN ... DEFAULT NULL`), safe for rolling upgrades.
+
+## Testing
+
+### Unit Tests
+
+- Verify `df.start()` accepts the new parameter.
+- Verify NULL database defaults to `pg_durable.database`.
+
+### E2E Tests
+
+- **Same-database (regression):** Existing tests continue to pass without changes.
+
+- **Cross-database test** (`NN_multi_database.sql`):
+
+  Must run as **superuser** (add to the superuser list in `test-e2e-local.sh`) because it creates/drops a database. However, the durable function itself should be submitted by `df_e2e_user` (non-privileged) to validate that role isolation works across databases.
+
+  ```sql
+  -- 1. Setup: create test database and grant access to df_e2e_user
+  CREATE DATABASE test_multi_db;
+  GRANT CONNECT ON DATABASE test_multi_db TO df_e2e_user;
+
+  -- 2. Create a table in the target database for df_e2e_user
+  --    (use dblink since we can't switch databases mid-session)
+  SELECT dblink_exec(
+      'dbname=test_multi_db',
+      'CREATE TABLE test_tbl (id INT, value TEXT)'
+  );
+  SELECT dblink_exec(
+      'dbname=test_multi_db',
+      'GRANT ALL ON test_tbl TO df_e2e_user'
+  );
+
+  -- 3. Submit durable function as df_e2e_user targeting test_multi_db
+  SET SESSION AUTHORIZATION df_e2e_user;
+  CREATE TEMP TABLE _test_state (instance_id TEXT);
+  INSERT INTO _test_state SELECT df.start(
+      df.sql('INSERT INTO test_tbl VALUES (1, ''hello'')'),
+      database => 'test_multi_db'
+  );
+  RESET SESSION AUTHORIZATION;
+
+  -- 4. Poll until complete (standard pattern)
+  -- ...
+
+  -- 5. Verify the row exists in test_multi_db
+  SELECT * FROM dblink(
+      'dbname=test_multi_db',
+      'SELECT value FROM test_tbl WHERE id = 1'
+  ) AS t(value TEXT);
+  -- Assert value = 'hello'
+
+  -- 6. Cleanup
+  DROP TABLE _test_state;
+  DROP DATABASE test_multi_db;
+  ```
+
+  Key aspects this test validates:
+  - `df.start()` with `database =>` parameter works
+  - SQL executes in the target database, not the extension database
+  - Role isolation: function runs as `df_e2e_user`, not the background worker's superuser
+  - `login_role` can connect to the target database (requires `GRANT CONNECT`)
+
+- **Invalid database:** Verify `df.start(..., database => 'nonexistent')` raises an immediate error (not a deferred background worker failure).
+
+## Scope Exclusions
+
+- **Cross-database functions:** A single function graph spanning multiple databases (e.g., read from `db1`, write to `db2`) is not supported. This would require per-node database targeting, which adds significant DSL and orchestration complexity. Users can achieve this via `dblink`/`postgres_fdw` within SQL queries, or by starting separate durable functions per database.
+- **Extension installation in multiple databases:** The extension continues to be installed in exactly one database. Supporting multiple installations would require distributed coordination between background workers.
+- **Connection pooling per database:** Each SQL activity creates a fresh connection (existing behavior). Per-database connection pooling could improve performance but is orthogonal to this feature.
+
+## Summary of Changes
+
+| File | Change |
+|------|--------|
+| `src/lib.rs` | Add `database TEXT` column to `df.instances` and `df.nodes` DDL |
+| `src/dsl.rs` | Add `database` param to `df.start()`, validate, pass to `insert_nodes()` |
+| `src/types.rs` | Add `database` to `FunctionNode`; add `database` param to `connect_as_user()` |
+| `src/activities/execute_sql.rs` | Add `database` to `ExecuteSqlInput`, pass to `connect_as_user()` |
+| `src/activities/load_function_graph.rs` | Include `database` in node SELECT |
+| `src/orchestrations/execute_function_graph.rs` | Include `node.database` in `ExecuteSqlInput` JSON |
+| `tests/e2e/sql/` | Add multi-database E2E test |

--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -312,6 +312,7 @@ for run in $(seq 1 $REPEAT_COUNT); do
         # 27 creates users and tests permissions
         # 28 drops/creates the extension
         # 29 uses dblink and creates pg_durable in a different database
+        # 34 creates/drops a database for multi-database testing
         PSQL_USER="$E2E_USER"
         if [[ "$test_name" == "00_requires_shared_preload" \
            || "$test_name" == "22_cross_connection" \
@@ -320,7 +321,8 @@ for run in $(seq 1 $REPEAT_COUNT); do
            || "$test_name" == 26_superuser_* \
            || "$test_name" == "27_user_isolation" \
            || "$test_name" == "28_bgw_lifecycle" \
-           || "$test_name" == "29_database_validation" ]]; then
+           || "$test_name" == "29_database_validation" \
+           || "$test_name" == "34_multi_database" ]]; then
             PSQL_USER="$PG_USER"
         fi
         

--- a/src/activities/execute_sql.rs
+++ b/src/activities/execute_sql.rs
@@ -19,6 +19,9 @@ pub struct ExecuteSqlInput {
     pub query: String,
     pub submitted_by: String,
     pub login_role: String,
+    /// Target database (None = extension database)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
 }
 
 /// Execute a SQL query as the submitting user and return results as JSON
@@ -31,12 +34,24 @@ pub async fn execute(
         serde_json::from_str(&input_json).map_err(|e| format!("Invalid execute_sql input: {e}"))?;
 
     ctx.trace_info(format!(
-        "Executing SQL as '{}' (connected as '{}'): {}",
-        input.submitted_by, input.login_role, input.query
+        "Executing SQL as '{}' (connected as '{}'){}: {}",
+        input.submitted_by,
+        input.login_role,
+        input
+            .database
+            .as_ref()
+            .map(|db| format!(" in database '{db}'"))
+            .unwrap_or_default(),
+        input.query
     ));
 
     // Create a single connection as login_role, SET ROLE to submitted_by
-    let mut conn = connect_as_user(&input.login_role, &input.submitted_by).await?;
+    let mut conn = connect_as_user(
+        &input.login_role,
+        &input.submitted_by,
+        input.database.as_deref(),
+    )
+    .await?;
 
     match sqlx::query(&input.query).fetch_all(&mut conn).await {
         Ok(rows) => {

--- a/src/activities/load_function_graph.rs
+++ b/src/activities/load_function_graph.rs
@@ -58,7 +58,8 @@ pub async fn execute(
         r#"SELECT id, node_type, query, result_name,
            left_node, right_node,
            submitted_by::text AS submitted_by,
-           login_role::text AS login_role
+           login_role::text AS login_role,
+           database
         FROM df.nodes WHERE instance_id = '{instance_id}'"#
     );
 
@@ -79,6 +80,7 @@ pub async fn execute(
             right_node: row.get("right_node"),
             submitted_by: row.get::<String, _>("submitted_by"),
             login_role: row.get::<String, _>("login_role"),
+            database: row.get("database"),
         };
         nodes.insert(id, node);
     }

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -475,8 +475,13 @@ pub fn signal(instance_id: &str, signal_name: &str, signal_data: default!(&str, 
 /// Starts a durable SQL function.
 /// The fut argument can be either Durofut JSON or plain SQL string (auto-wrapped).
 /// Variables from df.vars are captured and passed to the orchestration.
+/// Optional database parameter targets a specific database on the cluster.
 #[pg_extern(schema = "df")]
-pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
+pub fn start(
+    fut: &str,
+    label: default!(Option<&str>, "NULL"),
+    database: default!(Option<&str>, "NULL"),
+) -> String {
     let durofut = match Durofut::ensure_strict(fut) {
         Ok(d) => d,
         Err(e) => pgrx::error!("Invalid durable function: {}", e),
@@ -487,6 +492,19 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
         pgrx::error!("Invalid durable function graph: {}", e);
     }
     let instance_id = short_id();
+
+    // Validate that the target database exists (if specified)
+    if let Some(db) = database {
+        let exists: Option<bool> = Spi::get_one(&format!(
+            "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = '{}')",
+            db.replace('\'', "''")
+        ))
+        .ok()
+        .flatten();
+        if exists != Some(true) {
+            pgrx::error!("database \"{}\" does not exist", db);
+        }
+    }
 
     // Capture user identity for privilege isolation
     let session_user_oid = unsafe { pgrx::pg_sys::GetSessionUserId() };
@@ -505,6 +523,7 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
         instance_id: &str,
         outer_user_oid: u32,
         session_user_oid: u32,
+        database: Option<&str>,
     ) -> String {
         let node_id = short_id();
 
@@ -512,11 +531,11 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
         let left_id = node
             .left_node
             .as_ref()
-            .map(|n| insert_nodes(n, instance_id, outer_user_oid, session_user_oid));
+            .map(|n| insert_nodes(n, instance_id, outer_user_oid, session_user_oid, database));
         let right_id = node
             .right_node
             .as_ref()
-            .map(|n| insert_nodes(n, instance_id, outer_user_oid, session_user_oid));
+            .map(|n| insert_nodes(n, instance_id, outer_user_oid, session_user_oid, database));
 
         // Process config JSON to recursively insert embedded nodes and get their IDs
         let query_escaped = match node.transform_config_children(|child| {
@@ -525,6 +544,7 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
                 instance_id,
                 outer_user_oid,
                 session_user_oid,
+                database,
             ))
         }) {
             Ok(Some(updated_query)) => {
@@ -550,10 +570,14 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
             .map(|id| format!("'{id}'"))
             .unwrap_or_else(|| "NULL".to_string());
 
+        let database_escaped = database
+            .map(|db| format!("'{}'", db.replace('\'', "''")))
+            .unwrap_or_else(|| "NULL".to_string());
+
         // Insert this node with the generated ID
         let insert_sql = format!(
-            "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, login_role)
-             VALUES ('{}', '{}', '{}', {}, {}, {}, {}, {}::oid::regrole, {}::oid::regrole)",
+            "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, login_role, database)
+             VALUES ('{}', '{}', '{}', {}, {}, {}, {}, {}::oid::regrole, {}::oid::regrole, {})",
             node_id,
             instance_id,
             node.node_type.replace('\'', "''"),
@@ -562,7 +586,8 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
             left_node_escaped,
             right_node_escaped,
             outer_user_oid,
-            session_user_oid
+            session_user_oid,
+            database_escaped
         );
 
         if let Err(e) = Spi::run(&insert_sql) {
@@ -573,16 +598,27 @@ pub fn start(fut: &str, label: default!(Option<&str>, "NULL")) -> String {
         node_id
     }
 
-    let root_node_id = insert_nodes(&durofut, &instance_id, outer_oid_u32, session_oid_u32);
+    let root_node_id = insert_nodes(
+        &durofut,
+        &instance_id,
+        outer_oid_u32,
+        session_oid_u32,
+        database,
+    );
+
+    let database_sql = database
+        .map(|db| format!("'{}'", db.replace('\'', "''")))
+        .unwrap_or_else(|| "NULL".to_string());
 
     // Create instance record with root node ID
     let create_instance_sql = format!(
-        "INSERT INTO df.instances (id, label, root_node, status, submitted_by, login_role) VALUES ('{}', {}, '{}', 'pending', {}::oid::regrole, {}::oid::regrole)",
+        "INSERT INTO df.instances (id, label, root_node, status, submitted_by, login_role, database) VALUES ('{}', {}, '{}', 'pending', {}::oid::regrole, {}::oid::regrole, {})",
         instance_id,
         label_sql,
         root_node_id,
         outer_oid_u32,
-        session_oid_u32
+        session_oid_u32,
+        database_sql
     );
 
     if let Err(e) = Spi::run(&create_instance_sql) {

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -495,13 +495,15 @@ pub fn start(
 
     // Validate that the target database exists (if specified)
     if let Some(db) = database {
-        let exists: Option<bool> = Spi::get_one(&format!(
+        let exists: bool = match Spi::get_one(&format!(
             "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = '{}')",
             db.replace('\'', "''")
-        ))
-        .ok()
-        .flatten();
-        if exists != Some(true) {
+        )) {
+            Ok(Some(v)) => v,
+            Ok(None) => false,
+            Err(e) => pgrx::error!("failed to check database existence: {}", e),
+        };
+        if !exists {
             pgrx::error!("database \"{}\" does not exist", db);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ CREATE TABLE IF NOT EXISTS df.nodes (
     error TEXT,
     submitted_by REGROLE,
     login_role   REGROLE,
+    database TEXT,
     created_at TIMESTAMPTZ DEFAULT now(),
     updated_at TIMESTAMPTZ DEFAULT now()
 );
@@ -111,6 +112,7 @@ CREATE TABLE IF NOT EXISTS df.instances (
     status TEXT DEFAULT 'pending',
     submitted_by REGROLE NOT NULL,
     login_role   REGROLE NOT NULL,
+    database TEXT,
     created_at TIMESTAMPTZ DEFAULT now(),
     updated_at TIMESTAMPTZ DEFAULT now(),
     completed_at TIMESTAMPTZ
@@ -914,7 +916,7 @@ mod tests {
     #[pg_test]
     fn test_start_returns_instance_id() {
         let fut = crate::dsl::sql("SELECT 1");
-        let instance_id = crate::dsl::start(&fut, None);
+        let instance_id = crate::dsl::start(&fut, None, None);
         assert_eq!(instance_id.len(), 8);
         assert!(instance_id.chars().all(|c| c.is_ascii_hexdigit()));
     }
@@ -922,14 +924,14 @@ mod tests {
     #[pg_test]
     fn test_start_with_label() {
         let fut = crate::dsl::sql("SELECT 1");
-        let instance_id = crate::dsl::start(&fut, Some("my-test-function"));
+        let instance_id = crate::dsl::start(&fut, Some("my-test-function"), None);
         assert_eq!(instance_id.len(), 8);
     }
 
     #[pg_test]
     fn test_start_creates_instance_row() {
         let fut = crate::dsl::sql("SELECT 42");
-        let instance_id = crate::dsl::start(&fut, Some("test-instance-row"));
+        let instance_id = crate::dsl::start(&fut, Some("test-instance-row"), None);
         let count = Spi::get_one::<i64>(&format!(
             "SELECT COUNT(*) FROM df.instances WHERE id = '{instance_id}'"
         ))
@@ -941,7 +943,7 @@ mod tests {
     #[pg_test]
     fn test_status_returns_pending_for_new() {
         let fut = crate::dsl::sql("SELECT 1");
-        let instance_id = crate::dsl::start(&fut, None);
+        let instance_id = crate::dsl::start(&fut, None, None);
         let status = crate::dsl::status(&instance_id);
         assert_eq!(status, Some("pending".to_string()));
     }
@@ -973,8 +975,8 @@ mod tests {
         // The same graph JSON can be reused with df.start() multiple times,
         // each producing a distinct instance with its own node IDs.
         let fut = crate::dsl::sql("SELECT 1");
-        let id1 = crate::dsl::start(&fut, None);
-        let id2 = crate::dsl::start(&fut, None);
+        let id1 = crate::dsl::start(&fut, None, None);
+        let id2 = crate::dsl::start(&fut, None, None);
         assert_ne!(id1, id2, "Each start should create a new instance");
     }
 
@@ -1067,7 +1069,7 @@ mod tests {
     fn test_setvar_after_start_works() {
         // df.start() should not affect subsequent setvar calls
         let fut = crate::dsl::sql("SELECT 1");
-        let _ = crate::dsl::start(&fut, None);
+        let _ = crate::dsl::start(&fut, None, None);
 
         // setvar should work fine after start returns
         let result = crate::dsl::setvar("after_start_var", "works");
@@ -1086,7 +1088,7 @@ mod tests {
     fn test_explain_detects_instance_id() {
         // Create an instance first
         let fut = crate::dsl::sql("SELECT 1");
-        let instance_id = crate::dsl::start(&fut, None);
+        let instance_id = crate::dsl::start(&fut, None, None);
 
         // Explain should recognize it as an instance ID
         let result = crate::explain::explain(&instance_id);
@@ -1253,7 +1255,7 @@ mod tests {
     #[pg_test]
     fn test_autowrap_start_plain_sql() {
         // Start with plain SQL - simplest possible durable function
-        let instance_id = crate::dsl::start("SELECT 42", Some("autowrap-test"));
+        let instance_id = crate::dsl::start("SELECT 42", Some("autowrap-test"), None);
         assert_eq!(instance_id.len(), 8);
 
         // Verify instance was created
@@ -1332,7 +1334,7 @@ mod tests {
         // Start durable function
         let sql =
             crate::dsl::sql("INSERT INTO test_e2e_simple (val) VALUES ('hello') RETURNING id");
-        let instance_id = crate::dsl::start(&sql, Some("test-e2e-simple"));
+        let instance_id = crate::dsl::start(&sql, Some("test-e2e-simple"), None);
 
         // Wait for completion
         let result = wait_for_completion(&instance_id, 10);
@@ -1367,7 +1369,7 @@ mod tests {
         let step2 = crate::dsl::sql("INSERT INTO test_e2e_seq (step) VALUES (2)");
         let seq = crate::dsl::then_fn(&step1, &step2);
 
-        let instance_id = crate::dsl::start(&seq, Some("test-e2e-seq"));
+        let instance_id = crate::dsl::start(&seq, Some("test-e2e-seq"), None);
 
         // Wait for completion
         let result = wait_for_completion(&instance_id, 10);
@@ -1407,7 +1409,7 @@ mod tests {
         );
         let seq = crate::dsl::then_fn(&named, &use_val);
 
-        let instance_id = crate::dsl::start(&seq, Some("test-e2e-vars"));
+        let instance_id = crate::dsl::start(&seq, Some("test-e2e-vars"), None);
 
         // Wait for completion
         let result = wait_for_completion(&instance_id, 10);
@@ -1434,7 +1436,7 @@ mod tests {
         let sql_node = crate::dsl::sql("SELECT 'done'");
         let seq = crate::dsl::then_fn(&sleep_node, &sql_node);
 
-        let instance_id = crate::dsl::start(&seq, Some("test-e2e-sleep"));
+        let instance_id = crate::dsl::start(&seq, Some("test-e2e-sleep"), None);
 
         // Wait for completion (with extra time for sleep)
         let result = wait_for_completion(&instance_id, 15);
@@ -1456,7 +1458,7 @@ mod tests {
         let else_branch = crate::dsl::sql("SELECT 'no' as result");
         let if_node = crate::dsl::if_fn(&condition, &then_branch, &else_branch);
 
-        let instance_id = crate::dsl::start(&if_node, Some("test-e2e-if-true"));
+        let instance_id = crate::dsl::start(&if_node, Some("test-e2e-if-true"), None);
 
         let result = wait_for_completion(&instance_id, 10);
         assert!(result.is_ok(), "Function failed: {result:?}");
@@ -1473,7 +1475,7 @@ mod tests {
         let else_branch = crate::dsl::sql("SELECT 'no' as result");
         let if_node = crate::dsl::if_fn(&condition, &then_branch, &else_branch);
 
-        let instance_id = crate::dsl::start(&if_node, Some("test-e2e-if-false"));
+        let instance_id = crate::dsl::start(&if_node, Some("test-e2e-if-false"), None);
 
         let result = wait_for_completion(&instance_id, 10);
         assert!(result.is_ok(), "Function failed: {result:?}");
@@ -1491,7 +1493,7 @@ mod tests {
         let else_branch = crate::dsl::sql("SELECT 'falsy' as result");
         let if_node = crate::dsl::if_fn(&condition, &then_branch, &else_branch);
 
-        let instance_id = crate::dsl::start(&if_node, Some("test-e2e-if-zero"));
+        let instance_id = crate::dsl::start(&if_node, Some("test-e2e-if-zero"), None);
 
         let result = wait_for_completion(&instance_id, 10);
         assert!(result.is_ok(), "Function failed: {result:?}");
@@ -1518,7 +1520,7 @@ mod tests {
         let branch_b = crate::dsl::sql("INSERT INTO test_e2e_join (branch) VALUES ('B')");
         let join_node = crate::dsl::join(&branch_a, &branch_b);
 
-        let instance_id = crate::dsl::start(&join_node, Some("test-e2e-join"));
+        let instance_id = crate::dsl::start(&join_node, Some("test-e2e-join"), None);
 
         let result = wait_for_completion(&instance_id, 15);
         assert!(result.is_ok(), "Function failed: {result:?}");
@@ -1548,7 +1550,7 @@ mod tests {
         let c = crate::dsl::sql("SELECT 3 as val");
         let join_node = crate::dsl::join3(&a, &b, &c);
 
-        let instance_id = crate::dsl::start(&join_node, Some("test-e2e-join3"));
+        let instance_id = crate::dsl::start(&join_node, Some("test-e2e-join3"), None);
 
         let result = wait_for_completion(&instance_id, 15);
         assert!(result.is_ok(), "Function failed: {result:?}");
@@ -1564,7 +1566,7 @@ mod tests {
     fn test_e2e_cancel_running() {
         // Start a long-running sleep
         let sleep_node = crate::dsl::sleep(300); // 5 minutes
-        let instance_id = crate::dsl::start(&sleep_node, Some("test-e2e-cancel"));
+        let instance_id = crate::dsl::start(&sleep_node, Some("test-e2e-cancel"), None);
 
         // Give it a moment to start
         std::thread::sleep(std::time::Duration::from_millis(500));
@@ -1600,8 +1602,8 @@ mod tests {
         // Start a few durable functions
         let sql1 = crate::dsl::sql("SELECT 1");
         let sql2 = crate::dsl::sql("SELECT 2");
-        let id1 = crate::dsl::start(&sql1, Some("test-list-1"));
-        let id2 = crate::dsl::start(&sql2, Some("test-list-2"));
+        let id1 = crate::dsl::start(&sql1, Some("test-list-1"), None);
+        let id2 = crate::dsl::start(&sql2, Some("test-list-2"), None);
 
         // Wait for both to complete
         let _ = wait_for_completion(&id1, 10);
@@ -1626,7 +1628,7 @@ mod tests {
     #[ignore = "pgrx doesn't support shared_preload_libraries"]
     fn test_e2e_instance_info() {
         let sql = crate::dsl::sql("SELECT 'info-test'");
-        let instance_id = crate::dsl::start(&sql, Some("test-info-label"));
+        let instance_id = crate::dsl::start(&sql, Some("test-info-label"), None);
 
         let _ = wait_for_completion(&instance_id, 10);
 
@@ -1648,7 +1650,7 @@ mod tests {
         let a = crate::dsl::sql("SELECT 1");
         let b = crate::dsl::sql("SELECT 2");
         let seq = crate::dsl::then_fn(&a, &b);
-        let instance_id = crate::dsl::start(&seq, None);
+        let instance_id = crate::dsl::start(&seq, None, None);
 
         let _ = wait_for_completion(&instance_id, 10);
 
@@ -1670,7 +1672,7 @@ mod tests {
     fn test_e2e_sql_error() {
         // Try to select from a non-existent table
         let sql = crate::dsl::sql("SELECT * FROM nonexistent_table_xyz_12345");
-        let instance_id = crate::dsl::start(&sql, Some("test-sql-error"));
+        let instance_id = crate::dsl::start(&sql, Some("test-sql-error"), None);
 
         let result = wait_for_completion(&instance_id, 10);
 
@@ -1687,7 +1689,7 @@ mod tests {
     #[ignore = "pgrx doesn't support shared_preload_libraries"]
     fn test_e2e_status_sync() {
         let sql = crate::dsl::sql("SELECT 'sync-test'");
-        let instance_id = crate::dsl::start(&sql, Some("test-status-sync"));
+        let instance_id = crate::dsl::start(&sql, Some("test-status-sync"), None);
 
         let result = wait_for_completion(&instance_id, 10);
         assert!(result.is_ok(), "Function failed: {result:?}");

--- a/src/orchestrations/execute_function_graph.rs
+++ b/src/orchestrations/execute_function_graph.rs
@@ -269,6 +269,7 @@ async fn execute_sql_node(
         "query": final_query,
         "submitted_by": node.submitted_by,
         "login_role": node.login_role,
+        "database": node.database,
     });
 
     let result = ctx

--- a/src/types.rs
+++ b/src/types.rs
@@ -77,13 +77,16 @@ pub fn target_database() -> String {
 pub async fn connect_as_user(
     login_role: &str,
     effective_role: &str,
+    database: Option<&str>,
 ) -> Result<sqlx::postgres::PgConnection, String> {
     use sqlx::postgres::PgConnectOptions;
     use sqlx::Connection;
 
+    let default_db = target_database();
+    let db = database.unwrap_or(&default_db);
     let mut options = PgConnectOptions::new()
         .username(login_role)
-        .database(&target_database())
+        .database(db)
         .port(get_port());
 
     let host = get_host();
@@ -344,6 +347,9 @@ pub struct FunctionNode {
     pub submitted_by: String,
     /// Authenticated role (session user) for connection authentication
     pub login_role: String,
+    /// Target database for SQL execution (None = extension database)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
 }
 
 /// Represents the entire function graph for an instance

--- a/src/types.rs
+++ b/src/types.rs
@@ -98,8 +98,8 @@ pub async fn connect_as_user(
         .await
         .map_err(|e| {
             format!(
-                "Failed to connect as '{}' (for effective role '{}'). Error: {}",
-                login_role, effective_role, e
+                "Failed to connect to database '{}' as '{}' (for effective role '{}'). Error: {}",
+                db, login_role, effective_role, e
             )
         })?;
 

--- a/tests/e2e/sql/34_multi_database.sql
+++ b/tests/e2e/sql/34_multi_database.sql
@@ -1,0 +1,185 @@
+-- Test: Multi-database support
+--
+-- Validates that df.start() can target a specific database on the cluster
+-- using the optional `database` parameter.
+--
+-- Must run as superuser because it creates/drops a database.
+--
+-- Tests:
+-- 1. df.start() with database => works and executes SQL in the target database
+-- 2. df.start() with database => 'nonexistent' raises an immediate error
+-- 3. df.start() without database parameter (regression) still works
+
+CREATE EXTENSION IF NOT EXISTS dblink;
+
+-- ============================================================================
+-- Test 1: Execute durable function in a different database
+-- ============================================================================
+
+DROP DATABASE IF EXISTS _test_multi_db;
+CREATE DATABASE _test_multi_db;
+GRANT CONNECT ON DATABASE _test_multi_db TO df_e2e_user;
+
+-- Create a test table in the target database and grant access to df_e2e_user
+SELECT dblink_exec(
+    format('host=localhost dbname=_test_multi_db port=%s user=postgres', current_setting('port')),
+    'CREATE TABLE test_multi (id INT, value TEXT)'
+);
+SELECT dblink_exec(
+    format('host=localhost dbname=_test_multi_db port=%s user=postgres', current_setting('port')),
+    'GRANT ALL ON test_multi TO df_e2e_user'
+);
+
+-- Submit durable function as df_e2e_user targeting _test_multi_db
+SET SESSION AUTHORIZATION df_e2e_user;
+
+CREATE TEMP TABLE _test_state (instance_id TEXT);
+INSERT INTO _test_state SELECT df.start(
+    'INSERT INTO test_multi VALUES (1, ''hello from multi-db'')',
+    'test-multi-db',
+    '_test_multi_db'
+);
+
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+
+    SELECT df.wait_for_completion(inst_id) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [multi-db]: status = %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED: durable function completed in target database';
+END $$;
+
+-- Verify the row exists in _test_multi_db
+DO $$
+DECLARE
+    connstr TEXT;
+    row_value TEXT;
+BEGIN
+    connstr := format(
+        'host=localhost dbname=_test_multi_db port=%s user=postgres',
+        current_setting('port')
+    );
+
+    SELECT val INTO row_value
+    FROM dblink(connstr, 'SELECT value FROM test_multi WHERE id = 1')
+         AS t(val TEXT);
+
+    IF row_value IS NULL OR row_value != 'hello from multi-db' THEN
+        RAISE EXCEPTION 'TEST FAILED [multi-db verify]: expected ''hello from multi-db'', got %', row_value;
+    END IF;
+
+    RAISE NOTICE 'PASSED: verified row exists in target database: %', row_value;
+END $$;
+
+-- Verify the database column is set on the instance and nodes
+DO $$
+DECLARE
+    inst_id TEXT;
+    inst_db TEXT;
+    node_db TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+
+    SELECT database INTO inst_db FROM df.instances WHERE id = inst_id;
+    IF inst_db != '_test_multi_db' THEN
+        RAISE EXCEPTION 'TEST FAILED [instance.database]: expected _test_multi_db, got %', inst_db;
+    END IF;
+
+    SELECT database INTO node_db FROM df.nodes WHERE instance_id = inst_id LIMIT 1;
+    IF node_db != '_test_multi_db' THEN
+        RAISE EXCEPTION 'TEST FAILED [node.database]: expected _test_multi_db, got %', node_db;
+    END IF;
+
+    RAISE NOTICE 'PASSED: database column correctly set on instance and nodes';
+END $$;
+
+DROP TABLE _test_state;
+
+-- ============================================================================
+-- Test 2: Invalid database raises immediate error
+-- ============================================================================
+
+DO $$
+DECLARE
+    err_msg TEXT;
+BEGIN
+    SET SESSION AUTHORIZATION df_e2e_user;
+
+    BEGIN
+        PERFORM df.start(
+            'SELECT 1',
+            'test-bad-db',
+            'nonexistent_database_abc'
+        );
+        -- Should not reach here
+        RAISE EXCEPTION 'TEST FAILED: df.start() should have errored for nonexistent database';
+    EXCEPTION WHEN OTHERS THEN
+        err_msg := SQLERRM;
+    END;
+
+    RESET SESSION AUTHORIZATION;
+
+    IF err_msg NOT ILIKE '%nonexistent_database_abc%' THEN
+        RAISE EXCEPTION 'TEST FAILED [invalid db]: expected error about nonexistent_database_abc, got: %', err_msg;
+    END IF;
+    IF err_msg NOT ILIKE '%does not exist%' THEN
+        RAISE EXCEPTION 'TEST FAILED [invalid db]: expected "does not exist" in error, got: %', err_msg;
+    END IF;
+
+    RAISE NOTICE 'PASSED: invalid database correctly rejected: %', err_msg;
+END $$;
+
+-- ============================================================================
+-- Test 3: Regression - df.start() without database still works
+-- ============================================================================
+
+SET SESSION AUTHORIZATION df_e2e_user;
+CREATE TEMP TABLE _test_state2 (instance_id TEXT);
+
+INSERT INTO _test_state2 SELECT df.start(
+    'SELECT 99 as answer',
+    'test-no-db'
+);
+
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    inst_db TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state2;
+
+    SELECT df.wait_for_completion(inst_id) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [regression]: status = %', status;
+    END IF;
+
+    SELECT database INTO inst_db FROM df.instances WHERE id = inst_id;
+    IF inst_db IS NOT NULL THEN
+        RAISE EXCEPTION 'TEST FAILED [regression]: database should be NULL, got %', inst_db;
+    END IF;
+
+    RAISE NOTICE 'PASSED: regression test - df.start() without database works';
+END $$;
+
+DROP TABLE _test_state2;
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+
+DROP DATABASE IF EXISTS _test_multi_db;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/34_multi_database.sql
+++ b/tests/e2e/sql/34_multi_database.sql
@@ -9,6 +9,8 @@
 -- 1. df.start() with database => works and executes SQL in the target database
 -- 2. df.start() with database => 'nonexistent' raises an immediate error
 -- 3. df.start() without database parameter (regression) still works
+-- 4. Multi-node sequence graph targeting another database
+-- 5. Database dropped after df.start() — deferred connection failure
 
 CREATE EXTENSION IF NOT EXISTS dblink;
 
@@ -175,6 +177,154 @@ BEGIN
 END $$;
 
 DROP TABLE _test_state2;
+
+-- ============================================================================
+-- Test 4: Multi-node sequence graph targeting another database
+-- ============================================================================
+
+-- Insert a second row and update it in sequence, all in the target database
+SET SESSION AUTHORIZATION df_e2e_user;
+
+CREATE TEMP TABLE _test_state3 (instance_id TEXT);
+INSERT INTO _test_state3 SELECT df.start(
+    'INSERT INTO test_multi VALUES (10, ''step1'')'
+    ~> 'UPDATE test_multi SET value = ''step2'' WHERE id = 10'
+    ~> 'INSERT INTO test_multi VALUES (11, ''step3'')',
+    'test-multi-db-seq',
+    '_test_multi_db'
+);
+
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    node_count INT;
+    nodes_with_db INT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state3;
+
+    SELECT df.wait_for_completion(inst_id) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [multi-node seq]: status = %', status;
+    END IF;
+
+    -- Verify all nodes in the graph have the database field set
+    SELECT COUNT(*), COUNT(database) INTO node_count, nodes_with_db
+    FROM df.nodes WHERE instance_id = inst_id;
+
+    IF node_count != nodes_with_db THEN
+        RAISE EXCEPTION 'TEST FAILED [multi-node seq]: only %/% nodes have database set', nodes_with_db, node_count;
+    END IF;
+
+    RAISE NOTICE 'PASSED: multi-node sequence completed (% nodes, all with database)', node_count;
+END $$;
+
+-- Verify the rows in _test_multi_db
+DO $$
+DECLARE
+    connstr TEXT;
+    row_val TEXT;
+    row_cnt INT;
+BEGIN
+    connstr := format(
+        'host=localhost dbname=_test_multi_db port=%s user=postgres',
+        current_setting('port')
+    );
+
+    -- id=10 should have been updated to 'step2'
+    SELECT val INTO row_val
+    FROM dblink(connstr, 'SELECT value FROM test_multi WHERE id = 10')
+         AS t(val TEXT);
+    IF row_val != 'step2' THEN
+        RAISE EXCEPTION 'TEST FAILED [multi-node seq verify]: id=10 expected step2, got %', row_val;
+    END IF;
+
+    -- id=11 should exist with 'step3'
+    SELECT val INTO row_val
+    FROM dblink(connstr, 'SELECT value FROM test_multi WHERE id = 11')
+         AS t(val TEXT);
+    IF row_val != 'step3' THEN
+        RAISE EXCEPTION 'TEST FAILED [multi-node seq verify]: id=11 expected step3, got %', row_val;
+    END IF;
+
+    RAISE NOTICE 'PASSED: multi-node sequence results verified in target database';
+END $$;
+
+DROP TABLE _test_state3;
+
+-- ============================================================================
+-- Test 5: Database dropped after df.start() — deferred connection failure
+-- ============================================================================
+
+-- Create a temporary database, start a loop targeting it, then drop it
+-- to verify the worker produces a clean 'failed' status.
+
+DROP DATABASE IF EXISTS _test_drop_db;
+CREATE DATABASE _test_drop_db;
+GRANT CONNECT ON DATABASE _test_drop_db TO df_e2e_user;
+
+-- Create a table in the target database so the first iteration can succeed
+SELECT dblink_exec(
+    format('host=localhost dbname=_test_drop_db port=%s user=postgres', current_setting('port')),
+    'CREATE TABLE drop_test (id SERIAL, ts TIMESTAMP DEFAULT now())'
+);
+SELECT dblink_exec(
+    format('host=localhost dbname=_test_drop_db port=%s user=postgres', current_setting('port')),
+    'GRANT ALL ON drop_test TO df_e2e_user'
+);
+SELECT dblink_exec(
+    format('host=localhost dbname=_test_drop_db port=%s user=postgres', current_setting('port')),
+    'GRANT USAGE, SELECT ON SEQUENCE drop_test_id_seq TO df_e2e_user'
+);
+
+SET SESSION AUTHORIZATION df_e2e_user;
+
+CREATE TEMP TABLE _test_state4 (instance_id TEXT);
+INSERT INTO _test_state4 SELECT df.start(
+    df.loop(
+        'INSERT INTO drop_test (id) VALUES (DEFAULT)' ~> df.sleep(2)
+    ),
+    'test-drop-db-loop',
+    '_test_drop_db'
+);
+
+RESET SESSION AUTHORIZATION;
+
+-- Give the first iteration time to start
+SELECT pg_sleep(3);
+
+-- Drop the database (terminate existing connections first)
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+WHERE datname = '_test_drop_db' AND pid != pg_backend_pid();
+DROP DATABASE IF EXISTS _test_drop_db;
+
+-- Wait for the instance to fail (loop should fail on next iteration)
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state4;
+
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF lower(status) != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [drop-db]: expected failed, got %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED: deferred connection failure produced clean failed status';
+END $$;
+
+DROP TABLE _test_state4;
 
 -- ============================================================================
 -- Cleanup

--- a/tests/e2e/sql/34_multi_database.sql
+++ b/tests/e2e/sql/34_multi_database.sql
@@ -108,12 +108,12 @@ DROP TABLE _test_state;
 -- Test 2: Invalid database raises immediate error
 -- ============================================================================
 
+SET SESSION AUTHORIZATION df_e2e_user;
+
 DO $$
 DECLARE
     err_msg TEXT;
 BEGIN
-    SET SESSION AUTHORIZATION df_e2e_user;
-
     BEGIN
         PERFORM df.start(
             'SELECT 1',
@@ -126,8 +126,6 @@ BEGIN
         err_msg := SQLERRM;
     END;
 
-    RESET SESSION AUTHORIZATION;
-
     IF err_msg NOT ILIKE '%nonexistent_database_abc%' THEN
         RAISE EXCEPTION 'TEST FAILED [invalid db]: expected error about nonexistent_database_abc, got: %', err_msg;
     END IF;
@@ -137,6 +135,8 @@ BEGIN
 
     RAISE NOTICE 'PASSED: invalid database correctly rejected: %', err_msg;
 END $$;
+
+RESET SESSION AUTHORIZATION;
 
 -- ============================================================================
 -- Test 3: Regression - df.start() without database still works


### PR DESCRIPTION
## Summary

Allow durable functions to target any database on the cluster by adding an optional `database` parameter to `df.start()`. A single function invocation targets exactly one database; cross-database workflows can use `dblink`/`postgres_fdw` or separate durable functions.

Design spec: [docs/multi-database.md](docs/multi-database.md)

## API

```sql
-- Existing (unchanged):
SELECT df.start(df.sql('SELECT 1'));
SELECT df.start(df.sql('SELECT 1'), 'my-label');

-- New: target a specific database
SELECT df.start(df.sql('SELECT 1'), database => 'analytics');
SELECT df.start(df.sql('SELECT 1'), 'my-label', 'analytics');
```

Invalid database names are rejected immediately at `df.start()` time.

## Changes

| File | Change |
|------|--------|
| `src/lib.rs` | Add `database TEXT` column to `df.nodes` and `df.instances` DDL |
| `src/dsl.rs` | Add `database` param to `df.start()` with `pg_database` validation |
| `src/types.rs` | Add `database` to `FunctionNode`; add `database` param to `connect_as_user()` |
| `src/activities/execute_sql.rs` | Add `database` to `ExecuteSqlInput`, pass to `connect_as_user()` |
| `src/activities/load_function_graph.rs` | Include `database` in node SELECT |
| `src/orchestrations/execute_function_graph.rs` | Include `node.database` in SQL activity input |
| `tests/e2e/sql/34_multi_database.sql` | E2E test: cross-db execution, invalid db, regression |
| `scripts/test-e2e-local.sh` | Add test 34 to superuser list |

## Testing

- All 75 unit tests pass
- All E2E tests pass including new test 34 (cross-database execution, invalid database rejection, backward compatibility)
- Clippy clean, fmt clean