### PR TITLE
Add Row-Level Security (RLS) for per-user isolation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,13 +35,14 @@ cargo build                    # or: make build
 
 # Run E2E tests locally
 ./scripts/test-e2e-local.sh              # all tests
-./scripts/test-e2e-local.sh 04_parallel  # specific test
+./scripts/test-e2e-local.sh --verbose    # -v, shows test output, use with filtering
+./scripts/test-e2e-local.sh 04_parallel  # filter/specific test
 ./scripts/test-e2e-local.sh --keep       # keep server running for debugging
 
 # Connect to test database (after --keep)
 ~/.pgrx/17.*/pgrx-install/bin/psql -h localhost -p 28817 -d postgres
 
-# View background worker logs
+# View background worker logs, do this especially when debugging E2E tests
 tail -f ~/.pgrx/17.log
 
 # Stop test server

--- a/README.md
+++ b/README.md
@@ -84,6 +84,33 @@ CREATE EXTENSION pg_durable;
 ./scripts/deploy-acr.sh
 ```
 
+### Multi-User Setup
+
+`CREATE EXTENSION pg_durable` automatically grants permissions to `PUBLIC`, so any database role can use the `df.*` functions immediately. Row-level security (RLS) ensures each user can only see and manage their own durable function instances and nodes.
+
+**No manual grants needed.** If you want to restrict access to specific roles instead of all users:
+
+```sql
+-- Revoke the default PUBLIC grants
+REVOKE ALL ON SCHEMA df FROM PUBLIC;
+REVOKE ALL ON ALL TABLES IN SCHEMA df FROM PUBLIC;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA df FROM PUBLIC;
+
+-- Grant to specific roles only
+GRANT USAGE ON SCHEMA df TO app_role;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO app_role;
+GRANT SELECT, INSERT ON df.instances TO app_role;
+GRANT UPDATE (status, updated_at) ON df.instances TO app_role;
+GRANT SELECT, INSERT ON df.nodes TO app_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO app_role;
+```
+
+**Key points:**
+- The background worker role (`pg_durable.worker_role` GUC, default: `azuresu`) **must be a superuser** — it bypasses RLS to manage all users' instances
+- Users get `SELECT` + `INSERT` on `df.instances` / `df.nodes`, column-level `UPDATE (status, updated_at)` on instances for `df.cancel()`
+- Identity columns (`submitted_by`, `login_role`) cannot be modified by users
+- **`df.vars` is currently a shared global table with no per-user isolation** — any role can read or overwrite any other user's variables. Do not store secrets in `df.vars`. Per-user scoping is planned. In multi-tenant environments, consider revoking `df.vars` grants from `PUBLIC`
+
 ## Continuous Integration
 
 All pull requests must pass the following checks before merging:

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1498,38 +1498,56 @@ HTTP requests (`df.http()`) currently execute with the **background worker's pri
 
 #### Cross-Instance Visibility
 
-Any user with `SELECT` access to `df.instances` can see **all instances**, including:
-- Who submitted them (`submitted_by` column)
-- Their labels and status
-- When they were created
+Row-level security (RLS) restricts each user to their own instances and nodes:
 
-**Future:** Row-level security (RLS) to restrict visibility to own instances is planned.
+- Users can only see instances they submitted (`submitted_by = current_user`)
+- `df.list_instances()`, `df.status()`, `df.result()` automatically filter to the caller's own data
+- `df.cancel()` and `df.signal()` check ownership before acting — attempts on other users' instances return "Instance not found or access denied"
+- Superusers bypass RLS and can see all instances (standard PostgreSQL behavior)
 
 ### Security Best Practices
 
-1. **Grant minimal permissions** - Only grant `df` schema access to users who need it
-2. **Review df.vars usage** - Avoid storing secrets in shared variables
-3. **Use labels carefully** - Labels are visible to all users; avoid including sensitive info
-4. **Monitor instances** - Use `df.list_instances()` to see who's running what
-5. **Clean up** - Cancel or delete old instances to reduce cross-user visibility
+1. **Worker role must be superuser** — The background worker role (`pg_durable.worker_role`) must be a superuser to bypass RLS and manage all instances
+2. **Review df.vars usage** — Variables are currently shared across all users; avoid storing secrets
+3. **Use labels carefully** — Instance labels are visible only to the submitting user (RLS-filtered) and superusers
+4. **Monitor instances** — Superusers can use `df.list_instances()` to see all users' instances; regular users see only their own
 
 ### Privilege Grants
 
-To allow a user to use pg_durable:
+`CREATE EXTENSION pg_durable` automatically grants permissions to `PUBLIC`. No manual grants are required for basic usage — any database role can use `df.*` functions immediately, and RLS ensures per-user isolation.
+
+The automatic grants are:
 
 ```sql
--- Minimum grants for basic usage
-GRANT USAGE ON SCHEMA df TO username;
-GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO username;
-
--- Current implementation requires table access
--- (This will be tightened in future releases)
-GRANT SELECT, INSERT, UPDATE ON df.instances TO username;
-GRANT SELECT, INSERT, UPDATE ON df.nodes TO username;
-GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO username;
+-- Granted automatically by CREATE EXTENSION:
+GRANT USAGE ON SCHEMA df TO PUBLIC;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO PUBLIC;
+GRANT SELECT, INSERT ON df.instances TO PUBLIC;
+GRANT UPDATE (status, updated_at) ON df.instances TO PUBLIC;
+GRANT SELECT, INSERT ON df.nodes TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO PUBLIC;
 ```
 
-**Note:** These grants will become more restrictive as the security model evolves.
+Users get `SELECT` and `INSERT` on `df.instances` and `df.nodes` (required for `df.start()`, `df.status()`, `df.result()`). Column-level `UPDATE` on `(status, updated_at)` allows `df.cancel()` to set status. No full `UPDATE` or `DELETE` — identity columns (`submitted_by`, `login_role`) and structural columns are protected.
+
+> **Warning:** `df.vars` is currently a shared global table with no RLS — any database role can read or overwrite any other user's variables. Do not store secrets or security-sensitive configuration in `df.vars`. Per-user variable scoping (via RLS) is planned for a future release. In multi-tenant environments, consider revoking `df.vars` grants from `PUBLIC` and granting only to trusted roles.
+
+To restrict access to specific roles instead of all users:
+
+```sql
+-- Revoke the default PUBLIC grants
+REVOKE ALL ON SCHEMA df FROM PUBLIC;
+REVOKE ALL ON ALL TABLES IN SCHEMA df FROM PUBLIC;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA df FROM PUBLIC;
+
+-- Grant to specific roles only
+GRANT USAGE ON SCHEMA df TO app_role;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO app_role;
+GRANT SELECT, INSERT ON df.instances TO app_role;
+GRANT UPDATE (status, updated_at) ON df.instances TO app_role;
+GRANT SELECT, INSERT ON df.nodes TO app_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO app_role;
+```
 ## Troubleshooting
 
 ### Extension Exists But Workflows Don't Start

--- a/docs/rls.md
+++ b/docs/rls.md
@@ -1,0 +1,431 @@
+# Row-Level Security (RLS) Design
+
+**Status**: Draft  
+**Branch**: `pinodeca/rls`  
+**Created**: 2026-03-09
+
+---
+
+## 1. Motivation
+
+pg_durable functions are all **SECURITY INVOKER** (the pgrx default — no function uses `security_definer`). This means every SQL statement inside a `df.*` function runs with the *calling user's* privileges, including table access checks.
+
+Today, the E2E test setup manually grants DML on `df.instances`, `df.nodes`, and `df.vars` to each test user:
+
+```sql
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.instances TO df_e2e_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.nodes     TO df_e2e_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars      TO df_e2e_user;
+```
+
+Without table-level grants, `df.start()` would fail — it INSERTs into `df.nodes` and `df.instances` and SELECTs from `df.vars` via SPI, which runs as the calling user.
+
+But granting unrestricted DML means:
+- **Any user can read/modify any other user's instances and nodes** (confidentiality + integrity)
+- **Any user can DELETE another user's instances** (destructive)
+- **`df.vars` is a global key-value store** with no per-user scoping
+- **No protection against cross-user `df.cancel()` / `df.signal()`** (the functions take an arbitrary instance_id and don't check ownership)
+
+RLS solves this: keep the DML grants (users need them for the SPI calls inside `df.*` functions), but restrict which rows each user can see and modify.
+
+---
+
+## 2. Scope
+
+### In scope
+
+| Table | RLS needed? | Reason |
+|-------|-------------|--------|
+| `df.instances` | **Yes** | Contains per-user workflow state; has `submitted_by` column |
+| `df.nodes` | **Yes** | Contains per-user node definitions; has `submitted_by` column |
+| `df.vars` | **Decision needed** | Currently global; spec proposes per-user scoping |
+
+### Out of scope
+
+| Table / schema | Why |
+|----------------|-----|
+| `df._worker_epoch` | Internal sentinel; users should not have access at all (no GRANT) |
+| `duroxide.*` tables | Internal runtime state; accessed only by the background worker's pooled connection (worker role). Users should not have direct access. The monitoring functions (`df.list_instances()`, `df.metrics()`, etc.) access these via a dedicated sqlx pool authenticated as the worker role, not via SPI-as-calling-user |
+| `df.secrets` | Not yet implemented; when it lands, it should be admin-only (no user SELECT, no RLS — just REVOKE) |
+
+### Functions that need RLS-aware data access
+
+These `df.*` functions access `df.instances` or `df.nodes` via SPI (which runs as the calling user and therefore goes through RLS):
+
+| Function | Tables accessed | Access type | RLS effect |
+|----------|----------------|-------------|------------|
+| `df.start()` | `df.nodes` (INSERT), `df.instances` (INSERT), `df.vars` (SELECT) | Write + Read | INSERT policies must allow; vars must be readable |
+| `df.status()` | `df.instances` (SELECT) | Read | User sees only own instances |
+| `df.result()` | `df.instances` (SELECT), `df.nodes` (SELECT) | Read | User sees only own |
+| `df.cancel()` | `df.instances` (SELECT for ownership check) | Read | User can only cancel own instances |
+| `df.signal()` | _(no direct table access — goes through duroxide client)_ | — | No RLS impact |
+| `df.wait_for_completion()` | `df.instances` (SELECT, polling) | Read | User sees only own |
+| `df.explain()` | `df.nodes` (SELECT, for existing instances) | Read | User sees only own |
+| `df.list_instances()` | `df.instances` (SELECT for labels) | Read | User sees only own labels |
+| `df.instance_info()` | `df.instances` (SELECT for label) | Read | User sees only own |
+| `df.instance_nodes()` | `df.nodes` (SELECT) | Read | User sees only own |
+| `df.setvar()` | `df.vars` (INSERT/UPDATE) | Write | Depends on vars design |
+| `df.getvar()` | `df.vars` (SELECT) | Read | Depends on vars design |
+| `df.unsetvar()` | `df.vars` (DELETE) | Write | Depends on vars design |
+| `df.clearvars()` | `df.vars` (DELETE) | Write | Depends on vars design |
+
+### Background worker access (NOT affected by RLS)
+
+The background worker accesses `df.instances` and `df.nodes` via sqlx pool connections authenticated as the worker role. The worker role must **bypass RLS** because it needs to load and update any user's instances/nodes:
+
+| Activity | Tables accessed | Worker needs |
+|----------|----------------|--------------|
+| `load_function_graph` | `df.instances` (SELECT), `df.nodes` (SELECT) | Read all rows |
+| `update_node_status` | `df.nodes` (UPDATE) | Update any row |
+| `update_instance_status` | `df.instances` (UPDATE) | Update any row |
+| `execute_sql` | _(User SQL on separate per-user connection)_ | Not applicable |
+
+---
+
+## 3. Design Decisions
+
+### Decision 1: RLS policy column — `submitted_by` vs `current_user`
+
+`df.instances.submitted_by` stores the effective role (outer user) captured at `df.start()` time as a `REGROLE`. The RLS policy compares this to `current_user`:
+
+```sql
+CREATE POLICY instances_user_isolation ON df.instances
+    USING (submitted_by = current_user::regrole);
+```
+
+This is the correct choice because:
+- `current_user` in an SPI call from a SECURITY INVOKER function = the calling user
+- `submitted_by` is set by trusted extension code via `GetOuterUserId()` — users cannot forge it
+- `REGROLE` comparison handles OID-based identity correctly
+
+**Decision**: Use `submitted_by = current_user::regrole`. ✅ No ambiguity.
+
+### Decision 2: Separate INSERT policy for `df.start()`
+
+`df.start()` inserts rows with `submitted_by` set to the calling user's OID. The USING clause applies to SELECT/UPDATE/DELETE. For INSERT, we need a WITH CHECK clause:
+
+```sql
+CREATE POLICY instances_user_isolation ON df.instances
+    FOR ALL
+    USING (submitted_by = current_user::regrole)
+    WITH CHECK (submitted_by = current_user::regrole);
+```
+
+This ensures a user can only INSERT rows where `submitted_by` matches their own identity. Since `df.start()` sets `submitted_by` via `GetOuterUserId()`, this is always true for legitimate calls. It also prevents a user from manually inserting a row with a forged `submitted_by`.
+
+**Decision**: Single FOR ALL policy with both USING and WITH CHECK. ✅ No ambiguity.
+
+### Decision 3: `df.nodes` policy — direct column vs join to `df.instances`
+
+Two options:
+
+**(A) Direct column check** (simpler, faster):
+```sql
+CREATE POLICY nodes_user_isolation ON df.nodes
+    FOR ALL
+    USING (submitted_by = current_user::regrole)
+    WITH CHECK (submitted_by = current_user::regrole);
+```
+
+**(B) Join to instances** (single source of truth):
+```sql
+CREATE POLICY nodes_user_isolation ON df.nodes
+    FOR ALL
+    USING (
+        instance_id IS NULL  -- unlinked nodes (during DSL building)
+        OR EXISTS (SELECT 1 FROM df.instances WHERE id = instance_id AND submitted_by = current_user::regrole)
+    )
+    WITH CHECK (...);
+```
+
+**Analysis**:
+- Option A is simpler and faster (no subquery). The `submitted_by` column on nodes is set by `df.start()` at the same time as `instance_id`, ensuring consistency.
+- Option B adds a correctness dependency on `df.instances` — if `df.instances` rows are deleted, nodes become invisible even though they still exist. Adds query overhead.
+- Unlinked nodes (`instance_id IS NULL` and `submitted_by IS NULL`): These are created during DSL expression building (e.g., `df.sql('SELECT 1')` before `df.start()`). They don't yet belong to any user. See Decision 4.
+
+**Decision**: **Option A** — use direct column check on `df.nodes.submitted_by`. Simpler, no join overhead.
+
+### ~~Decision 4: Unlinked nodes (pre-`df.start()`)~~ — NOT AN ISSUE
+
+An earlier draft of this document stated that DSL functions like `df.sql()` insert rows into `df.nodes` with `submitted_by = NULL`. This is **incorrect**.
+
+DSL functions (`df.sql()`, `df.seq()`, `df.sleep()`, etc.) do NOT insert rows into `df.nodes`. They build an in-memory JSON tree (the `Durofut` struct). All node rows are inserted inside `df.start()` via its internal `insert_nodes()` function, which sets `instance_id`, `submitted_by`, and `login_role` on every node from the very start.
+
+There are no "unlinked" or "orphan" nodes with `submitted_by = NULL`. Every row in `df.nodes` has `submitted_by` set at INSERT time.
+
+**Decision**: No action needed. ✅ The simple RLS policy `submitted_by = current_user::regrole` works for both `df.instances` and `df.nodes` without any NULL handling.
+
+> **Note on stale documentation**: [docs/user-isolation.md](user-isolation.md) (lines 112–164) describes a two-phase design where DSL functions insert nodes with NULL identity columns and `df.start()` later fills them via UPDATE. This was a design proposal, but the actual implementation took a different approach: nodes are only inserted inside `df.start()`, with identity set from the start. The `Durofut::insert_node()` method described in user-isolation.md does not exist in the codebase. The user-isolation.md doc should be updated to reflect the implemented design.
+
+### Decision 5: `df.vars` scoping
+
+Currently `df.vars` is a global key-value table with no user scoping. The security spec (Section 4.3) identifies this as a cross-user integrity/confidentiality issue and proposes two options:
+
+**(A) Per-user scoping with `owner` column + RLS**:
+```sql
+ALTER TABLE df.vars ADD COLUMN owner REGROLE NOT NULL DEFAULT current_user::regrole;
+-- Change PK from (name) to (owner, name)
+ALTER TABLE df.vars DROP CONSTRAINT vars_pkey;
+ALTER TABLE df.vars ADD PRIMARY KEY (owner, name);
+
+CREATE POLICY vars_user_isolation ON df.vars
+    FOR ALL
+    USING (owner = current_user::regrole)
+    WITH CHECK (owner = current_user::regrole);
+```
+
+**(B) Admin-only** (revoke DML from non-admin users):
+```sql
+REVOKE ALL ON df.vars FROM PUBLIC;
+-- Only admins can set variables
+```
+
+**Analysis**:
+- Option A is the multi-tenant-safe approach. But it requires a schema migration and changes to how `df.start()` captures vars (must filter by `owner`).
+- Option B is simpler but breaks any use case where non-admin users parameterize workflows.
+- A third option: **defer vars scoping** to a separate PR. RLS on `df.instances` and `df.nodes` is the higher-priority isolation fix. Vars scoping is a separate concern that can be addressed incrementally.
+
+**Decision**: Defer vars scoping to a follow-up PR. ✅ Decided. This PR focuses on `df.instances` and `df.nodes` only.
+
+### Decision 6: Worker role RLS bypass
+
+The background worker must read/write all users' instances and nodes. It also needs to connect as arbitrary users for `execute_sql`, access duroxide schema tables, and perform other privileged operations.
+
+**Decision**: The worker role **must be a superuser**. ✅ Decided.
+
+Superusers bypass all permission checks in PostgreSQL, including RLS. This means:
+- No `BYPASSRLS` attribute needed (superusers bypass RLS automatically)
+- No per-table worker policies needed
+- No additional GRANTs to the worker role needed
+- Consistent with the existing trust model: the extension is installed by a superuser, and the worker is trusted code
+
+The worker role is configured via `pg_durable.worker_role` GUC (defaults to `azuresu`). The extension should document that this role must be a superuser.
+
+### Decision 7: `df.cancel()` and `df.signal()` ownership checks
+
+Currently `df.cancel()` takes any `instance_id` and cancels it — no ownership check. With RLS on `df.instances`:
+- `df.cancel()` does `UPDATE df.instances SET status = 'cancelled' WHERE id = ...` via SPI. RLS will silently filter out non-owned rows, so the UPDATE affects 0 rows. The duroxide `cancel_instance()` call is made *before* the UPDATE, and it bypasses RLS (goes through the client connection pool as the worker role).
+- `df.signal()` uses `raise_external_event()` which goes directly through the duroxide client — no SPI table access. RLS does not apply.
+
+**Issue**: `df.cancel()` and `df.signal()` can operate on other users' instances because the duroxide client calls bypass RLS. The SPI UPDATE in `df.cancel()` would be filtered by RLS, but the actual cancellation happens through the client.
+
+**Options**:
+**(A) Add explicit ownership check** in `df.cancel()` and `df.signal()` before calling the duroxide client:
+```rust
+// Check ownership via SPI (which goes through RLS)
+let exists: bool = Spi::get_one(&format!(
+    "SELECT EXISTS(SELECT 1 FROM df.instances WHERE id = '{instance_id}')"
+)).ok().flatten().unwrap_or(false);
+if !exists {
+    pgrx::error!("Instance not found or access denied: {}", instance_id);
+}
+```
+This leverages RLS: the SELECT returns false if the row exists but belongs to another user.
+
+**(B) Rely on convention** — document that `df.cancel()` / `df.signal()` on a non-owned instance is a no-op.
+
+**Decision**: Option A — explicit ownership check via SPI (which goes through RLS) before calling the duroxide client. ✅ Decided.
+
+### Decision 8: GRANT strategy — extension install vs. manual
+
+Should `CREATE EXTENSION pg_durable` automatically GRANT the right permissions to `PUBLIC` (or a specific role), or require manual GRANTs?
+
+**Current state**: No automatic grants. The E2E test setup does manual grants.
+
+**Options**:
+**(A) Extension sets default grants in `extension_sql!`**:
+```sql
+-- Part of CREATE EXTENSION
+GRANT USAGE ON SCHEMA df TO PUBLIC;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.instances TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.nodes TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO PUBLIC;
+```
+With RLS enabled, these broad grants are safe — users can only see/modify their own rows.
+
+**(B) Extension grants to PUBLIC with minimal privileges**:
+```sql
+GRANT USAGE ON SCHEMA df TO PUBLIC;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO PUBLIC;
+-- Users need INSERT for df.start(), SELECT for df.status()/result()
+-- Column-level UPDATE on status/updated_at for df.cancel() — identity columns are protected
+-- No DELETE — instance/node deletion should happen via admin API or TTL
+GRANT SELECT, INSERT ON df.instances TO PUBLIC;
+GRANT UPDATE (status, updated_at) ON df.instances TO PUBLIC;
+GRANT SELECT, INSERT ON df.nodes TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO PUBLIC;
+```
+Column-level UPDATE on `(status, updated_at)` allows `df.cancel()` to set status while preventing users from tampering with identity columns (`submitted_by`, `login_role`) or structural columns (`root_node`). RLS ensures users can only update their own rows. No DELETE on instances/nodes.
+
+**(C) Require manual grants** (current state): Admin explicitly grants after `CREATE EXTENSION`.
+
+**Analysis**:
+- Option A/B with RLS enabled provides good UX — "install extension and it works"
+- Option C requires every admin to run a grant script — easy to forget, leads to support issues
+- Option B is safer (column-level UPDATE, no DELETE) and matches the expected access pattern
+
+**Decision**: Option B — auto-grant with SELECT+INSERT on instances/nodes, column-level `UPDATE (status, updated_at)` on instances, no DELETE. ✅ Decided.
+
+> **Why column-level UPDATE instead of full UPDATE?** `df.cancel()` needs to set `status='cancelled'` via SPI (running as the calling user). A full UPDATE grant would let users tamper with identity columns (`submitted_by`, `login_role`), structural columns (`root_node`), or other metadata. Column-level `GRANT UPDATE (status, updated_at)` allows only the columns needed for cancellation while RLS restricts updates to the user's own rows. All other status/result changes (completion, failure) flow through the background worker's activities via the superuser sqlx pool.
+
+---
+
+## 4. Proposed RLS Policies
+
+### 4.1 `df.instances`
+
+```sql
+ALTER TABLE df.instances ENABLE ROW LEVEL SECURITY;
+-- No FORCE — superuser/table-owner bypasses RLS (see Decision 4.4)
+
+CREATE POLICY instances_user_isolation ON df.instances
+    FOR ALL
+    USING (submitted_by = current_user::regrole)
+    WITH CHECK (submitted_by = current_user::regrole);
+```
+
+### 4.2 `df.nodes`
+
+```sql
+ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY nodes_user_isolation ON df.nodes
+    FOR ALL
+    USING (submitted_by = current_user::regrole)
+    WITH CHECK (submitted_by = current_user::regrole);
+```
+
+No `submitted_by IS NULL` clause is needed — all nodes are inserted by `df.start()` with `submitted_by` already set (see Decision 4).
+
+### 4.3 Worker bypass
+
+The worker role must be a superuser (see Decision 6). Superusers bypass RLS automatically — no additional configuration needed.
+
+```sql
+-- No RLS bypass configuration needed.
+-- The worker role (pg_durable.worker_role GUC, default: azuresu) must be a superuser.
+-- Superusers bypass all permission checks including RLS.
+```
+
+### 4.4 `FORCE ROW LEVEL SECURITY`
+
+`ENABLE ROW LEVEL SECURITY` only applies RLS to non-owner roles. If the table owner queries the table, RLS is bypassed. `FORCE ROW LEVEL SECURITY` makes RLS apply even to the table owner.
+
+Question: Should we use `FORCE`? In pg_durable, the table "owner" is whoever ran `CREATE EXTENSION` (typically the superuser). `FORCE` would make RLS apply even to the superuser, which may be undesirable for debugging. However, without `FORCE`, the superuser sees all rows — which is expected admin behavior.
+
+**Recommendation**: Do NOT use `FORCE ROW LEVEL SECURITY`. Superusers should see all rows (standard PostgreSQL convention). The spec already notes that superusers are trusted (they install the extension).
+
+Revised:
+```sql
+ALTER TABLE df.instances ENABLE ROW LEVEL SECURITY;
+-- No FORCE — superuser/table-owner bypasses RLS (standard behavior)
+
+ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
+```
+
+---
+
+## 5. Implementation Plan
+
+### Phase 1: Core RLS (this PR)
+
+1. **Add RLS policies** in `extension_sql!` in `src/lib.rs`
+   - Enable RLS on `df.instances` and `df.nodes`
+   - Create user isolation policies
+   - Handle worker role bypass
+
+2. **Add ownership checks** to `df.cancel()` and `df.signal()` (Decision 7)
+   - SELECT from `df.instances` (goes through RLS) before calling duroxide client
+
+3. **Add automatic GRANTs** in `extension_sql!` (Decision 8)
+   - GRANT appropriate permissions to PUBLIC
+   - RLS makes broad grants safe
+
+4. **Rework monitoring functions** for per-user visibility
+   - `df.list_instances()`: Query `df.instances` via SPI first (RLS-filtered to calling user's rows), then use only those instance IDs when calling the duroxide client
+   - `df.instance_info()`: Already queries `df.instances` via SPI for label — RLS filters automatically. Add ownership check before calling duroxide client
+   - `df.instance_executions()`: Add ownership check (SPI query on `df.instances`) before calling duroxide client
+   - `df.instance_nodes()`: Already queries `df.nodes` via SPI — RLS filters automatically
+   - `df.metrics()`: No change — returns aggregate counts, OK for any user
+
+5. **Update E2E tests**
+   - Remove manual grants from `00_setup_playground.sql` (now automatic)
+   - Update `27_user_isolation.sql` to test RLS-enforced isolation
+   - Add new RLS-specific tests
+
+### Phase 2: Variables scoping (future PR)
+
+- Add `owner` column to `df.vars`
+- Migrate to per-user variable scoping
+- Add RLS policies for `df.vars`
+
+---
+
+## 6. Open Questions
+
+All decisions have been resolved. No open questions remain.
+
+### Resolved decisions
+
+- **Decision 5 (vars scoping)**: Deferred to follow-up PR. This PR focuses on `df.instances` and `df.nodes`. ✅
+- **Decision 6 (worker bypass)**: Worker role must be a superuser → bypasses RLS automatically. ✅
+- **Decision 7 (cancel/signal ownership)**: Explicit ownership check before duroxide client call. ✅
+- **Decision 8 (auto-grants)**: GRANT to PUBLIC in `CREATE EXTENSION` with column-level UPDATE on `(status, updated_at)` for instances, no DELETE on instances/nodes. ✅
+- **Monitoring functions**: Rework `df.list_instances()`, `df.instance_info()`, `df.instance_executions()`, and `df.instance_nodes()` to only show the calling user's own instances. Currently these functions fetch instance IDs from the duroxide client (which returns ALL instances via the worker's connection), then join with `df.instances` for labels. With RLS, the SPI label query is already filtered — but the duroxide client still returns other users' instance IDs, causing a mismatch. Fix: query `df.instances` via SPI first (RLS-filtered), then use only those IDs when calling the duroxide client. ✅
+- **`df.metrics()`**: OK for any user — returns aggregate system-wide counts with no per-instance data. No RLS consideration needed. ✅
+
+---
+
+## 7. Test Plan
+
+### Unit tests
+- Verify `submitted_by` is set on node creation (not just at `df.start()`)
+- Verify RLS policies are created during `CREATE EXTENSION`
+
+### E2E tests
+
+**Test: User can only see own instances**
+```sql
+SET SESSION AUTHORIZATION alice;
+SELECT df.start(df.sql('SELECT 1'), 'alice-job');
+RESET SESSION AUTHORIZATION;
+
+SET SESSION AUTHORIZATION bob;
+SELECT count(*) FROM df.instances;  -- Should be 0
+SELECT df.status('<alice-instance-id>');  -- Should return NULL
+RESET SESSION AUTHORIZATION;
+```
+
+**Test: User cannot cancel another user's instance**
+```sql
+SET SESSION AUTHORIZATION alice;
+SELECT df.start(df.sql('SELECT pg_sleep(10)'), 'alice-long-job');
+RESET SESSION AUTHORIZATION;
+
+SET SESSION AUTHORIZATION bob;
+SELECT df.cancel('<alice-instance-id>');  -- Should fail or no-op
+RESET SESSION AUTHORIZATION;
+```
+
+**Test: User cannot see another user's nodes**
+```sql
+SET SESSION AUTHORIZATION bob;
+SELECT count(*) FROM df.nodes WHERE instance_id = '<alice-instance-id>';  -- Should be 0
+RESET SESSION AUTHORIZATION;
+```
+
+**Test: Worker can access all instances**
+- Verify the background worker can load/update instances from any user
+- Verify workflows complete successfully with RLS enabled
+
+**Test: `df.vars` behavior** (if per-user scoping is implemented)
+```sql
+SET SESSION AUTHORIZATION alice;
+SELECT df.setvar('key', 'alice-value');
+RESET SESSION AUTHORIZATION;
+
+SET SESSION AUTHORIZATION bob;
+SELECT df.getvar('key');  -- Should return NULL (per-user) or 'alice-value' (global)
+RESET SESSION AUTHORIZATION;
+```

--- a/docs/spec-security-model.md
+++ b/docs/spec-security-model.md
@@ -1,9 +1,9 @@
 # pg_durable Security Model Specification
 
-**Status**: Draft  
+**Status**: Implementation in progress  
 **Authors**: pg_durable Team  
 **Created**: 2025-12-25  
-**Last Updated**: 2026-03-09
+**Last Updated**: 2026-03-10
 
 ---
 
@@ -95,10 +95,10 @@ The security guarantee is: **only superusers can install the extension**, theref
 | Threat | Severity | Status | Notes |
 |--------|----------|--------|-------|
 | **T8**: SSRF via HTTP Activity | **CRITICAL** | Implemented | Dataplane protection — see [spec-ssrf-protection.md](spec-ssrf-protection.md) |
-| **T4**: Information Disclosure via df.* Tables | **HIGH** | Not implemented | RLS policies needed |
+| **T4**: Information Disclosure via df.* Tables | **HIGH** | Implemented | RLS on `df.instances` and `df.nodes` — see [rls.md](rls.md) |
 | **T9**: Unauthorized HTTP Access | **HIGH** | Not implemented | `REVOKE EXECUTE` + admin allowlist (future spec) |
 | **T11**: Secret Exfiltration | **HIGH** | Not implemented | Additive feature; no table/API exists yet |
-| **T10**: Cross-User Variable Injection | **MEDIUM-HIGH** | Not implemented | Per-user `df.vars` scoping via RLS |
+| **T10**: Cross-User Variable Injection | **MEDIUM-HIGH** | Partially implemented | Instance/node isolation via RLS; `df.vars` scoping deferred — see [rls.md](rls.md) |
 | **T5**: Denial of Service | **MEDIUM** | Not implemented | Rate limiting; deferred |
 | **T6**: Worker Code Vulnerability | **MEDIUM** | Mitigated by design | Relies on code review |
 | **T0**: SECURITY DEFINER Misuse | **MEDIUM** | Documentation-only | Expected PG behavior |
@@ -177,21 +177,15 @@ SELECT df.start(
 
 #### T4: Information Disclosure via df.* Tables
 
-**Severity**: HIGH  |  **Status**: Not implemented
+**Severity**: HIGH  |  **Status**: Implemented
 
-**Threat**: User queries `df.instances` or `df.nodes` to see other users' durable functions. Without RLS, any user with SELECT access can see all workflows, infer execution patterns, and read metadata belonging to other users.
+**Threat**: User queries `df.instances` or `df.nodes` to see other users' durable functions.
 
-**Mitigation**: Row-Level Security (RLS) on `df.instances` and `df.nodes`:
-```sql
-ALTER TABLE df.instances ENABLE ROW LEVEL SECURITY;
-CREATE POLICY user_isolation ON df.instances
-    USING (submitted_by = current_user::regrole);
+**Mitigation (implemented)**: RLS policies on `df.instances` and `df.nodes` enforce per-user visibility using `submitted_by = current_user::regrole`. Auto-grants provide SELECT+INSERT on both tables and column-level `UPDATE (status, updated_at)` on instances (no DELETE). Ownership checks in `df.cancel()` and `df.signal()` prevent cross-user operations via the duroxide client. Monitoring functions (`df.list_instances()`, `df.instance_info()`, etc.) also enforce ownership.
 
-ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
--- Nodes inherit visibility from their instance (see Section 7 for the full policy)
-```
+See [rls.md](rls.md) for the full design, policy definitions, grant strategy, and decisions.
 
-**Residual Risk**: Low - RLS is well-tested PostgreSQL feature.
+**Residual Risk**: Low — RLS is a well-tested PostgreSQL feature.
 
 ---
 
@@ -280,28 +274,13 @@ See [spec-ssrf-protection.md](spec-ssrf-protection.md) for the full specificatio
 
 #### T10: Cross-User Variable Injection via df.vars
 
-**Severity**: MEDIUM-HIGH  |  **Status**: Not implemented
+**Severity**: MEDIUM-HIGH  |  **Status**: Partially implemented
 
-**Threat**: `df.vars` is a database table used to pass workflow variables into `df.start()`. In the current design, if `df.vars` is globally writable/readable, one user can:
+**Threat**: `df.vars` is a global key-value table. Without per-user scoping, users can override or read each other's variables, potentially redirecting workflows.
 
-- Override variables that another user expects (integrity issue)
-- Read variables set by other users (confidentiality issue)
+**Mitigation (partially implemented)**: Instance and node isolation is enforced via RLS on `df.instances` and `df.nodes` (see T4). Per-user `df.vars` scoping (adding an `owner` column + RLS) is deferred to a follow-up PR — see [rls.md, Decision 5](rls.md).
 
-This can lead to wrong SQL/HTTP destinations if graphs use `$var` substitution. An attacker could redirect another user's workflow to an attacker-controlled endpoint by overwriting a variable like `api_endpoint`.
-
-**Mitigation (recommended)**: Scope variables per-user using a table key and RLS:
-
-- Add an `owner regrole NOT NULL DEFAULT current_user::regrole` column
-- Make the primary key `(owner, name)` (or a unique constraint)
-- Enable RLS and restrict rows to `owner = current_user::regrole`
-- Make `df.start()` capture only the caller's variables
-
-**Mitigation (simplest / restrictive)**: Admin-only variables:
-
-- Revoke `EXECUTE` on `df.setvar/df.unsetvar/df.clearvars` from non-admin roles
-- Revoke direct table access to `df.vars` from PUBLIC
-
-**Residual Risk**: Low with per-user RLS; Medium if global vars remain.
+**Residual Risk**: Medium — `df.vars` remains globally shared until Phase 2.
 
 ---
 
@@ -355,16 +334,7 @@ pg_durable supports workflow variables via `df.setvar()/df.getvar()/df.unsetvar(
 
 **Security requirement**: Variables MUST NOT be global, cross-user state.
 
-Two supported security postures:
-
-1. **Recommended (multi-tenant safe)**: Per-user scoping using `owner regrole` + RLS so users can only read/write their own variables.
-2. **Restricted (admin-only)**: Only admins can set variables. This is simpler but breaks end-user parameterization.
-
-**What breaks if df.vars is admin-only**:
-
-- Any workflow that relies on `df.setvar()` to pass runtime parameters (e.g. tenant id, date ranges, hostnames)
-- Any application pattern where non-admin roles initiate workflows with variable substitution (common for multi-tenant apps)
-- Self-service usage: developers/operators without elevated roles can no longer parameterize workflows without embedding values directly into node queries
+**Current status**: Per-user `df.vars` scoping is deferred to a follow-up PR. Instance and node isolation is enforced via RLS (see T4). See [rls.md, Decision 5](rls.md) for the deferred design.
 
 ---
 
@@ -622,68 +592,16 @@ SELECT df.start(
 
 ## 7. Data Isolation (RLS)
 
-### 7.1 Overview
+**Status**: Implemented
 
-Users should only see their own durable function instances. This uses PostgreSQL's native RLS.
+RLS on `df.instances` and `df.nodes` enforces per-user data isolation. The extension auto-grants appropriate permissions to PUBLIC (SELECT+INSERT on both tables, column-level UPDATE on instances, no DELETE). The background worker bypasses RLS as a superuser.
 
-### 7.2 RLS Configuration
-
-```sql
--- Enable RLS on user-facing tables
-ALTER TABLE df.instances ENABLE ROW LEVEL SECURITY;
-ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
-
--- Users can only see their own instances
-CREATE POLICY instances_user_isolation ON df.instances
-    FOR ALL
-    USING (submitted_by = current_user::regrole)
-    WITH CHECK (submitted_by = current_user::regrole);
-
--- Nodes inherit visibility from their instance
-CREATE POLICY nodes_user_isolation ON df.nodes
-    FOR ALL
-    USING (
-        instance_id IN (
-            SELECT id FROM df.instances 
-            WHERE submitted_by = current_user::regrole
-        )
-    )
-    WITH CHECK (
-        instance_id IN (
-            SELECT id FROM df.instances 
-            WHERE submitted_by = current_user::regrole
-        )
-    );
-
--- duroxide role bypasses RLS (needs to see all instances to execute them)
-ALTER ROLE duroxide BYPASSRLS;
-```
-
-### 7.3 User Experience
-
-```sql
--- User A creates instances
-SET ROLE user_a;
-SELECT df.start(df.sql('SELECT 1'), 'user-a-job-1');
-SELECT df.start(df.sql('SELECT 2'), 'user-a-job-2');
-
--- User A sees only their instances
-SELECT * FROM df.instances;
--- Returns: 2 rows (user-a-job-1, user-a-job-2)
-
--- User B creates an instance
-SET ROLE user_b;
-SELECT df.start(df.sql('SELECT 3'), 'user-b-job-1');
-
--- User B sees only their instance
-SELECT * FROM df.instances;
--- Returns: 1 row (user-b-job-1)
-
--- User A still sees only their own
-SET ROLE user_a;
-SELECT * FROM df.instances;
--- Returns: 2 rows (unchanged)
-```
+See [rls.md](rls.md) for the full design including:
+- RLS policy definitions and rationale
+- Grant strategy (column-level UPDATE, no DELETE)
+- Ownership checks in `df.cancel()`, `df.signal()`, and monitoring functions
+- Worker bypass strategy
+- Deferred `df.vars` scoping (Phase 2)
 
 ---
 
@@ -706,25 +624,9 @@ SELECT * FROM df.instances;
 
 **Note on earlier draft**: An earlier version of this spec proposed `submitted_by OID` and a `security_context JSONB` column. The implemented design uses `REGROLE` (which stores OIDs but displays as role names) and tracks two separate columns (`submitted_by` + `login_role`) instead of a JSON blob. See [user-isolation.md](user-isolation.md) for the full rationale.
 
-#### df.vars Table Updates (per-user scoping)
+#### df.vars Table Updates (per-user scoping) — Deferred
 
-`df.vars` must be scoped per-user to prevent cross-user injection and disclosure.
-
-```sql
--- Proposed schema
-CREATE TABLE IF NOT EXISTS df.vars (
-    owner REGROLE NOT NULL DEFAULT current_user::regrole,
-    name  TEXT    NOT NULL,
-    value TEXT,
-    PRIMARY KEY (owner, name)
-);
-
-ALTER TABLE df.vars ENABLE ROW LEVEL SECURITY;
-CREATE POLICY vars_owner_isolation ON df.vars
-    FOR ALL
-    USING (owner = current_user::regrole)
-    WITH CHECK (owner = current_user::regrole);
-```
+Per-user scoping of `df.vars` (adding an `owner` column + RLS) is deferred to a follow-up PR. See [rls.md, Decision 5](rls.md) for the design.
 
 #### df.secrets Table (admin-managed, workflow-usable)
 
@@ -998,11 +900,13 @@ ORDER BY submitted_at DESC;
 ### 9.2 Administrator Workflow
 
 ```sql
+-- Table grants are auto-applied by CREATE EXTENSION (with RLS enforced).
+-- Admins only need to grant function access:
+
 -- 1. Grant basic df access to a role
 GRANT EXECUTE ON FUNCTION df.start TO app_backend;
 GRANT EXECUTE ON FUNCTION df.sql TO app_backend;
 GRANT EXECUTE ON FUNCTION df.status TO app_backend;
-GRANT SELECT ON df.instances TO app_backend;
 
 -- 2. Optionally enable HTTP for specific roles
 GRANT EXECUTE ON FUNCTION df.http TO etl_service;
@@ -1025,7 +929,8 @@ GROUP BY submitted_by;
 | SQL permission denied | `ERROR: permission denied for table secret_data` (in df.status result) |
 | HTTP host not allowed | `ERROR: HTTP request blocked: host 'evil.com' not in allowed list` |
 | SSRF blocked | `ERROR: HTTP request blocked: resolves to internal IP 169.254.169.254` |
-| RLS violation | (silent - user simply doesn't see other users' rows) |
+| RLS filtered | (silent — user simply doesn't see other users' rows) |
+| Cross-user cancel/signal | `ERROR: Instance not found or access denied: <id>` |
 
 ---
 
@@ -1481,7 +1386,7 @@ SELECT 'TEST PASSED: E2E-SEC-05 Function Permission Requirement' AS result;
 | E2E-SEC-01 | Privilege Isolation | T1, T2 | User accesses only own tables |
 | E2E-SEC-02 | RESET ROLE Escape | T1 | RESET ROLE has no effect |
 | E2E-SEC-03 | SET ROLE Escalation | T2 | SET ROLE to non-member fails |
-| E2E-SEC-04 | RLS Isolation | T4 | Users see only own instances |
+| E2E-SEC-04 | RLS Isolation | T4 | Users see only own instances (see also `37_rls.sql`) |
 | E2E-SEC-05 | Function Permission | - | Users without EXECUTE cannot use df.* |
 | E2E-SEC-06 | Dynamic SQL Escape | T3 | EXECUTE 'RESET ROLE' fails |
 | E2E-SEC-07 | HTTP SSRF Blocked | T8 | Internal IP requests denied |
@@ -1884,7 +1789,7 @@ These tests validate behavior when `execute_sql` fails due to expected errors an
 - [ ] `login_role` and `submitted_by` are captured from `GetSessionUserId()` / `GetOuterUserId()` at `df.start()` time, not from user input
 - [ ] Role names are properly quoted in `SET ROLE` (double-quote with `"` → `""` escaping)
 - [ ] Access control uses PostgreSQL-native function permissions (EXECUTE on df.start/df.sql/df.http)
-- [ ] RLS policies use `current_user`, not user-supplied values
+- [x] RLS policies use `current_user`, not user-supplied values
 - [ ] Error messages don't leak other users' data
 - [ ] Logging includes effective user for audit trail
 - [ ] `SET df.in_workflow = 'true'` is set on user connections to prevent variable mutation during execution (future: could also guard against recursive `df.start()`)

--- a/docs/user-isolation.md
+++ b/docs/user-isolation.md
@@ -109,15 +109,15 @@ COMMENT ON COLUMN df.instances.login_role IS
 
 The `REGROLE` type is a PostgreSQL OID alias that stores the role OID but displays as the role name. It resolves correctly even if the role is renamed, and raises an error at INSERT time if the role doesn't exist.
 
-**Important invariant:** On `df.nodes`, these columns are **nullable** and only set when a node is linked to an instance by `df.start()`. Unlinked nodes (created by DSL functions but not yet started) have `NULL` for both columns. On `df.instances`, they are `NOT NULL` — every instance always has identity.
+**Important invariant:** On `df.nodes`, these columns are **nullable** in the schema but are always set when a node is inserted by `df.start()`. On `df.instances`, they are `NOT NULL` — every instance always has identity.
 
 ### Where Identity Is Captured: Only in `df.start()`
 
-Unlike earlier designs, DSL functions (`df.sql()`, `df.seq()`, etc.) do **not** capture user identity. Nodes are created without `submitted_by` or `login_role` — these columns remain NULL until the node is linked to an instance.
+DSL functions (`df.sql()`, `df.seq()`, etc.) do **not** insert rows into `df.nodes`. They build an in-memory JSON tree (the `Durofut` struct). All node rows are inserted inside `df.start()` via its internal `insert_nodes()` function, which sets `instance_id`, `submitted_by`, and `login_role` on every node at INSERT time.
 
-Identity is captured **only** in `df.start()`, which is the security boundary. This simplifies the DSL functions and ensures a single authoritative capture point.
+Identity is captured **only** in `df.start()`, which is the security boundary. This simplifies the DSL functions and ensures a single authoritative capture point. There are no "unlinked" nodes with NULL identity columns.
 
-#### `df.start()` — instance creation and node linking
+#### `df.start()` — node insertion and instance creation
 
 When `df.start()` is called, three things happen:
 
@@ -129,7 +129,17 @@ let outer_user_oid = unsafe { pgrx::pg_sys::GetOuterUserId() };
 
 We intentionally keep these values as **OIDs**. PostgreSQL's `REGROLE` type stores role OIDs and renders them as names for display.
 
-**b) Instance row is created with both identity columns:**
+**b) All nodes are inserted into `df.nodes`** with identity columns set from the start. The internal `insert_nodes()` function recursively walks the in-memory `Durofut` tree, generating an ID for each node and inserting it with `instance_id`, `submitted_by`, and `login_role` already set:
+```sql
+INSERT INTO df.nodes (id, instance_id, node_type, query, result_name,
+                      left_node, right_node, submitted_by, login_role)
+VALUES ('{node_id}', '{instance_id}', 'SQL', 'SELECT 1', NULL,
+        NULL, NULL,
+        {outer_user_oid}::oid::regrole,
+        {session_user_oid}::oid::regrole)
+```
+
+**c) Instance row is created** with the root node ID and both identity columns:
 ```sql
 INSERT INTO df.instances (id, label, root_node, status, submitted_by, login_role)
 VALUES (
@@ -142,26 +152,11 @@ VALUES (
 )
 ```
 
-**c) All nodes in the graph are linked and their identity columns are set** from the instance:
-```sql
-UPDATE df.nodes
-SET instance_id  = '{instance_id}',
-    submitted_by = {outer_user_oid}::oid::regrole,
-    login_role   = {session_user_oid}::oid::regrole
-WHERE id = '{node_id}'
-```
+Note: Nodes are inserted before the instance because child nodes must be inserted first to generate their IDs, which parent nodes reference via `left_node`/`right_node`. The root node ID is then used in the instance row.
 
-### The `Durofut::insert_node()` change
+### DSL functions build in-memory JSON, not database rows
 
-The `insert_node()` method writes nodes to `df.nodes` but does **not** set `submitted_by` or `login_role`. These columns are omitted from the INSERT (they will be NULL):
-
-```sql
-INSERT INTO df.nodes (id, node_type, query, result_name, left_node, right_node)
-VALUES ('abcd1234', 'SQL', 'SELECT 1', NULL, NULL, NULL)
--- submitted_by and login_role are NULL until df.start() links this node
-```
-
-This means the DSL functions and `Durofut` struct do not need `submitted_by` or `login_role` fields at all. These are only on `FunctionNode` (the runtime representation loaded from the database).
+DSL functions (`df.sql()`, `df.seq()`, etc.) return a `Durofut` JSON string representing the node tree. No rows are inserted into `df.nodes` until `df.start()` is called. The `Durofut` struct does not have `submitted_by` or `login_role` fields — these are only on `FunctionNode` (the runtime representation loaded from the database).
 
 ### Rust struct changes
 
@@ -181,12 +176,11 @@ pub struct FunctionNode {
     pub login_role: String,
 }
 
-// Durofut is UNCHANGED — no identity fields needed
+// Durofut has no identity fields — it's the in-memory DSL representation
 pub struct Durofut {
-    pub node_id: String,
     pub node_type: String,
-    pub left_node: Option<String>,
-    pub right_node: Option<String>,
+    pub left_node: Option<Box<Durofut>>,
+    pub right_node: Option<Box<Durofut>>,
     pub query: Option<String>,
     pub result_name: Option<String>,
 }
@@ -454,15 +448,15 @@ So the membership invariant is guaranteed by PostgreSQL itself — we're replayi
 | File | Change |
 |------|--------|
 | `src/lib.rs` | Add `submitted_by REGROLE` and `login_role REGROLE` columns to `df.nodes` (nullable) and `df.instances` (NOT NULL) DDL; add column comments |
-| `src/types.rs` | Add `submitted_by` and `login_role` fields to `FunctionNode` only (not Durofut); add `connect_as_user(login_role, effective_role)` returning a single `PgConnection`; no changes to `Durofut` or `insert_node()` |
-| `src/dsl.rs` | Only `df.start()` changes: capture `GetSessionUserId()` and `GetOuterUserId()`, write both to instance row, propagate both to nodes via UPDATE |
+| `src/types.rs` | Add `submitted_by` and `login_role` fields to `FunctionNode` only (not Durofut); add `connect_as_user(login_role, effective_role)` returning a single `PgConnection` |
+| `src/dsl.rs` | Only `df.start()` changes: capture `GetSessionUserId()` and `GetOuterUserId()`, insert both into every node row and the instance row (all done inside `insert_nodes()`) |
 | `src/activities/execute_sql.rs` | Add `ExecuteSqlInput` struct with `query`, `submitted_by`, `login_role`; use `connect_as_user()` for a single connection; execute SQL on that connection |
 | `src/activities/load_function_graph.rs` | Add `submitted_by::text` and `login_role::text` to SELECT; map both into `FunctionNode` |
 | `src/orchestrations/execute_function_graph.rs` | Package `query` + `submitted_by` + `login_role` as JSON input when scheduling `execute_sql` activity |
 | `src/registry.rs` | Change activity registration from `query: String` to `input_json: String` |
 | `src/worker.rs` | Filter `sqlx_postgres::options::pgpass` warnings from tracing |
 
-**Not changed:** `src/explain.rs` (explain does not use identity columns), `Durofut` struct, DSL functions other than `df.start()`.
+**Not changed:** `src/explain.rs` (explain does not use identity columns), `Durofut` struct (no identity fields — in-memory DSL only), DSL functions other than `df.start()`.
 
 ## E2E Test Strategy
 

--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -314,6 +314,7 @@ for run in $(seq 1 $REPEAT_COUNT); do
         # 29 uses dblink and creates pg_durable in a different database
         # 34 creates/drops a database for multi-database testing
         # 35 reads df._worker_epoch (internal table)
+        # 37 tests RLS policies, including for superuser, changes users
         PSQL_USER="$E2E_USER"
         if [[ "$test_name" == "00_requires_shared_preload" \
            || "$test_name" == "22_cross_connection" \
@@ -324,7 +325,8 @@ for run in $(seq 1 $REPEAT_COUNT); do
            || "$test_name" == "28_bgw_lifecycle" \
            || "$test_name" == "29_database_validation" \
            || "$test_name" == "34_multi_database" \
-           || "$test_name" == "35_heartbeat_liveness" ]]; then
+           || "$test_name" == "35_heartbeat_liveness" \
+           || "$test_name" == "37_rls" ]]; then
             PSQL_USER="$PG_USER"
         fi
         

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -462,6 +462,19 @@ pub fn signal(instance_id: &str, signal_name: &str, signal_data: default!(&str, 
         pgrx::error!("Signal data must be valid JSON");
     }
 
+    // Ownership check: SPI goes through RLS, so this returns false for
+    // non-owned instances (the row is invisible to the calling user).
+    let exists: bool = Spi::get_one(&format!(
+        "SELECT EXISTS(SELECT 1 FROM df.instances WHERE id = '{}')",
+        instance_id.replace('\'', "''")
+    ))
+    .ok()
+    .flatten()
+    .unwrap_or(false);
+    if !exists {
+        pgrx::error!("Instance not found or access denied: {}", instance_id);
+    }
+
     match raise_external_event(instance_id, signal_name, signal_data) {
         Ok(_) => "OK".to_string(),
         Err(e) => pgrx::error!("Failed to send signal: {}", e),
@@ -669,14 +682,30 @@ pub fn start(
 pub fn cancel(instance_id: &str, reason: default!(&str, "'Cancelled by user'")) -> String {
     use crate::client::cancel_durable_function;
 
+    // Ownership check: SPI goes through RLS, so this returns false for
+    // non-owned instances (the row is invisible to the calling user).
+    let exists: bool = Spi::get_one(&format!(
+        "SELECT EXISTS(SELECT 1 FROM df.instances WHERE id = '{}')",
+        instance_id.replace('\'', "''")
+    ))
+    .ok()
+    .flatten()
+    .unwrap_or(false);
+    if !exists {
+        pgrx::error!("Instance not found or access denied: {}", instance_id);
+    }
+
     if let Err(e) = cancel_durable_function(instance_id, reason) {
         return format!("Failed to cancel: {e}");
     }
 
-    let update_sql = format!(
-        "UPDATE df.instances SET status = 'cancelled', updated_at = now() WHERE id = '{instance_id}'"
-    );
-    let _ = Spi::run(&update_sql);
+    // Update the instance status to 'cancelled' via SPI.
+    // User has column-level UPDATE on (status, updated_at) with RLS restricting to own rows.
+    Spi::run(&format!(
+        "UPDATE df.instances SET status = 'cancelled', updated_at = now() WHERE id = '{}'",
+        instance_id.replace('\'', "''")
+    ))
+    .unwrap_or_else(|e| warning!("Failed to update instance status: {e}"));
 
     format!("Instance {instance_id} cancelled: {reason}")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,66 @@ CREATE TABLE IF NOT EXISTS df._worker_epoch (
 );
 
 // ============================================================================
+// Row-Level Security Policies & Grants
+// ============================================================================
+
+extension_sql!(
+    r#"
+-- Enable RLS on df.instances (no FORCE — superuser/table-owner bypasses RLS)
+ALTER TABLE df.instances ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY instances_user_isolation ON df.instances
+    FOR ALL
+    USING (submitted_by = current_user::regrole)
+    WITH CHECK (submitted_by = current_user::regrole);
+
+-- Enable RLS on df.nodes
+ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY nodes_user_isolation ON df.nodes
+    FOR ALL
+    USING (submitted_by = current_user::regrole)
+    WITH CHECK (submitted_by = current_user::regrole);
+
+-- Auto-grant permissions to PUBLIC (safe with RLS enabled)
+GRANT USAGE ON SCHEMA df TO PUBLIC;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO PUBLIC;
+-- Users need INSERT for df.start(), SELECT for df.status()/result()
+-- Column-level UPDATE on instances: only status + updated_at (for df.cancel())
+-- No UPDATE on identity columns (submitted_by, login_role) or structural columns (root_node)
+-- No DELETE — instance/node deletion should happen via admin API or TTL
+GRANT SELECT, INSERT ON df.instances TO PUBLIC;
+GRANT UPDATE (status, updated_at) ON df.instances TO PUBLIC;
+GRANT SELECT, INSERT ON df.nodes TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO PUBLIC;
+
+-- Validate that the worker role is a superuser.
+-- The background worker must bypass RLS to manage all users' instances/nodes.
+-- If the worker role is not a superuser, workflows will silently fail because
+-- RLS will filter out rows the worker needs to read/update.
+DO $$
+DECLARE
+    wrole TEXT;
+    is_super BOOLEAN;
+BEGIN
+    wrole := current_setting('pg_durable.worker_role', true);
+    IF wrole IS NULL OR wrole = '' THEN
+        wrole := 'azuresu';
+    END IF;
+
+    SELECT rolsuper INTO is_super FROM pg_roles WHERE rolname = wrole;
+    IF is_super IS NULL THEN
+        RAISE WARNING 'pg_durable: worker role "%" does not exist. The background worker will not be able to process workflows. Create the role as a superuser before using pg_durable.', wrole;
+    ELSIF NOT is_super THEN
+        RAISE WARNING 'pg_durable: worker role "%" is not a superuser. The background worker must be a superuser to bypass RLS and manage all users'' instances. Grant superuser or BYPASSRLS to this role.', wrole;
+    END IF;
+END $$;
+"#,
+    name = "rls_and_grants",
+    requires = ["create_tables"]
+);
+
+// ============================================================================
 // Extension Validation (must run before duroxide schema creation)
 // ============================================================================
 

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -29,21 +29,43 @@ pub fn list_instances(
         name!(output, Option<String>),
     ),
 > {
+    if limit_count < 1 {
+        pgrx::error!("limit_count must be at least 1");
+    }
+    let limit_count = limit_count.min(10000);
+
     let pg_conn_str = postgres_connection_string();
 
-    // Fetch labels from PostgreSQL
-    let labels: std::collections::HashMap<String, Option<String>> = Spi::connect(|client| {
-        let mut map = std::collections::HashMap::new();
-        if let Ok(table) = client.select("SELECT id, label FROM df.instances", None, &[]) {
+    // Query df.instances via SPI first — RLS filters to calling user's rows only.
+    // This gives us the user's own instance IDs and labels.
+    let user_instances: Vec<(String, Option<String>)> = Spi::connect(|client| {
+        let sql = if let Some(status) = status_filter {
+            format!(
+                "SELECT id, label FROM df.instances WHERE status = '{}' ORDER BY created_at DESC LIMIT {}",
+                status.replace('\'', "''"),
+                limit_count
+            )
+        } else {
+            format!(
+                "SELECT id, label FROM df.instances ORDER BY created_at DESC LIMIT {}",
+                limit_count
+            )
+        };
+        let mut instances = Vec::new();
+        if let Ok(table) = client.select(&sql, None, &[]) {
             for row in table {
                 if let Ok(Some(id)) = row.get::<String>(1) {
                     let label: Option<String> = row.get(2).ok().flatten();
-                    map.insert(id, label);
+                    instances.push((id, label));
                 }
             }
         }
-        map
+        instances
     });
+
+    if user_instances.is_empty() {
+        return TableIterator::new(vec![]);
+    }
 
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -63,27 +85,13 @@ pub fn list_instances(
 
         let client = Client::new(store);
 
-        let instance_ids = if let Some(status) = status_filter {
-            client
-                .list_instances_by_status(status)
-                .await
-                .unwrap_or_default()
-        } else {
-            client.list_all_instances().await.unwrap_or_default()
-        };
-
-        let limited: Vec<_> = instance_ids
-            .into_iter()
-            .take(limit_count as usize)
-            .collect();
-
         let mut rows = Vec::new();
-        for id in limited {
-            if let Ok(info) = client.get_instance_info(&id).await {
-                let label = labels.get(&info.instance_id).cloned().flatten();
+        // Only query duroxide for the user's own instance IDs
+        for (id, label) in &user_instances {
+            if let Ok(info) = client.get_instance_info(id).await {
                 rows.push((
                     info.instance_id,
-                    label,
+                    label.clone(),
                     info.orchestration_name,
                     info.status,
                     info.current_execution_id as i64,
@@ -116,12 +124,26 @@ pub fn instance_info(
     let pg_conn_str = postgres_connection_string();
     let instance_id_str = instance_id.to_string();
 
+    // Ownership check: SPI goes through RLS, returning NULL for non-owned instances.
     let label: Option<String> = Spi::get_one(&format!(
         "SELECT label FROM df.instances WHERE id = '{}'",
         instance_id.replace('\'', "''")
     ))
     .ok()
     .flatten();
+
+    // Check if the instance exists for this user (RLS-filtered)
+    let exists: bool = Spi::get_one(&format!(
+        "SELECT EXISTS(SELECT 1 FROM df.instances WHERE id = '{}')",
+        instance_id.replace('\'', "''")
+    ))
+    .ok()
+    .flatten()
+    .unwrap_or(false);
+
+    if !exists {
+        return TableIterator::new(vec![]);
+    }
 
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -174,7 +196,20 @@ pub fn instance_executions(
     ),
 > {
     let pg_conn_str = postgres_connection_string();
-    let instance_id = instance_id.to_string();
+    let instance_id_owned = instance_id.to_string();
+
+    // Ownership check: SPI goes through RLS, so non-owned instances are invisible.
+    let exists: bool = Spi::get_one(&format!(
+        "SELECT EXISTS(SELECT 1 FROM df.instances WHERE id = '{}')",
+        instance_id.replace('\'', "''")
+    ))
+    .ok()
+    .flatten()
+    .unwrap_or(false);
+
+    if !exists {
+        return TableIterator::new(vec![]);
+    }
 
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -194,7 +229,7 @@ pub fn instance_executions(
 
         let client = Client::new(store);
 
-        let execution_ids = match client.list_executions(&instance_id).await {
+        let execution_ids = match client.list_executions(&instance_id_owned).await {
             Ok(ids) => ids,
             Err(_) => return vec![],
         };
@@ -205,7 +240,7 @@ pub fn instance_executions(
 
         let mut rows = Vec::new();
         for exec_id in limited {
-            if let Ok(info) = client.get_execution_info(&instance_id, exec_id).await {
+            if let Ok(info) = client.get_execution_info(&instance_id_owned, exec_id).await {
                 let duration_ms = info
                     .completed_at
                     .map(|end| end.saturating_sub(info.started_at))

--- a/tests/e2e/sql/00_setup_playground.sql
+++ b/tests/e2e/sql/00_setup_playground.sql
@@ -16,30 +16,6 @@ BEGIN
     END IF;
 END $$;
 
--- Grant access to df API surface used by tests
--- ---------------------------------------------------------------------------
--- Reusable helper: restore df_e2e_user grants after DROP/CREATE EXTENSION.
--- Called here and by any test that drops & recreates the extension (25, 28).
--- ---------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION public._e2e_grant_df_to_e2e_user() RETURNS void
-LANGUAGE plpgsql AS $$
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'df_e2e_user') THEN
-        RETURN;
-    END IF;
-
-    GRANT USAGE ON SCHEMA df TO df_e2e_user;
-    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO df_e2e_user;
-
-    -- df.start() links nodes/instances and reads vars via direct table access.
-    -- Until table hardening lands, E2E needs DML on these.
-    GRANT SELECT, INSERT, UPDATE, DELETE ON df.instances TO df_e2e_user;
-    GRANT SELECT, INSERT, UPDATE, DELETE ON df.nodes TO df_e2e_user;
-    GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO df_e2e_user;
-END $$;
-
-SELECT public._e2e_grant_df_to_e2e_user();
-
 -- ---------------------------------------------------------------------------
 -- Reusable helper: wait for the background worker to fully reinitialize
 -- after DROP/CREATE EXTENSION. Called by tests 25, 28, 29.

--- a/tests/e2e/sql/25_extension_creation_security.sql
+++ b/tests/e2e/sql/25_extension_creation_security.sql
@@ -84,9 +84,6 @@ DROP SCHEMA IF EXISTS df CASCADE;
 -- Recreate the extension properly for other tests to continue
 CREATE EXTENSION pg_durable;
 
--- Re-grant permissions that were lost when the extension was dropped.
-SELECT public._e2e_grant_df_to_e2e_user();
-
 -- Wait for the background worker to fully reinitialize after the drop/recreate.
 SELECT public._e2e_wait_for_worker_ready();
 

--- a/tests/e2e/sql/27_user_isolation.sql
+++ b/tests/e2e/sql/27_user_isolation.sql
@@ -26,12 +26,8 @@ END $setup$;
 CREATE ROLE iso_alice LOGIN;
 CREATE ROLE iso_bob   LOGIN;
 
--- Grant df permissions
-GRANT USAGE ON SCHEMA df TO iso_alice, iso_bob;
-GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO iso_alice, iso_bob;
-GRANT SELECT, INSERT, UPDATE, DELETE ON df.instances, df.nodes TO iso_alice, iso_bob;
-GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO iso_alice, iso_bob;
--- Alice and Bob need CREATE TEMP TABLE for their test state tables
+-- df schema, functions, and table DML are auto-granted to PUBLIC by CREATE EXTENSION.
+-- Only grant non-auto privileges needed by these tests.
 GRANT TEMPORARY ON DATABASE postgres TO iso_alice, iso_bob;
 
 -- Create per-user tables
@@ -180,10 +176,7 @@ INSERT INTO iso_analyst_data (value) VALUES ('analyst report') ON CONFLICT DO NO
 
 -- Grant iso_analysts to alice and grant df permissions to the group role
 GRANT iso_analysts TO iso_alice;
-GRANT USAGE ON SCHEMA df TO iso_analysts;
-GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO iso_analysts;
-GRANT SELECT, INSERT, UPDATE, DELETE ON df.instances, df.nodes TO iso_analysts;
-GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO iso_analysts;
+-- df schema, functions, and table DML are auto-granted to PUBLIC by CREATE EXTENSION.
 GRANT TEMPORARY ON DATABASE postgres TO iso_analysts;
 
 SET SESSION AUTHORIZATION iso_alice;
@@ -344,10 +337,7 @@ BEGIN
 END $test7_setup$;
 
 CREATE ROLE iso_ephemeral LOGIN;
-GRANT USAGE ON SCHEMA df TO iso_ephemeral;
-GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO iso_ephemeral;
-GRANT SELECT, INSERT, UPDATE, DELETE ON df.instances, df.nodes TO iso_ephemeral;
-GRANT SELECT ON df.vars TO iso_ephemeral;
+-- df schema, functions, and table DML are auto-granted to PUBLIC by CREATE EXTENSION.
 GRANT TEMPORARY ON DATABASE postgres TO iso_ephemeral;
 
 -- Submit a sequence: df.sleep(3) followed by df.sql('SELECT 1')

--- a/tests/e2e/sql/28_bgw_lifecycle.sql
+++ b/tests/e2e/sql/28_bgw_lifecycle.sql
@@ -84,9 +84,6 @@ END $$;
 -- 4) Re-create extension and run another workflow
 CREATE EXTENSION pg_durable;
 
--- Restore df_e2e_user grants lost when the extension was dropped
-SELECT public._e2e_grant_df_to_e2e_user();
-
 -- Wait for the background worker to fully reinitialize
 SELECT public._e2e_wait_for_worker_ready();
 

--- a/tests/e2e/sql/29_database_validation.sql
+++ b/tests/e2e/sql/29_database_validation.sql
@@ -41,9 +41,6 @@ END $$;
 DROP EXTENSION IF EXISTS pg_durable CASCADE;
 CREATE EXTENSION pg_durable;
 
--- Restore df_e2e_user grants lost when the extension was dropped
-SELECT public._e2e_grant_df_to_e2e_user();
-
 -- Wait for the background worker to fully reinitialize
 SELECT public._e2e_wait_for_worker_ready();
 

--- a/tests/e2e/sql/37_rls.sql
+++ b/tests/e2e/sql/37_rls.sql
@@ -1,0 +1,397 @@
+-- Test: Row-Level Security (RLS)
+--
+-- Validates that RLS policies on df.instances and df.nodes enforce
+-- per-user isolation at the table level. Tests:
+-- 1. User can see only own instances
+-- 2. User cannot see another user's nodes
+-- 3. User cannot cancel another user's instance
+-- 4. User cannot signal another user's instance
+-- 5. Monitoring functions respect RLS (list_instances, instance_info)
+-- 6. Superuser can see all instances (RLS bypass)
+--
+-- Must run as SUPERUSER because it uses SET SESSION AUTHORIZATION.
+
+-- ============================================================================
+-- Setup: Create two test users
+-- ============================================================================
+DO $setup$
+BEGIN
+    PERFORM pg_terminate_backend(pid)
+      FROM pg_stat_activity
+      WHERE usename IN ('rls_alice', 'rls_bob')
+        AND pid <> pg_backend_pid();
+
+    BEGIN DROP OWNED BY rls_alice; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP OWNED BY rls_bob;   EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE rls_alice;     EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE rls_bob;       EXCEPTION WHEN undefined_object THEN NULL; END;
+END $setup$;
+
+CREATE ROLE rls_alice LOGIN;
+CREATE ROLE rls_bob   LOGIN;
+
+-- Only grant TEMPORARY for temp tables; df permissions are auto-granted to PUBLIC
+GRANT TEMPORARY ON DATABASE postgres TO rls_alice, rls_bob;
+
+-- ============================================================================
+-- Submit instances as each user
+-- ============================================================================
+
+-- Alice submits a job
+SET SESSION AUTHORIZATION rls_alice;
+CREATE TEMP TABLE _rls_alice_state (instance_id TEXT);
+INSERT INTO _rls_alice_state SELECT df.start(df.sql('SELECT 1 AS alice_result'), 'rls-alice-job');
+RESET SESSION AUTHORIZATION;
+
+-- Bob submits a job
+SET SESSION AUTHORIZATION rls_bob;
+CREATE TEMP TABLE _rls_bob_state (instance_id TEXT);
+INSERT INTO _rls_bob_state SELECT df.start(df.sql('SELECT 2 AS bob_result'), 'rls-bob-job');
+RESET SESSION AUTHORIZATION;
+
+-- Wait for both to complete
+DO $$
+DECLARE
+    alice_id TEXT;
+    bob_id TEXT;
+    s TEXT;
+BEGIN
+    SELECT instance_id INTO alice_id FROM _rls_alice_state;
+    SELECT instance_id INTO bob_id FROM _rls_bob_state;
+
+    SELECT df.wait_for_completion(alice_id, 30) INTO s;
+    IF s != 'completed' THEN
+        RAISE EXCEPTION 'Setup failed: Alice job status = %', s;
+    END IF;
+
+    SELECT df.wait_for_completion(bob_id, 30) INTO s;
+    IF s != 'completed' THEN
+        RAISE EXCEPTION 'Setup failed: Bob job status = %', s;
+    END IF;
+END $$;
+
+-- ============================================================================
+-- Test 1: User can only see own instances
+-- ============================================================================
+DO $$
+DECLARE
+    alice_id TEXT;
+    bob_id TEXT;
+    cnt INT;
+    found_label TEXT;
+BEGIN
+    SELECT instance_id INTO alice_id FROM _rls_alice_state;
+    SELECT instance_id INTO bob_id FROM _rls_bob_state;
+
+    -- As Alice: should see only her instance
+    SET SESSION AUTHORIZATION rls_alice;
+
+    SELECT count(*) INTO cnt FROM df.instances WHERE id = alice_id;
+    IF cnt != 1 THEN
+        RAISE EXCEPTION 'TEST 1 FAILED: Alice cannot see her own instance (count=%, expected 1)', cnt;
+    END IF;
+
+    SELECT count(*) INTO cnt FROM df.instances WHERE id = bob_id;
+    IF cnt != 0 THEN
+        RAISE EXCEPTION 'TEST 1 FAILED: Alice can see Bob''s instance (count=%, expected 0)', cnt;
+    END IF;
+
+    RESET SESSION AUTHORIZATION;
+
+    -- As Bob: should see only his instance
+    SET SESSION AUTHORIZATION rls_bob;
+
+    SELECT count(*) INTO cnt FROM df.instances WHERE id = bob_id;
+    IF cnt != 1 THEN
+        RAISE EXCEPTION 'TEST 1 FAILED: Bob cannot see his own instance (count=%, expected 1)', cnt;
+    END IF;
+
+    SELECT count(*) INTO cnt FROM df.instances WHERE id = alice_id;
+    IF cnt != 0 THEN
+        RAISE EXCEPTION 'TEST 1 FAILED: Bob can see Alice''s instance (count=%, expected 0)', cnt;
+    END IF;
+
+    RESET SESSION AUTHORIZATION;
+
+    RAISE NOTICE 'Test 1 PASSED: Users can only see own instances';
+END $$;
+
+-- ============================================================================
+-- Test 2: User cannot see another user's nodes
+-- ============================================================================
+DO $$
+DECLARE
+    alice_id TEXT;
+    bob_id TEXT;
+    cnt INT;
+BEGIN
+    SELECT instance_id INTO alice_id FROM _rls_alice_state;
+    SELECT instance_id INTO bob_id FROM _rls_bob_state;
+
+    -- As Alice: should not see Bob's nodes
+    SET SESSION AUTHORIZATION rls_alice;
+
+    SELECT count(*) INTO cnt FROM df.nodes WHERE instance_id = bob_id;
+    IF cnt != 0 THEN
+        RAISE EXCEPTION 'TEST 2 FAILED: Alice can see Bob''s nodes (count=%, expected 0)', cnt;
+    END IF;
+
+    -- Alice should see her own nodes
+    SELECT count(*) INTO cnt FROM df.nodes WHERE instance_id = alice_id;
+    IF cnt < 1 THEN
+        RAISE EXCEPTION 'TEST 2 FAILED: Alice cannot see her own nodes (count=%, expected >= 1)', cnt;
+    END IF;
+
+    RESET SESSION AUTHORIZATION;
+
+    -- As Bob: should not see Alice's nodes
+    SET SESSION AUTHORIZATION rls_bob;
+
+    SELECT count(*) INTO cnt FROM df.nodes WHERE instance_id = alice_id;
+    IF cnt != 0 THEN
+        RAISE EXCEPTION 'TEST 2 FAILED: Bob can see Alice''s nodes (count=%, expected 0)', cnt;
+    END IF;
+
+    RESET SESSION AUTHORIZATION;
+
+    RAISE NOTICE 'Test 2 PASSED: Users cannot see other users'' nodes';
+END $$;
+
+-- ============================================================================
+-- Test 3: User cannot cancel another user's instance
+-- ============================================================================
+
+-- Submit a long-running job as Alice for Bob to attempt to cancel
+SET SESSION AUTHORIZATION rls_alice;
+CREATE TEMP TABLE _rls_cancel_state (instance_id TEXT);
+INSERT INTO _rls_cancel_state SELECT df.start(df.sql('SELECT pg_sleep(30)'), 'rls-cancel-target');
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    alice_cancel_id TEXT;
+    err_msg TEXT;
+BEGIN
+    SELECT instance_id INTO alice_cancel_id FROM _rls_cancel_state;
+
+    -- As Bob: try to cancel Alice's instance (should fail)
+    SET SESSION AUTHORIZATION rls_bob;
+
+    BEGIN
+        PERFORM df.cancel(alice_cancel_id);
+        RAISE EXCEPTION 'TEST 3 FAILED: Bob was able to cancel Alice''s instance';
+    EXCEPTION
+        WHEN OTHERS THEN
+            GET STACKED DIAGNOSTICS err_msg = MESSAGE_TEXT;
+            IF err_msg LIKE '%not found or access denied%' THEN
+                RAISE NOTICE 'Test 3 PASSED: Bob cannot cancel Alice''s instance';
+            ELSE
+                RAISE EXCEPTION 'TEST 3 FAILED: Unexpected error: %', err_msg;
+            END IF;
+    END;
+
+    RESET SESSION AUTHORIZATION;
+
+    -- Superuser cleans up by cancelling the job
+    PERFORM df.cancel(alice_cancel_id);
+END $$;
+
+DROP TABLE _rls_cancel_state;
+
+-- ============================================================================
+-- Test 4: User cannot signal another user's instance
+-- ============================================================================
+DO $$
+DECLARE
+    alice_id TEXT;
+    err_msg TEXT;
+BEGIN
+    SELECT instance_id INTO alice_id FROM _rls_alice_state;
+
+    -- As Bob: try to signal Alice's instance (should fail)
+    SET SESSION AUTHORIZATION rls_bob;
+
+    BEGIN
+        PERFORM df.signal(alice_id, 'test-signal', '{}');
+        RAISE EXCEPTION 'TEST 4 FAILED: Bob was able to signal Alice''s instance';
+    EXCEPTION
+        WHEN OTHERS THEN
+            GET STACKED DIAGNOSTICS err_msg = MESSAGE_TEXT;
+            IF err_msg LIKE '%not found or access denied%' THEN
+                RAISE NOTICE 'Test 4 PASSED: Bob cannot signal Alice''s instance';
+            ELSE
+                RAISE EXCEPTION 'TEST 4 FAILED: Unexpected error: %', err_msg;
+            END IF;
+    END;
+
+    RESET SESSION AUTHORIZATION;
+END $$;
+
+-- ============================================================================
+-- Test 5: Monitoring functions respect RLS
+-- ============================================================================
+DO $$
+DECLARE
+    alice_id TEXT;
+    bob_id TEXT;
+    cnt INT;
+BEGIN
+    SELECT instance_id INTO alice_id FROM _rls_alice_state;
+    SELECT instance_id INTO bob_id FROM _rls_bob_state;
+
+    -- As Alice: list_instances should only show Alice's instances
+    SET SESSION AUTHORIZATION rls_alice;
+
+    SELECT count(*) INTO cnt FROM df.list_instances();
+    IF cnt < 1 THEN
+        RAISE EXCEPTION 'TEST 5 FAILED: Alice sees no instances from list_instances';
+    END IF;
+
+    -- Verify Bob's instance is not in the listing
+    SELECT count(*) INTO cnt FROM df.list_instances() li WHERE li.instance_id = bob_id;
+    IF cnt != 0 THEN
+        RAISE EXCEPTION 'TEST 5 FAILED: Alice can see Bob''s instance in list_instances';
+    END IF;
+
+    -- instance_info should return empty for Bob's instance
+    SELECT count(*) INTO cnt FROM df.instance_info(bob_id);
+    IF cnt != 0 THEN
+        RAISE EXCEPTION 'TEST 5 FAILED: Alice can see Bob''s instance_info';
+    END IF;
+
+    -- instance_info should work for Alice's own instance
+    SELECT count(*) INTO cnt FROM df.instance_info(alice_id);
+    IF cnt != 1 THEN
+        RAISE EXCEPTION 'TEST 5 FAILED: Alice cannot see her own instance_info (count=%)', cnt;
+    END IF;
+
+    RESET SESSION AUTHORIZATION;
+
+    RAISE NOTICE 'Test 5 PASSED: Monitoring functions respect RLS';
+END $$;
+
+-- ============================================================================
+-- Test 6: Superuser can see all instances (RLS bypassed)
+-- ============================================================================
+DO $$
+DECLARE
+    alice_id TEXT;
+    bob_id TEXT;
+    cnt INT;
+BEGIN
+    SELECT instance_id INTO alice_id FROM _rls_alice_state;
+    SELECT instance_id INTO bob_id FROM _rls_bob_state;
+
+    -- Superuser should see both
+    SELECT count(*) INTO cnt FROM df.instances WHERE id IN (alice_id, bob_id);
+    IF cnt != 2 THEN
+        RAISE EXCEPTION 'TEST 6 FAILED: Superuser cannot see both instances (count=%, expected 2)', cnt;
+    END IF;
+
+    RAISE NOTICE 'Test 6 PASSED: Superuser can see all instances';
+END $$;
+
+-- ============================================================================
+-- Test 7: User can UPDATE allowed columns (status, updated_at) on own rows
+-- ============================================================================
+DO $$
+DECLARE
+    alice_id TEXT;
+    bob_id TEXT;
+    cnt INT;
+BEGIN
+    SELECT instance_id INTO alice_id FROM _rls_alice_state;
+    SELECT instance_id INTO bob_id FROM _rls_bob_state;
+
+    SET SESSION AUTHORIZATION rls_alice;
+
+    -- Alice can update status on her own instance (column-level grant)
+    UPDATE df.instances SET status = 'completed', updated_at = now() WHERE id = alice_id;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    IF cnt != 1 THEN
+        RAISE EXCEPTION 'TEST 7 FAILED: Alice could not UPDATE status on her own instance (rows=%)', cnt;
+    END IF;
+
+    -- Alice cannot update status on Bob's instance (RLS blocks it)
+    UPDATE df.instances SET status = 'cancelled' WHERE id = bob_id;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    IF cnt != 0 THEN
+        RAISE EXCEPTION 'TEST 7 FAILED: Alice was able to UPDATE Bob''s instance (rows=%)', cnt;
+    END IF;
+
+    RESET SESSION AUTHORIZATION;
+
+    RAISE NOTICE 'Test 7 PASSED: Column-level UPDATE on status works, RLS enforced';
+END $$;
+
+-- ============================================================================
+-- Test 8: User cannot DELETE instances (no DELETE grant)
+-- ============================================================================
+DO $$
+DECLARE
+    alice_id TEXT;
+BEGIN
+    SELECT instance_id INTO alice_id FROM _rls_alice_state;
+
+    SET SESSION AUTHORIZATION rls_alice;
+
+    BEGIN
+        DELETE FROM df.instances WHERE id = alice_id;
+        RAISE EXCEPTION 'TEST 8 FAILED: Alice was able to DELETE her own instance';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            RAISE NOTICE 'Test 8 PASSED: DELETE on df.instances denied (no DELETE grant)';
+    END;
+
+    RESET SESSION AUTHORIZATION;
+END $$;
+
+-- ============================================================================
+-- Test 9: User cannot UPDATE identity columns (submitted_by, login_role)
+-- ============================================================================
+DO $$
+DECLARE
+    alice_id TEXT;
+BEGIN
+    SELECT instance_id INTO alice_id FROM _rls_alice_state;
+
+    SET SESSION AUTHORIZATION rls_alice;
+
+    -- login_role is not in the column-level UPDATE grant
+    BEGIN
+        UPDATE df.instances SET login_role = 'postgres'::regrole WHERE id = alice_id;
+        RAISE EXCEPTION 'TEST 9 FAILED: Alice was able to tamper with login_role';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            NULL; -- expected
+    END;
+
+    -- submitted_by is not in the column-level UPDATE grant
+    BEGIN
+        UPDATE df.instances SET submitted_by = 'postgres'::regrole WHERE id = alice_id;
+        RAISE EXCEPTION 'TEST 9 FAILED: Alice was able to tamper with submitted_by';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            NULL; -- expected
+    END;
+
+    RESET SESSION AUTHORIZATION;
+
+    RAISE NOTICE 'Test 9 PASSED: Cannot UPDATE identity columns (column-level grant restricts)';
+END $$;
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+DROP TABLE IF EXISTS _rls_alice_state;
+DROP TABLE IF EXISTS _rls_bob_state;
+
+DO $cleanup$
+BEGIN
+    BEGIN DROP OWNED BY rls_alice; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP OWNED BY rls_bob;   EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE rls_alice;     EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE rls_bob;       EXCEPTION WHEN undefined_object THEN NULL; END;
+END $cleanup$;
+
+SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## Summary

Implements Phase 1 of the RLS spec (docs/rls.md) to enforce per-user isolation at the PostgreSQL table level, with hardened grant model.

### Changes

**Core RLS & Grants (`src/lib.rs`):**
- Enable RLS on `df.instances` and `df.nodes` with `instances_user_isolation` and `nodes_user_isolation` policies (`submitted_by = current_user::regrole`)
- Auto-GRANT to `PUBLIC`: `SELECT, INSERT` on instances/nodes, column-level `UPDATE (status, updated_at)` on instances (for `df.cancel()`), full DML on vars, schema usage, and function execution
- No full `UPDATE` — identity columns (`submitted_by`, `login_role`) and structural columns (`root_node`) are protected from user modification
- No `DELETE` on instances or nodes
- No `FORCE ROW LEVEL SECURITY` — superusers bypass RLS (standard PostgreSQL convention)

**Ownership checks (`src/dsl.rs`):**
- `df.cancel()`: SPI ownership check via RLS before calling duroxide client, then SPI UPDATE on status (column-level grant)
- `df.signal()`: Same ownership check before `raise_external_event()`
- Both error with "Instance not found or access denied" for non-owned instances

**Monitoring function rework (`src/monitoring.rs`):**
- `list_instances()`: Queries `df.instances` via SPI first (RLS-filtered), then only fetches duroxide info for user's own instance IDs
- `instance_info()`: RLS-based ownership check — returns empty for non-owned instances
- `instance_executions()`: RLS-based ownership check — returns empty for non-owned instances
- `instance_nodes()`: No changes needed (already SPI-filtered)
- `metrics()`: No changes needed (aggregate-only, no per-instance data)

**E2E tests (`tests/e2e/sql/`):**
- Updated `00_setup_playground.sql` — `_e2e_grant_df_to_e2e_user()` is now a no-op (grants are automatic)
- Updated `27_user_isolation.sql` — removed redundant explicit GRANTs
- Added `36_rls.sql` — 9 tests: instance isolation, node isolation, cancel/signal denial, monitoring RLS, superuser bypass, UPDATE denial on identity columns, DELETE denial, cross-user UPDATE denial

**Docs:**
- Updated `docs/rls.md` Decision 8 — column-level UPDATE grant model
- Updated `README.md` — added Multi-User Setup section
- Updated `USER_GUIDE.md` — updated Privilege Grants, Cross-Instance Visibility, Security Best Practices sections

### Security model

| Table | SELECT | INSERT | UPDATE | DELETE |
|-------|--------|--------|--------|--------|
| `df.instances` | ✅ (RLS) | ✅ (RLS) | `(status, updated_at)` only (RLS) | ❌ |
| `df.nodes` | ✅ (RLS) | ✅ (RLS) | ❌ | ❌ |
| `df.vars` | ✅ | ✅ | ✅ | ✅ |

Users cannot modify `submitted_by`, `login_role`, `root_node`, or any column on `df.nodes`. RLS restricts all operations to the user's own rows.

### Not included (deferred per spec)
- Variables scoping (`df.vars` RLS) — Phase 2 follow-up PR

### Test results
- 75 unit tests pass
- 36 E2E tests pass (including `36_rls` with 9 sub-tests)