### PR TITLE
fix: replace fixed sleep with polling loop in test 22 to fix CI race condition

### DIFF
--- a/tests/e2e/sql/22_cross_connection.sql
+++ b/tests/e2e/sql/22_cross_connection.sql
@@ -118,22 +118,26 @@ INSERT INTO _test_cross_cancel SELECT df.start(
     'cross-conn-cancel'
 );
 
--- Wait for at least one iteration
-SELECT pg_sleep(2);
-
--- Verify workflow is running
+-- Wait for at least one loop iteration to be committed (poll instead of fixed sleep)
 DO $$
 DECLARE
     inst_id TEXT;
     status TEXT;
     iteration_count INT;
+    attempts INT := 0;
 BEGIN
     SELECT instance_id INTO inst_id FROM _test_cross_cancel;
+    LOOP
+        SELECT COUNT(*) INTO iteration_count FROM cross_conn_log WHERE msg = 'loop_iteration';
+        EXIT WHEN iteration_count >= 1 OR attempts > 100;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
     SELECT s INTO status FROM df.status(inst_id) s;
-    SELECT COUNT(*) INTO iteration_count FROM cross_conn_log WHERE msg = 'loop_iteration';
     
     IF iteration_count < 1 THEN
-        RAISE EXCEPTION 'TEST FAILED: loop should have at least 1 iteration, got %', iteration_count;
+        RAISE EXCEPTION 'TEST FAILED: loop should have at least 1 iteration after 10s, got %', iteration_count;
     END IF;
     
     RAISE NOTICE 'Workflow % is running (status: %, iterations: %)', inst_id, status, iteration_count;


### PR DESCRIPTION
Test 22 (cross_connection) was flaky in CI because it used a fixed `pg_sleep(2)` before asserting that the loop had completed at least one iteration. On slower CI runners, the background worker hadn't committed the INSERT yet.

**Fix:** Replace the fixed sleep + immediate check with a polling loop that waits up to 10s for the first loop iteration row to appear in `cross_conn_log`.