### PR TITLE
Switch duroxide-pg-opt to a git submodule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,7 +85,7 @@ pg_durable includes the duroxide-pg-opt schema DDL as extension SQL to ensure pr
 
 ### Migration Files
 
-- **Upstream source**: `duroxide-pg-opt/migrations/000*.sql` (from duroxide-pg-opt repository)
+- **Upstream source**: `duroxide-pg-opt/migrations/000*.sql` (from duroxide-pg-opt submodule)
 - **Checked-in copies**: [sql/duroxide_upstream/](sql/duroxide_upstream/) (verbatim copies of upstream)
 - **Combined install SQL**: [sql/duroxide_install.sql](sql/duroxide_install.sql) (generated from copies)
 - **Extension integration**: [src/lib.rs](src/lib.rs) includes via `extension_sql_file!("../sql/duroxide_install.sql")`
@@ -100,34 +100,34 @@ pg_durable includes the duroxide-pg-opt schema DDL as extension SQL to ensure pr
 
 **Verify migrations match upstream:**
 ```bash
-# Requires duroxide-pg-opt cloned at repository root
-git clone --branch pinodeca/initialization \
-  https://github.com/microsoft/duroxide-pg-opt.git
+# Ensure the submodule is initialized
+git submodule update --init
 ./scripts/verify-duroxide-migrations.sh
 ```
 
 ### When to Update Migrations
 
-1. **Upgrading duroxide-pg-opt dependency**: When Cargo.toml points to a new version/tag/branch:
-   - Clone/pull the matching duroxide-pg-opt version
+1. **Upgrading duroxide-pg-opt dependency**: When updating the submodule to a new commit/branch:
+   - Update the submodule: `cd duroxide-pg-opt && git fetch && git checkout <new-ref>`
    - Copy new/updated migration files from `duroxide-pg-opt/migrations/` to `sql/duroxide_upstream/`
    - Run `./scripts/gen-duroxide-install-sql.sh` to regenerate install SQL
    - Run `./scripts/verify-duroxide-migrations.sh` to confirm sync
-   - Commit both the upstream copies and generated install SQL
+   - Commit the submodule update, upstream copies, and generated install SQL
 
-2. **After cloning pg_durable**: CI automatically verifies migrations on every PR
+2. **After cloning pg_durable**: Run `git submodule update --init`, CI automatically verifies migrations on every PR
 
 ### Important Notes
 
 - ⚠️ **Never manually edit `sql/duroxide_install.sql`** - it's generated
-- ⚠️ **Keep `sql/duroxide_upstream/` in sync** with the duroxide-pg-opt version referenced in Cargo.toml
-- ✅ **CI enforces sync** - `.github/workflows/ci.yml` clones duroxide-pg-opt and runs verification
+- ⚠️ **Keep `sql/duroxide_upstream/` in sync** with the duroxide-pg-opt submodule
+- ✅ **CI enforces sync** - uses `actions/checkout` with `submodules: true` and runs verification
 - ✅ **Extension owns the schema** - duroxide schema/tables are created by `CREATE EXTENSION pg_durable`
 
 ## Dependencies
 
 - **pgrx 0.16.1**: PostgreSQL extension framework (pinned version)
-- **duroxide/duroxide-pg**: Durable execution runtime
+- **duroxide**: Durable execution runtime
+- **duroxide-pg-opt**: duroxide provider/stores engine state in PostgreSQL (git submodule)
 - **sqlx**: Async PostgreSQL from background worker
 - **tokio**: Async runtime for background worker
 
@@ -138,7 +138,7 @@ git clone --branch pinodeca/initialization \
 ### Before Committing
 
 1. **Clean warnings**: Run `cargo build --features pg17` and `cargo clippy --features pg17` — fix all warnings
-2. **Format code**: Run `cargo fmt --all`
+2. **Format code**: Run `cargo fmt`
 3. **Run tests**: `./scripts/test-unit.sh` then `./scripts/test-e2e-local.sh`
 
 ### Handling Unused Code Warnings
@@ -211,7 +211,7 @@ SELECT 'TEST PASSED' AS result;
 Pull requests automatically run the CI workflow (`.github/workflows/ci.yml`):
 
 1. **Format Check**: `cargo fmt --check`
-2. **Migration Verification**: Clones duroxide-pg-opt and runs `./scripts/verify-duroxide-migrations.sh`
+2. **Migration Verification**: Uses submodule checkout and runs `./scripts/verify-duroxide-migrations.sh`
 3. **Clippy & Tests**: `cargo clippy`, `cargo pgrx test pg17`, and `./scripts/test-e2e-local.sh`
 
 All checks must pass before a PR can be merged. Configure branch protection rules in GitHub to enforce this.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
           rustup default nightly
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        # --all includes path dependencies; limit to our package to skip submodules
+        run: cargo fmt --package pg_durable -- --check
 
   prepare:
     name: Prepare Matrix
@@ -76,6 +77,9 @@ jobs:
     continue-on-error: ${{ matrix.pg_version == 18 }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GH_PAT }}
 
       - name: Install Rust nightly
         run: |
@@ -139,18 +143,8 @@ jobs:
             echo "PostgreSQL ${{ matrix.pg_version }} already initialized, skipping download"
           fi
 
-      - name: Configure git credentials for private repos
-        run: |
-          git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
-
       - name: Verify duroxide migrations match upstream
-        run: |
-          # Clone duroxide-pg-opt to verify our checked-in copies match upstream.
-          # NOTE: The branch must match the duroxide-pg-opt ref in Cargo.toml.
-          # Update this when switching to a tag or a different branch.
-          git clone --depth=1 --branch pinodeca/initialization \
-            https://${{ secrets.GH_PAT }}@github.com/microsoft/duroxide-pg-opt.git
-          ./scripts/verify-duroxide-migrations.sh
+        run: ./scripts/verify-duroxide-migrations.sh
 
       - name: Run clippy
         run: cargo clippy --no-default-features --features pg${{ matrix.pg_version }} -- -D warnings

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GH_PAT }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -57,7 +60,6 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-            --build-arg GITHUB_TOKEN=${{ secrets.GH_PAT }} \
             --tag ${{ env.IMAGE_NAME }} \
             --file Dockerfile \
             .

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "duroxide-pg-opt"]
+	path = duroxide-pg-opt
+	url = https://github.com/microsoft/duroxide-pg-opt.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,6 @@ dependencies = [
 [[package]]
 name = "duroxide-pg-opt"
 version = "0.1.18"
-source = "git+https://github.com/microsoft/duroxide-pg-opt.git?branch=pinodeca%2Fmigration-policy#8ce65bd8d43851a7ab9966639822ed46d1869296"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -807,20 +806,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1181,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -1243,9 +1242,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -1895,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1930,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1942,6 +1941,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -2439,12 +2444,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2766,7 +2771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2848,9 +2853,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -3194,11 +3199,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3816,9 +3821,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "wit-bindgen"
@@ -3948,18 +3953,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 
 # duroxide integration
 duroxide = "=0.1.20"
-duroxide-pg-opt = { git = "https://github.com/microsoft/duroxide-pg-opt.git", branch = "pinodeca/migration-policy", package = "duroxide-pg-opt" }
+duroxide-pg-opt = { path = "duroxide-pg-opt", package = "duroxide-pg-opt" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 
 # For ExecuteSQL activity (connecting back to PostgreSQL)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@
 # Stage 1: Build the extension
 FROM rustlang/rust:nightly-bookworm AS builder
 
-# GitHub token for private repos (passed as build arg, not persisted in image)
-ARG GITHUB_TOKEN
-
 # Install PostgreSQL 17 dev packages and build dependencies
 RUN apt-get update && apt-get install -y \
     curl \
@@ -39,17 +36,13 @@ COPY Cargo.toml Cargo.lock* ./
 COPY .cargo .cargo
 COPY build.rs ./
 
+# Copy duroxide-pg-opt submodule (path dependency)
+COPY duroxide-pg-opt ./duroxide-pg-opt
+
 # Copy source code
 COPY src ./src
 COPY pg_durable.control ./
 COPY sql ./sql
-
-# Configure git to use token for private GitHub repos
-# Also configure Cargo to use git CLI for fetching (required for git config to take effect)
-RUN if [ -n "$GITHUB_TOKEN" ]; then \
-        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"; \
-        mkdir -p /usr/local/cargo && printf '[net]\ngit-fetch-with-cli = true\n' >> /usr/local/cargo/config.toml; \
-    fi
 
 # Build the extension
 RUN cargo pgrx package --pg-config /usr/lib/postgresql/17/bin/pg_config

--- a/README.md
+++ b/README.md
@@ -34,32 +34,22 @@ SELECT df.start(
 - Rust (nightly)
 - [cargo-pgrx](https://github.com/pgcentralfoundation/pgrx) 0.16.1
 
-### GitHub SSH Access (Required)
+### GitHub Access (Required)
 
-This project depends on a private repository (`microsoft/duroxide-pg-opt`) via SSH. You need SSH access to the Azure GitHub organization.
+This project includes `microsoft/duroxide-pg-opt` as a git submodule. You need access to this private repository.
 
-1. **Set up SSH key** with GitHub: https://docs.github.com/en/authentication/connecting-to-github-with-ssh
-2. **Authorize SSO** for the Azure organization on your SSH key
-3. **Configure Cargo** to use git CLI for fetching (required for SSH agent authentication):
+1. **Create a GitHub PAT** with `repo` scope: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+2. **Authorize SSO** for the Microsoft organization on the PAT
+3. **Configure git** to use the PAT for GitHub HTTPS URLs:
 
 ```bash
-# Add to ~/.cargo/config.toml
-mkdir -p ~/.cargo
-echo '[net]
-git-fetch-with-cli = true' >> ~/.cargo/config.toml
+git config --global url."https://<YOUR_PAT>@github.com/".insteadOf "https://github.com/"
 ```
 
-4. **Verify SSH access**:
+4. **Initialize the submodule** after cloning:
 
 ```bash
-git ls-remote ssh://git@github.com/microsoft/duroxide-pg-opt.git
-```
-
-5. **For Docker builds**, create a `.env` file in the project root with a GitHub PAT:
-
-```bash
-# .env (gitignored)
-GITHUB_TOKEN=ghp_your_token_here
+git submodule update --init
 ```
 
 ## Installation
@@ -77,7 +67,7 @@ CREATE EXTENSION pg_durable;
 ### Docker
 
 ```bash
-# Build and test (requires .env with GITHUB_TOKEN)
+# Build and test
 ./scripts/test-e2e-docker.sh --rebuild
 
 # Optional: Deploy to ACR (for custom PG17 image with pg_durable baked-in)
@@ -147,23 +137,20 @@ See [tests/e2e/](tests/e2e/) for details.
 
 ## Verifying Duroxide Migrations
 
-pg_durable includes checked-in copies of duroxide-pg-opt migration SQL files to ensure the extension owns the duroxide schema. To verify these copies match upstream:
+pg_durable includes checked-in copies of duroxide-pg-opt migration SQL files to ensure the extension owns the duroxide schema. The `duroxide-pg-opt` submodule provides the upstream source. To verify the copies match:
 
 ```bash
-# Clone duroxide-pg-opt at the repository root
-git clone --branch pinodeca/initialization \
-  https://github.com/microsoft/duroxide-pg-opt.git
+# Ensure the submodule is initialized
+git submodule update --init
 
 # Verify migrations match upstream
 ./scripts/verify-duroxide-migrations.sh
 ```
 
 **When to verify:**
-- After updating the `duroxide-pg-opt` dependency in Cargo.toml
+- After updating the `duroxide-pg-opt` submodule to a new commit
 - When contributing changes to pg_durable
 - CI automatically verifies on every pull request
-
-**Note:** The verification script requires the `duroxide-pg-opt` repository to be cloned at the root of the pg_durable repository.
 
 ## Documentation
 

--- a/docs/nested-graph-design.md
+++ b/docs/nested-graph-design.md
@@ -327,7 +327,7 @@ All items completed in commit `fdfbd44` and subsequent fixes:
 - [x] Update `USER_GUIDE.md` with new graph construction model
 - [x] Update `docs/ARCHITECTURE.md` with stateless design
 - [x] Update `README.md` if needed (checked — no stale references)
-- [x] Run `cargo fmt --all`
+- [x] Run `cargo fmt`
 - [x] Run `cargo clippy --features pg17` and fix warnings
 - [x] Run `./scripts/test-unit.sh`
 - [x] Run `./scripts/test-e2e-local.sh`

--- a/prompts/pg_durable-check-upstream-fixes.md
+++ b/prompts/pg_durable-check-upstream-fixes.md
@@ -48,9 +48,9 @@ Confirm the fix is mentioned in the release notes.
 
 If a fix is available in a new release:
 
-1. **Update Cargo.toml** - change the tag version:
-   ```toml
-   duroxide-pg-opt = { git = "ssh://git@github.com/microsoft/duroxide-pg-opt.git", tag = "v0.1.X", package = "duroxide-pg-opt" }
+1. **Update submodule** - point to the new version:
+   ```bash
+   cd duroxide-pg-opt && git fetch && git checkout v0.1.X && cd ..
    ```
 
 2. **Also update duroxide if needed** (check compatibility):

--- a/prompts/pg_durable-clean-warnings.md
+++ b/prompts/pg_durable-clean-warnings.md
@@ -37,7 +37,7 @@ Common clippy warnings to address:
 
 ### 3. Cargo Format
 ```bash
-cargo fmt --all
+cargo fmt
 ```
 
 Ensures consistent formatting across all code.
@@ -85,7 +85,7 @@ cargo build --features pg17
 cargo clippy --features pg17
 
 # 6. Format
-cargo fmt --all
+cargo fmt
 
 # 7. Test everything still works
 cargo pgrx test --features pg17
@@ -161,7 +161,7 @@ Before considering the cleanup complete:
 
 - [ ] `cargo build --features pg17` produces zero warnings
 - [ ] `cargo clippy --features pg17` produces zero warnings
-- [ ] `cargo fmt --all --check` produces no diff
+- [ ] `cargo fmt --check` produces no diff
 - [ ] `cargo pgrx test --features pg17` passes completely
 - [ ] `./scripts/test-e2e-local.sh` passes all tests
 - [ ] Spot-check: Run a few E2E tests to ensure they work

--- a/prompts/pg_durable-merge-main.md
+++ b/prompts/pg_durable-merge-main.md
@@ -62,7 +62,7 @@ az acr login --name toygresacr
 - **DO NOT** skip commit hooks with `--no-verify`
 - **DO NOT** commit or merge without user approval
 - **DO** ensure all tests pass before merging
-- **DO** run `cargo fmt --all` and `cargo clippy --features pg17` before committing
+- **DO** run `cargo fmt` and `cargo clippy --features pg17` before committing
 - **DO** create meaningful commit messages that future readers can understand
 
 ## Example Commit Messages
@@ -106,7 +106,7 @@ Before asking user to approve commit:
 
 - [ ] `cargo build --features pg17` succeeds
 - [ ] `cargo clippy --features pg17` has no warnings
-- [ ] `cargo fmt --all --check` shows no changes needed
+- [ ] `cargo fmt --check` shows no changes needed
 - [ ] `./scripts/test-unit.sh` passes
 - [ ] `./scripts/test-e2e-local.sh` passes (all tests)
 - [ ] No debug/temporary code left in changes

--- a/prompts/pg_durable-release.md
+++ b/prompts/pg_durable-release.md
@@ -22,8 +22,8 @@ cargo search duroxide --limit 5
 
 **Check for new duroxide-pg-opt tag:**
 ```bash
-# List recent tags from the microsoft/duroxide-pg-opt repo
-git ls-remote --tags ssh://git@github.com/microsoft/duroxide-pg-opt.git | tail -10
+# List recent tags from the duroxide-pg-opt submodule
+cd duroxide-pg-opt && git fetch --tags && git tag --sort=-v:refname | head -10 && cd ..
 ```
 
 ### 1.2 Ask User About Updates
@@ -46,17 +46,18 @@ Would you like to update to the new versions? (y/n)
 
 **If user approves updates:**
 
-Update `Cargo.toml` dependencies:
-```toml
-# Example update
-duroxide = "NEW_VERSION"
-duroxide-pg-opt = { git = "ssh://git@github.com/microsoft/duroxide-pg-opt.git", tag = "NEW_TAG", package = "duroxide-pg-opt" }
+Update `Cargo.toml` duroxide version and update the submodule:
+```bash
+# Update duroxide in Cargo.toml
+# duroxide = "NEW_VERSION"
+
+# Update submodule to new tag
+cd duroxide-pg-opt && git checkout NEW_TAG && cd ..
 ```
 
 Then run:
 ```bash
 cargo update -p duroxide
-cargo update -p duroxide-pg-opt
 ```
 
 ## Step 2: Update Package Version (if releasing)
@@ -122,7 +123,7 @@ Follow the guidance in `@pg_durable-clean-warnings.md`:
 
 ### 3.4 Format Code
 ```bash
-cargo fmt --all
+cargo fmt
 ```
 
 ### 3.5 Verify Clean Build
@@ -436,7 +437,7 @@ docker inspect pg_durable:latest --format '{{.Created}}'
 - [ ] Bump version in Cargo.toml if releasing
 - [ ] `cargo build --features pg17` - no errors
 - [ ] `cargo clippy --features pg17` - no warnings
-- [ ] `cargo fmt --all` - code formatted
+- [ ] `cargo fmt` - code formatted
 - [ ] Documentation reviewed and updated
 - [ ] New tests proposed and implemented (if applicable)
 - [ ] `./scripts/test-unit.sh` - all pass

--- a/scripts/test-e2e-docker.sh
+++ b/scripts/test-e2e-docker.sh
@@ -109,19 +109,10 @@ trap cleanup EXIT
 # Stop any existing container
 docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 
-# Load .env file if it exists (for GITHUB_TOKEN)
-if [ -f "$PROJECT_DIR/.env" ]; then
-    export $(grep -v '^#' "$PROJECT_DIR/.env" | xargs)
-fi
-
 # Build image if needed
 if [ "$FORCE_REBUILD" = true ] || ! docker image inspect "$IMAGE_NAME" &>/dev/null; then
     echo -e "${YELLOW}Building Docker image (linux/amd64)...${NC}"
-    BUILD_ARGS=""
-    if [ -n "$GITHUB_TOKEN" ]; then
-        BUILD_ARGS="--build-arg GITHUB_TOKEN=$GITHUB_TOKEN"
-    fi
-    docker build --platform linux/amd64 $BUILD_ARGS -t "$IMAGE_NAME" -f "$PROJECT_DIR/Dockerfile" "$PROJECT_DIR"
+    docker build --platform linux/amd64 -t "$IMAGE_NAME" -f "$PROJECT_DIR/Dockerfile" "$PROJECT_DIR"
 fi
 
 # Start container


### PR DESCRIPTION
## Summary

Switch `duroxide-pg-opt` from a Cargo git dependency to a git submodule with a path dependency. This gives us:

- **Explicit version control** — the submodule commit is tracked in the repo
- **Simpler CI** — `actions/checkout` with `submodules: true` replaces manual `git clone`
- **Simpler migration verification** — no separate clone step needed
- **Cleaner builds** — no git-fetch-with-cli cargo config needed for this dep

## Changes

- Add `duroxide-pg-opt` as a git submodule (`pinodeca/migration-policy` branch)
- `Cargo.toml`: git dep → `path = "duroxide-pg-opt"`
- CI: `actions/checkout` with `submodules: true` + `token`; remove manual git clone/config steps
- `Dockerfile`: COPY the submodule into the build context
- `README.md`: simplified setup (just `git submodule update --init`)
- Prompts/scripts/copilot-instructions: updated for submodule workflow
- Drop `--all` from `cargo fmt` to avoid formatting submodule code
- Fix `duroxide/duroxide-pg` → `duroxide-pg-opt` in copilot-instructions dependencies