### PR TITLE
Add resilience testing plan and 26 E2E tests

### DIFF
--- a/docs/resilience-testing.md
+++ b/docs/resilience-testing.md
@@ -27,9 +27,9 @@
 | **A. Stress & Overload** | System behavior under extreme load, large data, deep nesting | 100+ concurrent instances, 10K loop iterations, million-row results, deep graph nesting | **Covered** (tests 45-46, 51-56) | High |
 | **B. Bugs & Logical Errors** | Incorrect behavior at edge cases of normal operation | Infinite loops, `is_truthy("false")` bug, break-outside-loop, recursive `df.start()` | **Covered** (tests 38-42, 48-50, 57) | **Highest** |
 | **C. Misuse & Unintended Usage** | Passing garbage, using APIs in wrong order, breaking assumptions | Empty SQL, raw JSON bypass, rapid `df.status()` polling, crafted Durofut payloads | **Covered** (tests 32, 33, 43-44, 56) | Medium |
-| **D. Chaos / Fault Injection** | Behavior when infrastructure fails mid-operation | Kill worker mid-execution, crash PostgreSQL, drop+recreate extension | **None** | High |
-| **E. Data Integrity & State Corruption** | Orphaned rows, inconsistent state, GC pressure | No FK constraints, stuck instances, duroxide/df table bloat (no GC) | **None** | Medium |
-| **F. Concurrency & Race Conditions** | Parallel sessions, competing operations on shared state | Shared variable races, concurrent start/cancel/signal, parallel status polling | **Minimal** (test 22) | Medium |
+| **D. Chaos / Fault Injection** | Behavior when infrastructure fails mid-operation | Kill worker mid-execution, crash PostgreSQL, drop+recreate extension | **Partial** (test 58: worker kill/restart; test 28: drop+recreate) | High |
+| **E. Data Integrity & State Corruption** | Orphaned rows, inconsistent state, GC pressure | No FK constraints, stuck instances, duroxide/df table bloat (no GC) | **Partial** (tests 59: stuck instances, 60: orphaned nodes, 61: table bloat) | Medium |
+| **F. Concurrency & Race Conditions** | Parallel sessions, competing operations on shared state | Shared variable races, concurrent start/cancel/signal, parallel status polling | **Partial** (tests 22, 62: concurrent start, 63: variable race) | Medium |
 
 ---
 
@@ -585,13 +585,13 @@ UPDATE df.nodes SET query = 'SELECT evil()' WHERE instance_id = 'running1';
 
 ## Existing Coverage Analysis
 
-The E2E test suite now includes **57 tests** covering happy-path functionality and resilience scenarios:
+The E2E test suite now includes **63 tests** covering happy-path functionality and resilience scenarios:
 
 | Area | Tests | Gap |
 |---|---|---|
 | Basic SQL execution | 01 | No error cases |
 | Sequences | 02 | Deep nesting covered (46) |
-| Variables | 03, 20, 55, 57 | Name conflicts (57) and large payloads (55) covered |
+| Variables | 03, 20, 55, 57, 63 | Name conflicts (57), large payloads (55), shared-var race (63) covered |
 | Parallel (JOIN) | 04, 12, 16, 49, 51 | Branch-failure (49) and wide graphs (51) covered |
 | Conditionals (IF) | 05, 06, 13, 39 | Truthiness edge cases covered (39) |
 | Sleep | 07 | No large/zero values |
@@ -605,24 +605,33 @@ The E2E test suite now includes **57 tests** covering happy-path functionality a
 | Cross-connection | 22 | Basic only |
 | Transactions | 23 | Basic only |
 | Security/RLS | 25, 26, 27, 37 | Good coverage |
-| Worker lifecycle | 28 | Basic only |
+| Worker lifecycle | 28, 58 | Kill+restart durability covered (58) |
 | Error handling | 29, 32, 33, 40, 43, 44 | Runtime failures (40), empty SQL (43), crafted JSON (44) covered |
 | Graph reuse | 30 | Basic only |
 | Multi-database | 34 | Basic only |
 | Heartbeat | 35 | Basic only |
 | SSRF | 36 | Good coverage |
-| Stress: concurrency | 45 | 20-instance burst covered |
+| Stress: concurrency | 45, 62 | 20-instance burst (45), 10 concurrent sessions via dblink (62) |
 | Stress: cancel races | 47 | 20 rapid start/cancel cycles covered |
 | Stress: large queries | 54 | 10KB query text covered |
 | Stress: large results | 53 | 10K-row result set covered |
 | Stress: rapid polling | 56 | 500K status polls covered |
 | Break semantics | 41 | Top-level break covered |
 | Recursive df.start() | 42 | Workflow-spawned child instance covered |
+| Chaos: worker kill | 58 | Worker kill + restart, instance resumes covered |
+| Data integrity: orphans | 60 | Orphaned nodes (no FK cascade) documented |
+| Data integrity: bloat | 61 | Table bloat (no GC) measured and documented |
+| Stuck instances | 59 | Signal-waiting instance stays running; cancel escapes it |
 
 **Remaining gaps:**
-- Zero chaos/fault injection tests (D1–D6)
-- Zero data integrity/cleanup tests (E1–E6)
-- Zero multi-session concurrency tests (F1–F5)
+- D2 — PostgreSQL crash recovery (needs `pg_ctl stop -m immediate` + restart, requires shell harness)
+- D3 — Disk full simulation (infeasible in SQL)
+- D4 — Network partition to remote database
+- D5 — Clock skew / time jumps
+- D6 — Extension drop+recreate *while instances are in-flight* (D6 partial: 28 covers drop+recreate with no in-flight instances)
+- E6 — Tampering with df.nodes mid-execution
+- F2/F3 — signal/cancel concurrent with instance completion (timing-sensitive races)
+- F5 — Many sessions polling df.status() simultaneously (lock contention focus)
 - No iteration limit / infinite-loop safeguard exists (B1/B2 confirmed)
 - No recursion guard for df.start() inside workflows (B11 confirmed)
 - No GC for completed instances / duroxide history
@@ -650,19 +659,21 @@ The E2E test suite now includes **57 tests** covering happy-path functionality a
 11. **A2** — Deep graph nesting → ✅ Test 46: 50-level sequential chain completes, no stack overflow.
 12. **A7** — Rapid start/cancel cycles → ✅ Test 47: 20 rapid start/cancel cycles; all settle to terminal state.
 
-### Phase 3: Chaos & durability (validate the "durable" promise)
+### Phase 3: Chaos & durability (validate the "durable" promise) — ✅ COMPLETE (partial)
 
-13. **D1** — Kill worker mid-execution
-14. **D6** — Drop+recreate extension
-15. **D2** — PostgreSQL crash recovery
-16. **E2/E3** — Stuck instances detection
+13. **D1** — Kill worker mid-execution → ✅ Test 58: worker restarts via PG BGW auto-restart; in-flight instance resumes after restart.
+14. **E2/E3** — Stuck instances detection → ✅ Test 59: signal-waiting instance stays "running" indefinitely; `df.cancel()` is the only escape. No built-in idle timeout exists.
+15. **E1** — Orphaned nodes → ✅ Test 60: deleting `df.instances` row leaves `df.nodes` intact (no FK cascade). `df.status()` returns NULL gracefully.
+16. **E4/E5** — Table bloat measurement → ✅ Test 61: instance/node row counts increase proportionally; no automatic GC runs.
+17. **D6** — Drop+recreate extension → covered by Test 28 (lifecycle); in-flight coverage pending (D6 partial).
+18. **D2** — PostgreSQL crash recovery → requires `pg_ctl stop -m immediate`; needs shell harness (not yet implemented).
 
-### Phase 4: Concurrency & data integrity
+### Phase 4: Concurrency & data integrity — ✅ COMPLETE (partial)
 
-17. **F1** — Concurrent df.start()
-18. **F4** — Shared variable races
-19. **E4/E5** — Table bloat measurement
-20. **E1** — Orphaned nodes
+19. **F1** — Concurrent df.start() → ✅ Test 62: 10 dblink sessions start instances concurrently; all produce distinct IDs and complete.
+20. **F4** — Shared variable races → ✅ Test 63: two sessions race on the same `df.vars` key; both instances settle; last-writer-wins behavior documented.
+21. **F2/F3** — signal/cancel concurrent with completion → race-timing tests; not yet implemented.
+22. **F5** — Many concurrent status poll sessions → partially covered by test 56 (single-session rapid poll); multi-session lock contention not yet tested.
 
 ### Phase 5: Additional misuse & edge cases — ✅ COMPLETE
 
@@ -699,3 +710,7 @@ Bugs and design issues discovered through resilience testing:
 | **F5** | Serde ignores unknown JSON fields in crafted Durofut payloads | Quirk | 44 | Accepted — serde default behavior |
 | **F6** | Empty/whitespace SQL accepted by DSL validation, fails at execution time | Quirk | 43 | Accepted — could add DSL-time validation |
 | **F7** | Signal to non-existent/completed instance does not error | Quirk | 50 | Accepted — fire-and-forget semantics |
+| **F8** | No FK constraint between `df.instances` and `df.nodes` — deleting an instance leaves orphaned node rows | Design gap | 60 | Open — manual cleanup required; no cascade delete |
+| **F9** | No automatic GC for completed instances or duroxide history — tables grow without bound | Design gap | 61 | Open — need retention policy or VACUUM strategy |
+| **F10** | `df.vars` is a global (shared) table — concurrent sessions writing the same key will race; last writer wins | Design gap | 63 | Open — callers should use unique/namespaced variable keys |
+| **F11** | Instance waiting for a signal that never arrives stays "running" indefinitely — no idle timeout | Design gap | 59 | Open — `df.cancel()` is the only escape valve |

--- a/docs/resilience-testing.md
+++ b/docs/resilience-testing.md
@@ -1,0 +1,701 @@
+# Break-It Plan for pg_durable
+
+> **Goal:** Systematically test pg_durable the way a real user (or adversarial user) might, finding limits, bugs, logical errors, and failure modes that aren't covered by current E2E tests.
+>
+> **Out of scope:** SQL injection and other security vulnerabilities (addressed separately).
+
+## Table of Contents
+
+1. [Testing Categories](#testing-categories)
+2. [Category A: Stress & Overload](#category-a-stress--overload)
+3. [Category B: Bugs & Logical Errors](#category-b-bugs--logical-errors)
+4. [Category C: Misuse & Unintended Usage](#category-c-misuse--unintended-usage)
+5. [Category D: Chaos / Fault Injection](#category-d-chaos--fault-injection)
+6. [Category E: Data Integrity & State Corruption](#category-e-data-integrity--state-corruption)
+7. [Category F: Concurrency & Race Conditions](#category-f-concurrency--race-conditions)
+8. [Existing Coverage Analysis](#existing-coverage-analysis)
+9. [Priority & Sequencing](#priority--sequencing)
+
+---
+
+## Testing Categories
+
+"Breaking it the way a user might" decomposes into six distinct testing dimensions:
+
+| Category | What it tests | Examples | Current coverage | Priority |
+|---|---|---|---|---|
+| **A. Stress & Overload** | System behavior under extreme load, large data, deep nesting | 100+ concurrent instances, 10K loop iterations, million-row results, deep graph nesting | **Covered** (tests 45-46, 51-56) | High |
+| **B. Bugs & Logical Errors** | Incorrect behavior at edge cases of normal operation | Infinite loops, `is_truthy("false")` bug, break-outside-loop, recursive `df.start()` | **Covered** (tests 38-42, 48-50, 57) | **Highest** |
+| **C. Misuse & Unintended Usage** | Passing garbage, using APIs in wrong order, breaking assumptions | Empty SQL, raw JSON bypass, rapid `df.status()` polling, crafted Durofut payloads | **Covered** (tests 32, 33, 43-44, 56) | Medium |
+| **D. Chaos / Fault Injection** | Behavior when infrastructure fails mid-operation | Kill worker mid-execution, crash PostgreSQL, drop+recreate extension | **None** | High |
+| **E. Data Integrity & State Corruption** | Orphaned rows, inconsistent state, GC pressure | No FK constraints, stuck instances, duroxide/df table bloat (no GC) | **None** | Medium |
+| **F. Concurrency & Race Conditions** | Parallel sessions, competing operations on shared state | Shared variable races, concurrent start/cancel/signal, parallel status polling | **Minimal** (test 22) | Medium |
+
+---
+
+## Category A: Stress & Overload
+
+These tests find resource exhaustion bugs and missing limits. The goal is to discover what happens when a user (or a runaway loop) pushes the system past its design point.
+
+### A1. Many concurrent active instances
+
+**What:** Start N instances simultaneously from a single session, then from multiple sessions.
+
+**Why:** The background worker is single-threaded with a 5-connection pool. With enough instances queued, the worker may fall behind, the connection pool may starve, or the DB may spike in connections/memory.
+
+```sql
+-- Start 100 instances at once
+DO $$
+BEGIN
+  FOR i IN 1..100 LOOP
+    PERFORM df.start(df.sql('SELECT pg_sleep(0.1)'), 'burst-' || i);
+  END LOOP;
+END $$;
+
+-- Monitor: how long until all complete?
+-- Watch for: worker crash, OOM, stuck instances
+```
+
+**Variants:**
+- 10, 100, 500, 1000 instances
+- Mix of fast (SELECT 1) and slow (pg_sleep(5)) instances
+- Concurrent sessions each starting instances
+
+### A2. Very deep graph nesting
+
+**What:** Build deeply nested THEN chains (A ~> B ~> C ~> ... ~> Z × 100).
+
+**Why:** `execute_function_node_with_vars` is recursive via `Box::pin`. Deep graphs risk stack overflow. Node insertion in `df.start()` is also recursive. There is no depth limit anywhere in the code.
+
+```sql
+-- Generate a chain of 500 sequential SQL nodes
+SELECT df.start(
+  df.seq(df.seq(df.seq(df.seq(df.seq(
+    'SELECT 1', 'SELECT 2'), 'SELECT 3'), 'SELECT 4'), 'SELECT 5'), 'SELECT 6')
+  -- ... programmatically nest to depth 500
+);
+```
+
+**Variants:**
+- Depth 50, 100, 200, 500
+- Deeply nested IF inside IF inside IF
+- Deeply nested LOOP inside LOOP
+
+### A3. Very wide graph (many parallel branches)
+
+**What:** Use `join3` nested to create 10+, 50+, 100+ parallel branches.
+
+**Why:** Each JOIN branch spawns a sub-orchestration. Many parallel sub-orchestrations may overwhelm the duroxide runtime or exhaust the connection pool.
+
+```sql
+-- Nest join3 calls to get 9+ parallel branches
+SELECT df.start(
+  df.join3(
+    df.join3('SELECT 1', 'SELECT 2', 'SELECT 3'),
+    df.join3('SELECT 4', 'SELECT 5', 'SELECT 6'),
+    df.join3('SELECT 7', 'SELECT 8', 'SELECT 9')
+  )
+);
+```
+
+### A4. Very long execution history (loop iterations)
+
+**What:** Run a loop that iterates 1,000+ times.
+
+**Why:** Each loop iteration calls `continue_as_new`, which creates a new orchestration execution in Duroxide's history. The orchestration history tables (`duroxide.*`) may grow unboundedly. The background worker has no iteration cap.
+
+```sql
+CREATE TABLE loop_counter (n INT DEFAULT 0);
+INSERT INTO loop_counter VALUES (0);
+
+SELECT df.start(
+  df.loop(
+    'UPDATE loop_counter SET n = n + 1',            -- body
+    'SELECT n < 10000 FROM loop_counter'              -- condition
+  )
+);
+-- Watch: duroxide.* table sizes, memory, execution time
+```
+
+### A5. Large SQL result sets
+
+**What:** Execute a SQL node that returns millions of rows.
+
+**Why:** `execute_sql` activity calls `fetch_all()`, deserializes every row into a `serde_json::Value`, and returns the entire result as a single JSON string. This is unbounded — a large result set will OOM the background worker.
+
+```sql
+-- Generate a table with 1M rows, then select all of them in a durable function
+CREATE TABLE big_table AS SELECT generate_series(1, 1000000) AS id;
+
+SELECT df.start(df.sql('SELECT * FROM big_table'));
+-- Expected: OOM or extreme memory pressure
+```
+
+**Variants:**
+- 1K, 10K, 100K, 1M rows
+- Wide rows (many columns, large TEXT values)
+- Result passed through variable substitution (`$name`) to the next node
+
+### A6. Very large SQL query text
+
+**What:** Pass an extremely long SQL string (100KB+) as a node query.
+
+**Why:** The query is stored in `df.nodes.query` (TEXT column, no length limit), serialized into JSON for the orchestration, and logged. Very large queries may cause serialization failures or memory pressure.
+
+```sql
+-- Build a query string with 100K characters
+SELECT df.start(df.sql('SELECT ' || repeat('1,', 50000) || '1'));
+```
+
+### A7. Rapid fire start/cancel cycles
+
+**What:** Start an instance and immediately cancel it, in a tight loop.
+
+**Why:** Tests the race between the worker picking up an instance and the cancel signal arriving. May expose incomplete cleanup or stuck state.
+
+```sql
+DO $$
+DECLARE inst TEXT;
+BEGIN
+  FOR i IN 1..100 LOOP
+    inst := df.start('SELECT pg_sleep(10)', 'cancel-test-' || i);
+    PERFORM df.cancel(inst);
+  END LOOP;
+END $$;
+-- Check: are all instances properly canceled? Any stuck?
+```
+
+### A8. Large variable payloads
+
+**What:** Set a variable to a very large string (1MB+) and use it in a workflow.
+
+**Why:** Variables are stored in `df.vars` (TEXT column), captured at `df.start()`, serialized into the orchestration input JSON, and substituted into queries via string replacement. Large vars may cause serialization failures or memory issues.
+
+```sql
+SELECT df.setvar('big_val', repeat('x', 1048576));  -- 1MB
+SELECT df.start(df.sql('SELECT ''{big_val}'''));
+```
+
+---
+
+## Category B: Bugs & Logical Errors
+
+These tests are designed to expose incorrect behavior in normal-ish usage, targeting edge cases the happy-path tests don't cover.
+
+### B1. Loop with always-true condition (infinite loop)
+
+**What:** Create a while-loop whose condition never becomes false.
+
+**Why:** There is no iteration limit. The worker will spin forever on `continue_as_new`, bloating duroxide history tables. This is a realistic user mistake.
+
+```sql
+SELECT df.start(
+  df.loop('SELECT 1', 'SELECT true')
+);
+-- Expected: runs forever. How do you detect and stop this?
+-- Can df.cancel() stop it? How fast?
+```
+
+### B2. Unconditional infinite loop
+
+**What:** `df.loop('SELECT 1')` with no condition and no break.
+
+**Why:** Same as B1 but even simpler to accidentally create.
+
+### B3. Loop condition with ambiguous truthiness
+
+**What:** Test edge cases of `evaluate_condition()`:
+
+```sql
+-- What does each of these mean to the loop?
+df.loop('SELECT 1', 'SELECT 0')           -- falsy (stops)
+df.loop('SELECT 1', 'SELECT ''''')        -- empty string: truthy or falsy?
+df.loop('SELECT 1', 'SELECT NULL')        -- NULL: truthy or falsy?
+df.loop('SELECT 1', 'SELECT ''false''')   -- string "false": truthy in is_truthy!
+df.loop('SELECT 1', 'SELECT ''no''')      -- string "no": ???
+df.loop('SELECT 1', 'SELECT 0.0')         -- float zero
+df.loop('SELECT 1', 'SELECT ''{}'':jsonb') -- empty object
+df.loop('SELECT 1', 'SELECT ''[]''::jsonb') -- empty array
+```
+
+**Why:** `is_truthy()` in types.rs has some surprising behavior — e.g., the string `"false"` is truthy if it doesn't match the exact list `"true" | "t" | "yes" | "1"`, but then falls through to `parse::<i64>` which fails, then `!s.is_empty()` which is true. A user writing `SELECT 'false'` as a condition would expect it to be falsy.
+
+### B4. Variable substitution edge cases
+
+**What:** Test variable names that collide with system vars or result names:
+
+```sql
+-- Variable named same as system var
+SELECT df.setvar('sys_instance_id', 'hacked');
+SELECT df.start(df.sql('SELECT ''{sys_instance_id}'''));
+-- Does the user var win? Or the system var?
+
+-- Variable name with special characters
+SELECT df.setvar('name with spaces', 'value');
+SELECT df.setvar('name{with}braces', 'value');
+SELECT df.setvar('', 'empty name');
+
+-- Result name collision with variable
+-- (result $foo vs variable {foo})
+```
+
+**Why:** `substitute_all_with_options` does system vars first, then user vars, then results. A user var named `sys_instance_id` would be substituted after the system var, so `{sys_instance_id}` gets the system value. But this ordering is not documented.
+
+### B5. SQL node that returns no rows
+
+**What:** Execute a SQL node whose query returns 0 rows, then try to use the result.
+
+```sql
+SELECT df.start(
+  df.sql('SELECT 1 WHERE false') |=> 'empty_result'
+  ~> df.sql('SELECT $empty_result')
+);
+```
+
+**Why:** The result JSON will be `{"rows":[],"row_count":0}`. When substituted as `$empty_result`, the literal JSON string gets embedded into the next query. Is that what the user expects?
+
+### B6. SQL node that runs DML (INSERT/UPDATE/DELETE)
+
+**What:** A SQL node that modifies data but returns nothing (no RETURNING clause).
+
+```sql
+SELECT df.start(
+  df.sql('INSERT INTO some_table VALUES (1)')
+  |=> 'insert_result'
+  ~> df.sql('SELECT $insert_result')
+);
+```
+
+**Why:** DML without RETURNING returns 0 rows. The result would be `{"rows":[],"row_count":0}`. Does `$insert_result` substitution produce something useful?
+
+### B7. SQL node with multiple statements
+
+**What:** Pass multiple SQL statements separated by semicolons.
+
+```sql
+SELECT df.start(df.sql('SELECT 1; SELECT 2; DROP TABLE important'));
+```
+
+**Why:** `sqlx::query().fetch_all()` behavior with multiple statements is driver-dependent. It may execute only the first, execute all, or error. This should be tested and documented.
+
+### B8. RACE where both branches fail
+
+**What:** Both branches of a RACE node raise errors.
+
+```sql
+SELECT df.start(
+  df.race(
+    'SELECT 1/0',   -- division by zero
+    'SELECT 1/0'    -- division by zero
+  )
+);
+```
+
+**Why:** `execute_race_node` uses `ctx.select2` — does it report the first failure or wait for the second? What status does the instance end up in?
+
+### B9. JOIN where one branch fails
+
+**What:** One branch of a JOIN succeeds, the other fails.
+
+```sql
+SELECT df.start(
+  df.join(
+    'SELECT 1',     -- succeeds
+    'SELECT 1/0'    -- fails
+  )
+);
+```
+
+**Why:** `execute_join_node` iterates results and returns `Err` on the first failed branch. But the successful branch's side effects (DML) are already committed. Is this the desired behavior? Does the instance status reflect partial completion?
+
+### B10. Break outside a loop
+
+**What:** Use `df.break()` as a standalone node, not inside a loop.
+
+```sql
+SELECT df.start(df.break('done'));
+```
+
+**Why:** The break sentinel `{"__break__": true, "value": "done"}` will be returned as the top-level result. The THEN handler propagates break signals upward. But without an enclosing loop, the break sentinel becomes the final result. Is this correct?
+
+### B11. Using df.start() inside a workflow
+
+**What:** A SQL node that calls `df.start()` recursively.
+
+```sql
+SELECT df.start(
+  df.sql('SELECT df.start(df.sql(''SELECT 1''))')
+);
+```
+
+**Why:** The code has `df.in_workflow` check for setvar/unsetvar/clearvars, but `df.start()` itself does NOT check `is_in_workflow_context()`. Recursive invocation could cause unbounded spawning.
+
+### B12. Signal to non-existent or already-completed instance
+
+```sql
+-- Signal to a garbage ID
+SELECT df.signal('nonexist', 'approve', '{}');
+
+-- Start and complete, then signal
+-- Does the signal silently succeed? Error? Get lost?
+```
+
+### B13. Multiple signals with same name
+
+**What:** Send the same signal multiple times to an instance waiting for it.
+
+**Why:** How does duroxide handle duplicate external events? Does the second one get queued, ignored, or cause an error?
+
+### B14. Result name conflicts
+
+**What:** Multiple nodes named the same thing with `|=>`.
+
+```sql
+SELECT df.start(
+  df.sql('SELECT 1') |=> 'result'
+  ~> df.sql('SELECT 2') |=> 'result'
+  ~> df.sql('SELECT $result')
+);
+-- Which value does $result get?
+```
+
+---
+
+## Category C: Misuse & Unintended Usage
+
+These test what happens when users do something the API wasn't designed for.
+
+### C1. Empty or whitespace-only SQL
+
+```sql
+SELECT df.start(df.sql(''));
+SELECT df.start(df.sql('   '));
+SELECT df.start(df.sql(NULL));  -- if possible
+```
+
+### C2. Non-SQL query text
+
+```sql
+SELECT df.start(df.sql('this is not sql at all'));
+SELECT df.start(df.sql('{"json": "object"}'));
+```
+
+### C3. Calling df.status/df.result on someone else's instance
+
+**Why:** RLS should prevent this, but verify the error message is sensible.
+
+### C4. Using pg_durable operators on non-Durofut strings
+
+```sql
+SELECT 'hello' ~> 'world';    -- what happens?
+SELECT 'not json' & 'also not';
+```
+
+**Why:** The operators accept TEXT. Non-Durofut strings should auto-wrap as SQL nodes, but tests should verify this behavior explicitly.
+
+### C5. Extremely rapid polling of df.status()
+
+```sql
+-- Poll status in a tight loop with no sleep
+DO $$
+DECLARE s TEXT;
+BEGIN
+  FOR i IN 1..10000 LOOP
+    SELECT df.status('some-id') INTO s;
+  END LOOP;
+END $$;
+```
+
+**Why:** `df.status()` is a simple SPI query (`SELECT status FROM df.instances`), so individual calls are cheap. The concern here is whether tight-loop polling from a user session could interfere with the background worker (e.g., lock contention on `df.instances`) or cause unexpected hangs. Note: functions like `df.signal()` and `df.cancel()` *do* use the duroxide client (tokio runtime + connection pool) — rapid polling of *those* would be a more meaningful resource exhaustion test.
+
+### C6. Calling DSL functions after df.start()
+
+**What:** Call `df.setvar()`, `df.clearvars()` while instances are running.
+
+**Why:** Variables are captured at `df.start()` time and are immutable during execution. But the user might not know this and expect changes to take effect. Is the behavior clearly communicated?
+
+### C7. Using df.start() with manually crafted JSON
+
+```sql
+-- Bypass the DSL entirely and craft raw Durofut JSON
+SELECT df.start('{"node_type": "SQL", "query": "SELECT 1"}');
+
+-- Unknown fields in the JSON
+SELECT df.start('{"node_type": "SQL", "query": "SELECT 1", "evil_field": "pwned"}');
+
+-- Malformed nested structures
+SELECT df.start('{"node_type": "THEN", "left_node": "not an object"}');
+```
+
+### C8. DROP EXTENSION while instances are running
+
+```sql
+-- Start a long-running instance, then drop the extension
+SELECT df.start(df.sql('SELECT pg_sleep(60)'));
+DROP EXTENSION pg_durable CASCADE;
+-- What happens to the background worker? The running instance? The tables?
+```
+
+### C9. Instance ID collision
+
+**Why:** IDs are 8-char substrings of UUIDs. With enough instances, collisions are theoretically possible (birthday problem at ~77K instances for 50% probability with 36^8 space, though the actual space is hex = 16^8 = ~4.3 billion). Test what happens if an ID collides.
+
+---
+
+## Category D: Chaos / Fault Injection
+
+> **Does chaos testing make sense here?** Yes — pg_durable promises **durability** (it's in the name). Users will rely on it to survive crashes. If the worker crashes mid-execution, what happens to in-flight instances? Do they resume? Do they get stuck in "running" forever? Chaos testing is how you validate the durability guarantee.
+
+### D1. Kill the background worker mid-execution
+
+**What:** Start a long-running instance, then kill the worker process.
+
+```bash
+# Find and kill the worker
+kill -9 $(pgrep -f pg_durable_worker)
+```
+
+**Why:** The worker has `set_restart_time(Some(Duration::from_secs(5)))` — it should restart after 5s. But:
+- Does the interrupted instance resume or get stuck?
+- Is the duroxide execution history intact?
+- Does the runtime re-initialize cleanly?
+
+### D2. Kill PostgreSQL mid-execution
+
+**What:** `pg_ctl stop -m immediate` while instances are running, then restart.
+
+**Why:** Tests recovery after an unclean shutdown. Duroxide uses PostgreSQL for persistence — are transactions consistent after crash recovery?
+
+### D3. Disk full / Write failure
+
+**What:** Fill the disk (or use a test fixture) while the worker is executing.
+
+**Why:** If WAL/table writes fail, how does the worker behave? Does it crash? Retry? Corrupt state?
+
+### D4. Network partition to database (multi-database scenario)
+
+**What:** Start an instance targeting a remote database, then break the connection.
+
+**Why:** The `connect_as_user` function in activities will fail. Does the activity error propagate cleanly? Does the instance fail gracefully?
+
+### D5. Clock skew / Time jumps
+
+**What:** Jump the system clock forward or backward while instances are running.
+
+**Why:** `wait_for_schedule` computes wait duration at DSL time using `Utc::now()`. But `df.sleep()` uses duroxide's `schedule_timer`. If the system clock jumps, timers may fire at unexpected times. (The orchestration itself is deterministic — this mostly affects activity-level timestamps and completed_at.)
+
+### D6. Extension drop + recreate while worker is running
+
+**What:** Drop and immediately recreate the extension during execution.
+
+**Why:** The epoch sentinel mechanism is designed to handle this. Verify it actually works — does the worker detect the recreate and re-initialize?
+
+---
+
+## Category E: Data Integrity & State Corruption
+
+### E1. Orphaned nodes
+
+**What:** Delete an instance row but leave its nodes, or vice versa.
+
+```sql
+-- Direct delete bypassing normal flow (as superuser)
+DELETE FROM df.instances WHERE id = 'sometest';
+-- Are the nodes still there? Do they cause problems?
+```
+
+**Why:** There are no FK constraints between `df.nodes` and `df.instances`. Nodes don't cascade-delete.
+
+### E2. Instance stuck in "pending" forever
+
+**What:** Start an instance but ensure the background worker never picks it up (e.g., wrong database, broken worker).
+
+**Why:** There is no timeout on pending instances. A pending instance will sit forever. Users need a way to detect and clean up stale instances.
+
+### E3. Instance stuck in "running" forever
+
+**What:** An instance whose orchestration hangs (e.g., waiting on a signal that never comes, with no timeout).
+
+```sql
+SELECT df.start(df.wait_for_signal('never_coming'));
+-- This will wait forever. No default timeout.
+```
+
+### E4. Duroxide history table bloat
+
+**What:** After running thousands of instances, check the size of `duroxide.*` tables.
+
+**Why:** There is no GC/maintenance for completed orchestration history. Over time, these tables will grow without bound.
+
+```sql
+-- After running many tests:
+SELECT schemaname, tablename, pg_size_pretty(pg_total_relation_size(schemaname || '.' || tablename))
+FROM pg_tables WHERE schemaname = 'duroxide'
+ORDER BY pg_total_relation_size(schemaname || '.' || tablename) DESC;
+```
+
+### E5. df.nodes table bloat
+
+**What:** Same as E4 but for `df.nodes` and `df.instances`. Completed instances leave their nodes in the table forever.
+
+### E6. Tampering with df.nodes while instance is running
+
+```sql
+-- As a user with RLS bypass, modify a running instance's nodes
+UPDATE df.nodes SET query = 'SELECT evil()' WHERE instance_id = 'running1';
+```
+
+**Why:** The function graph is loaded once at the start of execution. Modifications after loading have no effect — but is this guaranteed? What if the graph is reloaded on `continue_as_new`?
+
+---
+
+## Category F: Concurrency & Race Conditions
+
+### F1. Concurrent df.start() from multiple sessions
+
+**What:** Multiple PostgreSQL sessions calling `df.start()` simultaneously.
+
+**Why:** Node/instance IDs are generated per-session. With enough concurrency, two sessions might generate the same 8-char ID (unlikely but testable as a correctness concern). Also tests that the worker handles multiple new instances appearing simultaneously.
+
+### F2. df.signal() concurrent with instance completion
+
+**What:** Send a signal at the exact moment an instance completes.
+
+**Why:** Race between the signal delivery and the instance status update. What state does the instance end up in?
+
+### F3. df.cancel() concurrent with instance completion
+
+**What:** Cancel at the exact moment a workflow completes naturally.
+
+**Why:** Similar race. Does the instance end up "completed" or "canceled"?
+
+### F4. Shared variable mutation during df.start()
+
+**What:** From two sessions: session A calls `df.setvar('x', 'A')` then `df.start(...)`, while session B calls `df.setvar('x', 'B')` then `df.start(...)`.
+
+**Why:** `df.vars` is a global table (not per-session, not per-instance). Two sessions setting the same variable will overwrite each other. The captured value at `df.start()` time depends on who wrote last.
+
+### F5. Many sessions polling df.status() simultaneously
+
+**What:** 20+ concurrent sessions all polling `df.status()` in a loop.
+
+**Why:** `df.status()` is a simple SPI query, so individual calls are cheap. The concern here is lock contention on `df.instances` under high concurrency rather than resource exhaustion. A more interesting variant would be many sessions calling `df.cancel()` or `df.signal()` simultaneously, since those use the duroxide client (tokio runtime + connection pool).
+
+---
+
+## Existing Coverage Analysis
+
+The E2E test suite now includes **57 tests** covering happy-path functionality and resilience scenarios:
+
+| Area | Tests | Gap |
+|---|---|---|
+| Basic SQL execution | 01 | No error cases |
+| Sequences | 02 | Deep nesting covered (46) |
+| Variables | 03, 20, 55, 57 | Name conflicts (57) and large payloads (55) covered |
+| Parallel (JOIN) | 04, 12, 16, 49, 51 | Branch-failure (49) and wide graphs (51) covered |
+| Conditionals (IF) | 05, 06, 13, 39 | Truthiness edge cases covered (39) |
+| Sleep | 07 | No large/zero values |
+| Loop | 08, 24, 38, 52 | Infinite loops (38) and long history (52) covered |
+| Monitoring | 09 | No concurrent monitoring |
+| Explain | 10, 31 | Happy path only |
+| Scenarios | 11, 14, 15 | Realistic but small-scale |
+| RACE | 17, 48 | Both-fail case covered (48) |
+| HTTP | 18, 19 | No timeout, no large response |
+| Signals | 21, 50 | Edge cases covered: non-existent instance, completed instance, duplicate signals (50) |
+| Cross-connection | 22 | Basic only |
+| Transactions | 23 | Basic only |
+| Security/RLS | 25, 26, 27, 37 | Good coverage |
+| Worker lifecycle | 28 | Basic only |
+| Error handling | 29, 32, 33, 40, 43, 44 | Runtime failures (40), empty SQL (43), crafted JSON (44) covered |
+| Graph reuse | 30 | Basic only |
+| Multi-database | 34 | Basic only |
+| Heartbeat | 35 | Basic only |
+| SSRF | 36 | Good coverage |
+| Stress: concurrency | 45 | 20-instance burst covered |
+| Stress: cancel races | 47 | 20 rapid start/cancel cycles covered |
+| Stress: large queries | 54 | 10KB query text covered |
+| Stress: large results | 53 | 10K-row result set covered |
+| Stress: rapid polling | 56 | 500K status polls covered |
+| Break semantics | 41 | Top-level break covered |
+| Recursive df.start() | 42 | Workflow-spawned child instance covered |
+
+**Remaining gaps:**
+- Zero chaos/fault injection tests (D1–D6)
+- Zero data integrity/cleanup tests (E1–E6)
+- Zero multi-session concurrency tests (F1–F5)
+- No iteration limit / infinite-loop safeguard exists (B1/B2 confirmed)
+- No recursion guard for df.start() inside workflows (B11 confirmed)
+- No GC for completed instances / duroxide history
+- HTTP timeout and large response edge cases untested
+
+---
+
+## Priority & Sequencing
+
+### Phase 1: High-value, easy to write (find real bugs fast) — ✅ COMPLETE
+
+1. **B1/B2** — Infinite loops → ✅ Test 38: loops run; `df.cancel()` stops them. **No iteration limit exists.**
+2. **B3** — Truthiness edge cases → ✅ Test 39: `NULL`, `0`, `false`, `'false'`, `'no'`, `''`, `0.0`, `[]`, `{}` all falsy. No bugs found.
+3. **B5/B6** — Empty/DML result handling → ✅ Test 40: **BUG FOUND** — `$var` substitution of empty results produces invalid SQL (unquoted JSON). Bug is in `substitute_all_with_options()` in `src/types.rs`.
+4. **B10** — Break outside loop → ✅ Test 41: break sentinel becomes final result; instance completes gracefully.
+5. **B11** — Recursive df.start() → ✅ Test 42: **CONFIRMED** — no recursion guard; `df.start()` inside workflow spawns child instances unboundedly.
+6. **C1** — Empty/null SQL → ✅ Test 43: accepted by DSL, fails gracefully at execution time (no crash).
+7. **C7** — Manually crafted JSON → ✅ Test 44: serde ignores unknown fields; null fields accepted as `Option::None`; invalid structures rejected at parse or runtime.
+
+### Phase 2: Stress tests (find resource limits) — ✅ COMPLETE
+
+8. **A1** — Many concurrent instances → ✅ Test 45: 20-instance burst completes within 60s, no stuck instances.
+9. **A4** — Long loop history → ✅ Test 52: 100-iteration loop completes; correct row count, no OOM.
+10. **A5** — Large result sets → ✅ Test 53: 10K-row result via CROSS JOIN handled without OOM.
+11. **A2** — Deep graph nesting → ✅ Test 46: 50-level sequential chain completes, no stack overflow.
+12. **A7** — Rapid start/cancel cycles → ✅ Test 47: 20 rapid start/cancel cycles; all settle to terminal state.
+
+### Phase 3: Chaos & durability (validate the "durable" promise)
+
+13. **D1** — Kill worker mid-execution
+14. **D6** — Drop+recreate extension
+15. **D2** — PostgreSQL crash recovery
+16. **E2/E3** — Stuck instances detection
+
+### Phase 4: Concurrency & data integrity
+
+17. **F1** — Concurrent df.start()
+18. **F4** — Shared variable races
+19. **E4/E5** — Table bloat measurement
+20. **E1** — Orphaned nodes
+
+### Phase 5: Additional misuse & edge cases — ✅ COMPLETE
+
+21. **C5** — Rapid status polling → ✅ Test 56: 500K polls in tight loop; no resource issues.
+22. **A3** — Wide parallel graphs → ✅ Test 51: 9 concurrent branches (3×3 join3); completes.
+23. **A6** — Large query text → ✅ Test 54: ~10KB query; no truncation or failure.
+24. **A8** — Large variable payloads → ✅ Test 55: 5KB variable; preserved without truncation.
+25. **B4** — Variable name collisions → ✅ Test 57: step result shadows user var; second binding wins.
+26. Remaining B, C items → ✅ Tests 48 (B8: race both-fail), 49 (B9: join one-fail), 50 (B12/B13: signal edge cases).
+
+---
+
+## Implementation Notes
+
+- **Stress tests need timeouts:** Each stress test should have a hard timeout (e.g., 60s) and a way to clean up if it hangs.
+- **Monitoring during stress:** Capture `pg_stat_activity`, table sizes, and worker logs during stress tests to diagnose failures.
+- **Idempotent cleanup:** Each test must clean up after itself, including killing stuck instances.
+- **Structured as E2E SQL:** Follow the existing `tests/e2e/sql/NN_*.sql` pattern where possible. Chaos tests (D) may need shell scripting or custom Rust test harness.
+- **Worker logs are critical:** Most failures manifest in `~/.pgrx/17.log` — tests should check logs for errors/panics.
+- **`--keep-going` flag:** Added to `test-e2e-local.sh` to continue running tests after a failure, with summary of failed tests at the end.
+
+---
+
+## Key Findings
+
+Bugs and design issues discovered through resilience testing:
+
+| ID | Finding | Severity | Test | Status |
+|---|---|---|---|---|
+| **F1** | `$var` substitution of empty/0-row results produces unquoted JSON in SQL context, causing syntax errors | Bug | 40 | Open — fix in `substitute_all_with_options()` (`src/types.rs`) |
+| **F2** | No iteration limit on `df.loop()` — infinite loops run forever, bloating duroxide history | Design gap | 38 | Open — need max-iteration safeguard |
+| **F3** | No recursion guard on `df.start()` — can be called inside workflows to spawn unbounded child instances | Design gap | 42 | Open — `is_in_workflow_context()` check missing |
+| **F4** | `df.break()` outside a loop produces break sentinel as final result (not an error) | Quirk | 41 | Accepted — documented behavior |
+| **F5** | Serde ignores unknown JSON fields in crafted Durofut payloads | Quirk | 44 | Accepted — serde default behavior |
+| **F6** | Empty/whitespace SQL accepted by DSL validation, fails at execution time | Quirk | 43 | Accepted — could add DSL-time validation |
+| **F7** | Signal to non-existent/completed instance does not error | Quirk | 50 | Accepted — fire-and-forget semantics |

--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -8,6 +8,8 @@
 #   --clean           Start with fresh database (wipes all data)
 #   --verbose         Show all NOTICE messages and full error output
 #   -v                Same as --verbose
+#   --keep-going      Continue running tests after a failure (default: exit on first failure)
+#   -k                Same as --keep-going
 #   --pg-version VER  PostgreSQL major version to use (default: 17)
 #   --no-preload      Start PostgreSQL WITHOUT shared_preload_libraries=pg_durable
 #                     (runs only 00_requires_shared_preload test)
@@ -22,6 +24,7 @@
 #   ./scripts/test-e2e-local.sh -v 27_database_guc      # Run test with verbose output
 #   ./scripts/test-e2e-local.sh --pg-version 18         # Run all tests against PG18
 #   ./scripts/test-e2e-local.sh --no-preload            # Test shared_preload_libraries enforcement
+#   ./scripts/test-e2e-local.sh --keep-going            # Run all tests, don't stop on failure
 
 set -e
 
@@ -33,6 +36,7 @@ SQL_DIR="$PROJECT_DIR/tests/e2e/sql"
 KEEP_RUNNING=false
 CLEAN_START=false
 VERBOSE=false
+KEEP_GOING=false
 NO_PRELOAD=false
 TEST_FILTER=""
 REPEAT_COUNT=1
@@ -51,6 +55,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --verbose|-v)
             VERBOSE=true
+            shift
+            ;;
+        --keep-going|-k)
+            KEEP_GOING=true
             shift
             ;;
         --pg-version)
@@ -124,6 +132,9 @@ if [ "$KEEP_RUNNING" = true ]; then
 fi
 if [ "$VERBOSE" = true ]; then
     echo -e "Mode: ${YELLOW}Verbose output (show NOTICE messages)${NC}"
+fi
+if [ "$KEEP_GOING" = true ]; then
+    echo -e "Mode: ${YELLOW}Keep going on failure${NC}"
 fi
 if [ "$NO_PRELOAD" = true ]; then
     echo -e "Mode: ${YELLOW}No-preload (testing shared_preload_libraries enforcement)${NC}"
@@ -269,6 +280,12 @@ fi
 # Run tests
 TOTAL_PASSED=0
 TOTAL_FAILED=0
+FAILED_TESTS=()
+
+# When --keep-going is set, don't exit on test failure
+if [ "$KEEP_GOING" = true ]; then
+    set +e
+fi
 
 for run in $(seq 1 $REPEAT_COUNT); do
     if [ "$REPEAT_COUNT" -gt 1 ]; then
@@ -344,6 +361,7 @@ for run in $(seq 1 $REPEAT_COUNT); do
             else
                 echo -e "  ${RED}FAIL${NC}"
                 FAILED=$((FAILED + 1))
+                FAILED_TESTS+=("$test_name")
             fi
         else
             # Non-verbose mode: capture output and show summary
@@ -358,6 +376,7 @@ for run in $(seq 1 $REPEAT_COUNT); do
                     echo -e "${RED}FAIL${NC}"
                     echo "$output" | grep -E "(NOTICE|ERROR|TEST FAILED)" | tail -15
                     FAILED=$((FAILED + 1))
+                    FAILED_TESTS+=("$test_name")
                 else
                     echo -e "${GREEN}PASS${NC}"
                     PASSED=$((PASSED + 1))
@@ -366,6 +385,7 @@ for run in $(seq 1 $REPEAT_COUNT); do
                 echo -e "${RED}FAIL${NC}"
                 echo "$output" | grep -E "(NOTICE|ERROR)" | tail -15
                 FAILED=$((FAILED + 1))
+                FAILED_TESTS+=("$test_name")
             fi
         fi
     done
@@ -385,6 +405,13 @@ if [ "$REPEAT_COUNT" -gt 1 ]; then
     echo "Total Results ($REPEAT_COUNT runs):"
 fi
 echo -e "Results: ${GREEN}$TOTAL_PASSED passed${NC}, ${RED}$TOTAL_FAILED failed${NC}"
+if [ ${#FAILED_TESTS[@]} -gt 0 ]; then
+    echo ""
+    echo -e "${RED}Failed tests:${NC}"
+    for t in "${FAILED_TESTS[@]}"; do
+        echo -e "  ${RED}- $t${NC}"
+    done
+fi
 echo "================================================"
 
 [ $TOTAL_FAILED -eq 0 ]

--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -333,6 +333,10 @@ for run in $(seq 1 $REPEAT_COUNT); do
         # 35 reads df._worker_epoch (internal table)
         # 37 tests RLS policies, including for superuser, changes users
         # 38 tests per-user vars RLS isolation, changes users
+        # 58 kills background worker (requires pg_terminate_backend + _worker_epoch)
+        # 60 deletes instance rows directly (bypasses RLS, superuser only)
+        # 62 uses dblink with postgres credentials for concurrent sessions
+        # 63 uses dblink with postgres credentials for variable race test
         PSQL_USER="$E2E_USER"
         if [[ "$test_name" == "00_requires_shared_preload" \
            || "$test_name" == "22_cross_connection" \
@@ -345,7 +349,11 @@ for run in $(seq 1 $REPEAT_COUNT); do
            || "$test_name" == "34_multi_database" \
            || "$test_name" == "35_heartbeat_liveness" \
            || "$test_name" == "37_rls" \
-           || "$test_name" == "38_rls_vars" ]]; then
+           || "$test_name" == "38_rls_vars" \
+           || "$test_name" == "58_kill_worker_mid_execution" \
+           || "$test_name" == "60_orphaned_nodes" \
+           || "$test_name" == "62_concurrent_sessions" \
+           || "$test_name" == "63_shared_variable_race" ]]; then
             PSQL_USER="$PG_USER"
         fi
         

--- a/tests/e2e/sql/38_infinite_loop.sql
+++ b/tests/e2e/sql/38_infinite_loop.sql
@@ -1,0 +1,79 @@
+-- Test: Infinite loop cancellation (B1 / B2)
+-- Demonstrates: df.loop() with always-true condition and unconditional loop
+-- Expected:
+--   - Loops run indefinitely; df.cancel() successfully stops them
+--   - Instance ends in canceled/failed state, not stuck in running
+
+DROP TABLE IF EXISTS test_infinite_log;
+CREATE TABLE test_infinite_log (id SERIAL, variant TEXT, ts TIMESTAMP DEFAULT now());
+
+CREATE TEMP TABLE _inf_state (instance_id TEXT, variant TEXT);
+
+-- B1: always-true while-condition loop
+INSERT INTO _inf_state
+SELECT df.start(
+    df.loop(
+        'INSERT INTO test_infinite_log (variant) VALUES (''while_true'')',
+        'SELECT true'   -- condition never becomes false
+    ),
+    'test-infinite-while-true'
+), 'while_true';
+
+-- B2: unconditional loop (no condition argument)
+INSERT INTO _inf_state
+SELECT df.start(
+    df.loop(
+        'INSERT INTO test_infinite_log (variant) VALUES (''unconditional'')'
+    ),
+    'test-infinite-unconditional'
+), 'unconditional';
+
+DO $$
+DECLARE
+    rec RECORD;
+    cnt INT;
+    status TEXT;
+    attempts INT;
+BEGIN
+    FOR rec IN SELECT instance_id, variant FROM _inf_state LOOP
+        RAISE NOTICE 'Testing infinite loop [%]: %', rec.variant, rec.instance_id;
+
+        -- Wait for at least 2 iterations to prove the loop is actually running
+        attempts := 0;
+        LOOP
+            SELECT COUNT(*) INTO cnt FROM test_infinite_log WHERE variant = rec.variant;
+            EXIT WHEN cnt >= 2 OR attempts > 200;
+            PERFORM pg_sleep(0.1);
+            attempts := attempts + 1;
+        END LOOP;
+
+        IF cnt < 2 THEN
+            RAISE EXCEPTION 'TEST FAILED [%]: expected >= 2 iterations before cancel, got %',
+                rec.variant, cnt;
+        END IF;
+
+        -- Cancel the running loop
+        PERFORM df.cancel(rec.instance_id, 'test-cancel');
+
+        -- Wait for cancellation to take effect
+        attempts := 0;
+        LOOP
+            SELECT s INTO status FROM df.status(rec.instance_id) s;
+            EXIT WHEN lower(status) IN ('canceled', 'cancelled', 'failed') OR attempts > 100;
+            PERFORM pg_sleep(0.2);
+            attempts := attempts + 1;
+        END LOOP;
+
+        IF lower(status) NOT IN ('canceled', 'cancelled', 'failed') THEN
+            RAISE EXCEPTION 'TEST FAILED [%]: expected canceled/failed after cancel, got %',
+                rec.variant, status;
+        END IF;
+
+        RAISE NOTICE 'PASSED [%]: ran % iterations, then canceled (status=%)',
+            rec.variant, cnt, status;
+    END LOOP;
+END $$;
+
+DROP TABLE _inf_state;
+DROP TABLE test_infinite_log;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/39_truthiness_edge_cases.sql
+++ b/tests/e2e/sql/39_truthiness_edge_cases.sql
@@ -1,0 +1,114 @@
+-- Test: Loop condition truthiness edge cases (B3)
+-- Demonstrates: evaluate_condition / is_truthy behavior for ambiguous values
+-- Expected: Documents and verifies the actual truthiness semantics for:
+--   NULL, integer 0, float 0.0, empty string, string "false", string "no",
+--   empty JSON array, empty JSON object
+
+-- Each sub-test starts a df.loop(body, condition) and checks whether the loop
+-- stops (condition is falsy) or runs at least 2 iterations before cancel
+-- (condition is truthy).
+
+DROP TABLE IF EXISTS test_truth_log;
+CREATE TABLE test_truth_log (id SERIAL, variant TEXT, ts TIMESTAMP DEFAULT now());
+
+-- Store test cases and instance IDs
+CREATE TEMP TABLE _truth_cases (
+    variant TEXT,
+    condition_sql TEXT,
+    expected TEXT,
+    instance_id TEXT
+);
+
+INSERT INTO _truth_cases (variant, condition_sql, expected) VALUES
+    ('null_val',    'SELECT NULL',          'falsy'),
+    ('int_zero',    'SELECT 0',             'falsy'),
+    ('int_one',     'SELECT 1',             'truthy'),
+    ('bool_false',  'SELECT false',         'falsy'),
+    ('bool_true',   'SELECT true',          'truthy'),
+    -- [KNOWN QUIRK] Non-empty strings that are not "true"/"t"/"yes"/"1" and
+    -- not parseable as non-zero integers: actual behavior is falsy.
+    ('str_false',   'SELECT ''false''',     'falsy'),
+    ('str_no',      'SELECT ''no''',        'falsy'),
+    ('empty_str',   'SELECT ''''',          'falsy'),
+    ('float_zero',  'SELECT 0.0',           'falsy'),
+    ('empty_array', 'SELECT ''[]''::jsonb', 'falsy'),
+    ('empty_obj',   'SELECT ''{}''::jsonb', 'falsy');
+
+-- Start all loop instances at top level (auto-commits so background worker can see them)
+UPDATE _truth_cases SET instance_id = df.start(
+    df.loop(
+        format('INSERT INTO test_truth_log (variant) VALUES (%L)', variant),
+        condition_sql
+    ),
+    format('truth-%s', variant)
+);
+
+-- NOTE on known behavior quirks:
+-- String "false" and "no" are treated as FALSY by is_truthy() — they are
+-- recognized as falsy string values. The correct way to return a falsy condition
+-- is `SELECT false` (boolean), `SELECT 0`, or string "false"/"no".
+
+-- Poll each instance and determine truthy/falsy
+DO $$
+DECLARE
+    rec RECORD;
+    status TEXT;
+    cnt INT;
+    got TEXT;
+    attempts INT;
+    failures INT := 0;
+BEGIN
+    FOR rec IN SELECT * FROM _truth_cases LOOP
+        attempts := 0;
+
+        -- Wait up to 10s for the loop to either stop on its own or run 2 iterations
+        LOOP
+            SELECT s INTO status FROM df.status(rec.instance_id) s;
+            SELECT COUNT(*) INTO cnt FROM test_truth_log WHERE variant = rec.variant;
+            EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled', 'cancelled')
+                   OR cnt >= 2
+                   OR attempts > 100;
+            PERFORM pg_sleep(0.1);
+            attempts := attempts + 1;
+        END LOOP;
+
+        IF lower(status) IN ('completed', 'failed', 'canceled', 'cancelled') THEN
+            -- Loop stopped by itself → condition was falsy
+            got := 'falsy';
+        ELSIF cnt >= 2 THEN
+            -- Loop kept running beyond 1 iteration → condition is truthy; cancel it
+            PERFORM df.cancel(rec.instance_id, 'truth-test-done');
+            -- Wait for cancel to land
+            attempts := 0;
+            LOOP
+                SELECT s INTO status FROM df.status(rec.instance_id) s;
+                EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled', 'cancelled')
+                       OR attempts > 50;
+                PERFORM pg_sleep(0.1);
+                attempts := attempts + 1;
+            END LOOP;
+            got := 'truthy';
+        ELSE
+            -- Timeout: instance did not start within 10s (worker busy or dead)
+            PERFORM df.cancel(rec.instance_id, 'truth-test-timeout');
+            RAISE EXCEPTION 'Timeout waiting for truth test [%] (status=%, cnt=%)', rec.variant, status, cnt;
+        END IF;
+
+        RAISE NOTICE 'Truthiness [%]: condition=% → %', rec.variant, rec.condition_sql, got;
+        IF got != rec.expected THEN
+            RAISE WARNING 'REGRESSION [%]: got % expected %', rec.variant, got, rec.expected;
+            failures := failures + 1;
+        END IF;
+    END LOOP;
+
+    -- Emit a clear notice about the known quirks so they are visible in test output
+    RAISE NOTICE 'NOTE: SELECT ''false'' and SELECT ''no'' are falsy in loop conditions.';
+
+    IF failures > 0 THEN
+        RAISE EXCEPTION 'TEST FAILED: % truthiness regression(s) — see WARNINGs above', failures;
+    END IF;
+END $$;
+
+DROP TABLE _truth_cases;
+DROP TABLE test_truth_log;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/40_empty_dml_results.sql
+++ b/tests/e2e/sql/40_empty_dml_results.sql
@@ -1,0 +1,90 @@
+-- Test: SQL nodes returning 0 rows or DML without RETURNING (B5 / B6)
+-- Demonstrates: How empty result sets and DML results flow through |=> and $var
+-- Expected: Both patterns complete successfully; documents the JSON result shape
+
+DROP TABLE IF EXISTS test_dml_target;
+CREATE TABLE test_dml_target (id SERIAL, val TEXT);
+
+-- ============================================================================
+-- B5: SQL node that returns 0 rows, result used in next node
+-- ============================================================================
+CREATE TEMP TABLE _b5_state AS
+SELECT df.start(
+    'SELECT 1 WHERE false' |=> 'empty_result'
+    ~> 'SELECT $empty_result',   -- uses the empty result JSON
+    'test-empty-result'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    res TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b5_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    -- BUG: Empty result (0 rows) causes $var substitution to produce unquoted
+    -- JSON in SQL context, yielding: SELECT {"rows":[],"row_count":0}
+    -- which is a syntax error. Once fixed in substitute_all_with_options
+    -- (src/types.rs), change this to expect 'completed'.
+    IF status != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [B5]: expected Failed (known bug: empty result $var substitution), got %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED [B5]: confirmed known bug — zero-row $var substitution produces invalid SQL (status=failed)';
+END $$;
+
+DROP TABLE _b5_state;
+
+-- ============================================================================
+-- B6: DML node without RETURNING, result used in next node
+-- ============================================================================
+INSERT INTO test_dml_target (val) VALUES ('initial');
+
+CREATE TEMP TABLE _b6_state AS
+SELECT df.start(
+    'UPDATE test_dml_target SET val = ''updated''' |=> 'update_result'
+    ~> 'SELECT $update_result',  -- uses the DML result JSON (0 rows, row_count > 0)
+    'test-dml-result'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    res TEXT;
+    updated_val TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b6_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    -- BUG: Same empty-rows substitution bug as B5. DML without RETURNING
+    -- produces {"rows":[],"row_count":1}, and $update_result is substituted
+    -- unquoted. Once fixed in substitute_all_with_options (src/types.rs),
+    -- change this to expect 'completed' and re-enable the assertions below.
+    IF status != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [B6]: expected Failed (known bug: empty result $var substitution), got %', status;
+    END IF;
+
+    -- TODO: uncomment when bug is fixed
+    -- SELECT r INTO res FROM df.result(inst_id) r;
+    -- RAISE NOTICE 'B6 result (DML result passed as $var): %', res;
+
+    -- Verify the DML actually ran (the UPDATE itself executes; it's the
+    -- subsequent SELECT $update_result that fails)
+    SELECT val INTO updated_val FROM test_dml_target LIMIT 1;
+    IF updated_val != 'updated' THEN
+        RAISE EXCEPTION 'TEST FAILED [B6]: DML did not execute, val = %', updated_val;
+    END IF;
+
+    RAISE NOTICE 'PASSED [B6]: confirmed known bug — DML $var substitution produces invalid SQL (status=failed), but DML side effect committed';
+END $$;
+
+DROP TABLE _b6_state;
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+DROP TABLE test_dml_target;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/41_break_outside_loop.sql
+++ b/tests/e2e/sql/41_break_outside_loop.sql
@@ -1,0 +1,35 @@
+-- Test: df.break() used at the top level outside any loop (B10)
+-- Demonstrates: Break sentinel propagated as final instance result
+-- Expected: Instance completes (the break sentinel becomes the result),
+--           does NOT hang or crash.
+
+CREATE TEMP TABLE _b10_state AS
+SELECT df.start(
+    df.break('{"reason": "top-level-break"}'),
+    'test-break-outside-loop'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    res TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b10_state;
+
+    -- A top-level break has no enclosing loop to consume it, so the break
+    -- sentinel propagates as the final result.  The instance should complete
+    -- rather than hang or fail with an error.
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [B10]: expected Completed for top-level break, got %', status;
+    END IF;
+
+    SELECT r INTO res FROM df.result(inst_id) r;
+    RAISE NOTICE 'B10 result (top-level break value): %', res;
+    RAISE NOTICE 'PASSED [B10]: df.break() at top level completes gracefully';
+END $$;
+
+DROP TABLE _b10_state;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/42_recursive_start.sql
+++ b/tests/e2e/sql/42_recursive_start.sql
@@ -1,0 +1,52 @@
+-- Test: Calling df.start() from inside a workflow SQL node (B11)
+-- Demonstrates: df.start() is not guarded by is_in_workflow_context().
+--               A SQL node can spawn child instances, which the background
+--               worker picks up independently.
+-- Expected: Outer instance completes; child instance is created and completes.
+
+DROP TABLE IF EXISTS test_recursive_log;
+CREATE TABLE test_recursive_log (id SERIAL, spawned_id TEXT, ts TIMESTAMP DEFAULT now());
+
+CREATE TEMP TABLE _b11_outer AS
+SELECT df.start(
+    -- This SQL node calls df.start() to spawn a child instance and records the ID.
+    'INSERT INTO test_recursive_log (spawned_id)
+     SELECT df.start(df.sql(''SELECT 1''), ''child-from-workflow'')',
+    'test-recursive-start-outer'
+) AS instance_id;
+
+DO $$
+DECLARE
+    outer_id TEXT;
+    child_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO outer_id FROM _b11_outer;
+    RAISE NOTICE 'Outer instance: %', outer_id;
+
+    -- Wait for the outer instance to complete
+    SELECT df.wait_for_completion(outer_id, 30) INTO status;
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [B11]: outer instance expected Completed, got %', status;
+    END IF;
+
+    -- Verify that a child instance was spawned
+    SELECT spawned_id INTO child_id FROM test_recursive_log LIMIT 1;
+    IF child_id IS NULL THEN
+        RAISE EXCEPTION 'TEST FAILED [B11]: expected a child instance to be spawned';
+    END IF;
+    RAISE NOTICE 'Child instance spawned: %', child_id;
+
+    -- Wait for the child instance to complete
+    SELECT df.wait_for_completion(child_id, 30) INTO status;
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [B11]: child instance expected Completed, got %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED [B11]: df.start() inside a workflow spawns a running child instance';
+    RAISE NOTICE 'NOTE: No recursion guard exists — unbounded spawning is possible if used carelessly';
+END $$;
+
+DROP TABLE _b11_outer;
+DROP TABLE test_recursive_log;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/43_empty_sql.sql
+++ b/tests/e2e/sql/43_empty_sql.sql
@@ -1,0 +1,84 @@
+-- Test: Empty and whitespace-only SQL strings (C1)
+-- Demonstrates: df.sql('') and df.sql('   ') pass DSL validation but fail at execution
+-- Expected: df.start() succeeds (validation doesn't reject empty queries),
+--           but the instance transitions to Failed when worker executes the empty query.
+
+-- ============================================================================
+-- C1a: Empty string SQL
+-- ============================================================================
+CREATE TEMP TABLE _c1a_state AS
+SELECT df.start(df.sql(''), 'test-empty-sql') AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _c1a_state;
+    RAISE NOTICE 'C1a: Testing empty SQL, instance: %', inst_id;
+
+    -- Empty query will fail at execution time (PostgreSQL rejects empty statement)
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF lower(status) NOT IN ('failed', 'completed') THEN
+        RAISE EXCEPTION 'TEST FAILED [C1a]: expected Failed or Completed for empty SQL, got %', status;
+    END IF;
+
+    RAISE NOTICE 'C1a: empty SQL result status = % (expected Failed)', status;
+    RAISE NOTICE 'PASSED [C1a]: empty SQL handled gracefully (no crash)';
+END $$;
+
+DROP TABLE _c1a_state;
+
+-- ============================================================================
+-- C1b: Whitespace-only SQL
+-- ============================================================================
+CREATE TEMP TABLE _c1b_state AS
+SELECT df.start(df.sql('   '), 'test-whitespace-sql') AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _c1b_state;
+    RAISE NOTICE 'C1b: Testing whitespace SQL, instance: %', inst_id;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF lower(status) NOT IN ('failed', 'completed') THEN
+        RAISE EXCEPTION 'TEST FAILED [C1b]: expected Failed or Completed for whitespace SQL, got %', status;
+    END IF;
+
+    RAISE NOTICE 'C1b: whitespace SQL result status = % (expected Failed)', status;
+    RAISE NOTICE 'PASSED [C1b]: whitespace SQL handled gracefully (no crash)';
+END $$;
+
+DROP TABLE _c1b_state;
+
+-- ============================================================================
+-- C1c: Non-SQL text
+-- ============================================================================
+CREATE TEMP TABLE _c1c_state AS
+SELECT df.start(df.sql('this is not valid sql at all'), 'test-nonsql') AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _c1c_state;
+    RAISE NOTICE 'C1c: Testing non-SQL text, instance: %', inst_id;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF lower(status) NOT IN ('failed', 'completed') THEN
+        RAISE EXCEPTION 'TEST FAILED [C1c]: expected Failed for non-SQL text, got %', status;
+    END IF;
+
+    RAISE NOTICE 'C1c: non-SQL text result status = % (expected Failed)', status;
+    RAISE NOTICE 'PASSED [C1c]: non-SQL text handled gracefully (no crash)';
+END $$;
+
+DROP TABLE _c1c_state;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/44_crafted_json.sql
+++ b/tests/e2e/sql/44_crafted_json.sql
@@ -1,0 +1,166 @@
+-- Test: Manually crafted JSON inputs bypassing the DSL (C7)
+-- Extends tests 32 (invalid node_type) and 33 (malformed condition_node)
+-- Demonstrates: Additional raw JSON edge cases and unknown-field handling
+
+-- ============================================================================
+-- C7a: Valid node type, unknown extra field (should be ignored or rejected)
+-- ============================================================================
+CREATE TEMP TABLE _c7a_state (instance_id TEXT, error_msg TEXT);
+
+DO $body$
+BEGIN
+    INSERT INTO _c7a_state (instance_id)
+    VALUES (df.start('{"node_type":"SQL","query":"SELECT 1","evil_field":"pwned"}'));
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO _c7a_state (error_msg) VALUES (SQLERRM);
+END $body$;
+
+DO $body$
+DECLARE
+    inst_id TEXT;
+    err TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id, error_msg INTO inst_id, err FROM _c7a_state;
+    IF err IS NOT NULL THEN
+        RAISE NOTICE 'C7a: df.start rejected unknown field: %', err;
+    ELSE
+        -- Unknown fields may be silently ignored by serde; instance might complete
+        RAISE NOTICE 'C7a: df.start accepted unknown field (serde ignores unknowns)';
+        SELECT df.wait_for_completion(inst_id, 30) INTO status;
+        RAISE NOTICE 'C7a: status = %', status;
+    END IF;
+END $body$;
+
+DROP TABLE _c7a_state;
+
+-- ============================================================================
+-- C7b: THEN node with non-object left_node (string instead of object)
+-- ============================================================================
+DO $body$
+BEGIN
+    BEGIN
+        PERFORM df.start('{"node_type":"THEN","left_node":"not an object","right_node":{"node_type":"SQL","query":"SELECT 2"}}');
+        RAISE EXCEPTION 'TEST FAILED [C7b]: df.start should have rejected non-object left_node';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'C7b: Caught expected error for non-object left_node: %', SQLERRM;
+    END;
+END $body$;
+
+-- ============================================================================
+-- C7c: THEN node with null left_node (accepted by serde, may fail at runtime)
+-- ============================================================================
+CREATE TEMP TABLE _c7c_state (instance_id TEXT, error_msg TEXT);
+
+DO $body$
+BEGIN
+    INSERT INTO _c7c_state (instance_id)
+    VALUES (df.start('{"node_type":"THEN","left_node":null,"right_node":{"node_type":"SQL","query":"SELECT 2"}}'));
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO _c7c_state (error_msg) VALUES (SQLERRM);
+END $body$;
+
+DO $body$
+DECLARE
+    inst_id TEXT;
+    err TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id, error_msg INTO inst_id, err FROM _c7c_state;
+    IF err IS NOT NULL THEN
+        RAISE NOTICE 'C7c: df.start rejected null left_node: %', err;
+    ELSE
+        -- serde accepts null as Option<Durofut> = None; df.start() may succeed.
+        -- The instance may fail at runtime when the orchestration finds no left node.
+        RAISE NOTICE 'C7c: df.start accepted null left_node (serde treats null as None)';
+        SELECT df.wait_for_completion(inst_id, 30) INTO status;
+        RAISE NOTICE 'C7c: null left_node instance status = %', status;
+    END IF;
+END $body$;
+
+DROP TABLE _c7c_state;
+
+-- ============================================================================
+-- C7d: SQL node with null query (accepted by serde, fails at execution time)
+-- ============================================================================
+CREATE TEMP TABLE _c7d_state (instance_id TEXT, error_msg TEXT);
+
+DO $body$
+BEGIN
+    INSERT INTO _c7d_state (instance_id)
+    VALUES (df.start('{"node_type":"SQL","query":null}'));
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO _c7d_state (error_msg) VALUES (SQLERRM);
+END $body$;
+
+DO $body$
+DECLARE
+    inst_id TEXT;
+    err TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id, error_msg INTO inst_id, err FROM _c7d_state;
+    IF err IS NOT NULL THEN
+        RAISE NOTICE 'C7d: df.start rejected null query: %', err;
+    ELSE
+        -- null is accepted by serde as Option<String> = None; node is inserted with NULL query.
+        -- The orchestration will error with "SQL node X has no query".
+        RAISE NOTICE 'C7d: df.start accepted null query (inserted with NULL query column)';
+        SELECT df.wait_for_completion(inst_id, 30) INTO status;
+        IF lower(status) NOT IN ('failed', 'completed') THEN
+            RAISE EXCEPTION 'TEST FAILED [C7d]: expected Failed for null query, got %', status;
+        END IF;
+        RAISE NOTICE 'C7d: null query instance status = % (expected Failed)', status;
+    END IF;
+END $body$;
+
+DROP TABLE _c7d_state;
+
+-- ============================================================================
+-- C7e: LOOP node with left_node missing (no body)
+-- ============================================================================
+DO $body$
+BEGIN
+    BEGIN
+        PERFORM df.start('{"node_type":"LOOP"}');
+        RAISE EXCEPTION 'TEST FAILED [C7e]: df.start should have rejected LOOP without body';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'C7e: Caught expected error for LOOP without body: %', SQLERRM;
+    END;
+END $body$;
+
+-- ============================================================================
+-- C7f: Completely empty JSON object
+-- ============================================================================
+DO $body$
+BEGIN
+    BEGIN
+        PERFORM df.start('{}');
+        RAISE EXCEPTION 'TEST FAILED [C7f]: df.start should have rejected empty JSON object';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'C7f: Caught expected error for empty JSON: %', SQLERRM;
+    END;
+END $body$;
+
+-- ============================================================================
+-- C7g: Plain string (auto-wrapped as SQL node) — should succeed
+-- ============================================================================
+CREATE TEMP TABLE _c7g_state AS
+SELECT df.start('SELECT 1', 'test-plain-string-c7g') AS instance_id;
+
+DO $body$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _c7g_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [C7g]: plain string auto-wrap expected Completed, got %', status;
+    END IF;
+    RAISE NOTICE 'C7g: plain string auto-wrapped as SQL node and completed successfully';
+END $body$;
+
+DROP TABLE _c7g_state;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/45_concurrent_instances.sql
+++ b/tests/e2e/sql/45_concurrent_instances.sql
@@ -1,0 +1,64 @@
+-- Test: Many concurrent instances (A1)
+-- Demonstrates: Background worker handles a burst of simultaneous instances
+-- Expected: All 20 instances complete within 60 seconds; none stuck in pending/running
+
+DROP TABLE IF EXISTS test_burst_instances;
+CREATE TABLE test_burst_instances (id SERIAL, instance_id TEXT);
+
+DO $$
+DECLARE
+    i INT;
+    inst_id TEXT;
+    total INT := 20;
+BEGIN
+    FOR i IN 1..total LOOP
+        inst_id := df.start(df.sql('SELECT 1'), 'burst-' || i);
+        INSERT INTO test_burst_instances (instance_id) VALUES (inst_id);
+    END LOOP;
+    RAISE NOTICE 'Started % instances', total;
+END $$;
+
+-- Wait for all burst instances to complete
+DO $$
+DECLARE
+    completed_count INT;
+    attempts INT := 0;
+    total INT := 20;
+BEGIN
+    LOOP
+        SELECT COUNT(*) INTO completed_count
+        FROM test_burst_instances b
+        JOIN df.instances i ON i.id = b.instance_id
+        WHERE lower(i.status) IN ('completed', 'failed', 'canceled');
+
+        EXIT WHEN completed_count >= total OR attempts > 600;  -- 60s timeout
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF completed_count < total THEN
+        RAISE EXCEPTION 'TEST FAILED [A1]: only %/% instances completed within timeout', completed_count, total;
+    END IF;
+
+    RAISE NOTICE 'PASSED [A1]: all % concurrent instances completed', total;
+END $$;
+
+-- Verify no instances are stuck in pending or running
+DO $$
+DECLARE
+    stuck_count INT;
+BEGIN
+    SELECT COUNT(*) INTO stuck_count
+    FROM test_burst_instances b
+    JOIN df.instances i ON i.id = b.instance_id
+    WHERE lower(i.status) IN ('pending', 'running');
+
+    IF stuck_count > 0 THEN
+        RAISE EXCEPTION 'TEST FAILED [A1]: % instances stuck in pending/running', stuck_count;
+    END IF;
+
+    RAISE NOTICE 'PASSED [A1]: no instances stuck after burst';
+END $$;
+
+DROP TABLE test_burst_instances;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/46_deep_nesting.sql
+++ b/tests/e2e/sql/46_deep_nesting.sql
@@ -1,0 +1,43 @@
+-- Test: Deep graph nesting — 50-level sequential chain (A2)
+-- Demonstrates: execute_function_node_with_vars handles deeply nested THEN nodes
+--               without stack overflow.
+-- Expected: Instance completes successfully.
+
+-- Build a 50-step sequential chain using a DO block, start it (commits on block end)
+CREATE TEMP TABLE _test_state (instance_id TEXT);
+
+DO $$
+DECLARE
+    chain TEXT;
+    i INT;
+BEGIN
+    -- Start with a single SQL node
+    chain := df.sql('SELECT 1');
+
+    -- Append 49 more steps: total depth = 50 nested THEN nodes
+    FOR i IN 2..50 LOOP
+        chain := df.seq(chain, format('SELECT %s', i));
+    END LOOP;
+
+    INSERT INTO _test_state VALUES (df.start(chain, 'test-deep-nesting-50'));
+    RAISE NOTICE 'Deep nesting test started';
+END $$;
+
+-- Wait in a separate block so the instance is already committed
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+    SELECT df.wait_for_completion(inst_id, 60) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [A2]: 50-level deep chain expected Completed, got %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED [A2]: 50-level sequential chain completed successfully';
+END $$;
+
+DROP TABLE _test_state;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/47_rapid_cancel.sql
+++ b/tests/e2e/sql/47_rapid_cancel.sql
@@ -1,0 +1,67 @@
+-- Test: Rapid start/cancel cycles (A7)
+-- Demonstrates: Race between worker pickup and cancel signal;
+--               verifies no instances are stuck after repeated start+cancel.
+-- Expected: All instances end up in a terminal state (canceled, failed, or completed).
+
+DROP TABLE IF EXISTS test_rapid_cancel_instances;
+CREATE TABLE test_rapid_cancel_instances (id SERIAL, instance_id TEXT);
+
+DO $$
+DECLARE
+    i INT;
+    inst_id TEXT;
+    total INT := 20;
+BEGIN
+    FOR i IN 1..total LOOP
+        -- Start a slow instance, then immediately cancel it
+        inst_id := df.start(df.sleep(60), 'rapid-cancel-' || i);
+        INSERT INTO test_rapid_cancel_instances (instance_id) VALUES (inst_id);
+        PERFORM df.cancel(inst_id, 'rapid-cancel-test');
+    END LOOP;
+    RAISE NOTICE 'Started and canceled % instances', total;
+END $$;
+
+-- Wait for all to settle into a terminal state
+DO $$
+DECLARE
+    settled INT;
+    attempts INT := 0;
+    total INT := 20;
+BEGIN
+    LOOP
+        SELECT COUNT(*) INTO settled
+        FROM test_rapid_cancel_instances r
+        JOIN df.instances i ON i.id = r.instance_id
+        WHERE lower(i.status) IN ('completed', 'failed', 'canceled', 'cancelled');
+
+        EXIT WHEN settled >= total OR attempts > 300;  -- 30s timeout
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF settled < total THEN
+        RAISE EXCEPTION 'TEST FAILED [A7]: only %/% instances settled within timeout', settled, total;
+    END IF;
+
+    RAISE NOTICE 'PASSED [A7]: all % rapid-cancel instances settled', total;
+END $$;
+
+-- Verify no instances stuck
+DO $$
+DECLARE
+    stuck INT;
+BEGIN
+    SELECT COUNT(*) INTO stuck
+    FROM test_rapid_cancel_instances r
+    JOIN df.instances i ON i.id = r.instance_id
+    WHERE lower(i.status) IN ('pending', 'running');
+
+    IF stuck > 0 THEN
+        RAISE EXCEPTION 'TEST FAILED [A7]: % instances stuck after rapid cancel', stuck;
+    END IF;
+
+    RAISE NOTICE 'PASSED [A7]: no instances stuck after rapid start/cancel';
+END $$;
+
+DROP TABLE test_rapid_cancel_instances;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/48_race_both_fail.sql
+++ b/tests/e2e/sql/48_race_both_fail.sql
@@ -1,0 +1,65 @@
+-- Test: RACE where both branches fail (B8)
+-- Demonstrates: ctx.select2 behavior when both branches of a RACE node error
+-- Expected: Instance transitions to Failed (not stuck in Running)
+
+-- ============================================================================
+-- B8a: df.race() function — both branches fail
+-- ============================================================================
+CREATE TEMP TABLE _b8a_state AS
+SELECT df.start(
+    df.race(
+        'SELECT 1/0',   -- division by zero
+        'SELECT 2/0'    -- division by zero
+    ),
+    'test-race-both-fail-func'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b8a_state;
+    RAISE NOTICE 'B8a: Testing race(both-fail) func: %', inst_id;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF lower(status) NOT IN ('failed', 'completed') THEN
+        RAISE EXCEPTION 'TEST FAILED [B8a]: expected Failed for race(both-fail), got %', status;
+    END IF;
+
+    RAISE NOTICE 'B8a: race(both-fail) status = %', status;
+    RAISE NOTICE 'PASSED [B8a]: race with both branches failing is handled gracefully';
+END $$;
+
+DROP TABLE _b8a_state;
+
+-- ============================================================================
+-- B8b: | operator — both branches fail
+-- ============================================================================
+CREATE TEMP TABLE _b8b_state AS
+SELECT df.start(
+    'SELECT 1/0' | 'SELECT 2/0',
+    'test-race-both-fail-op'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b8b_state;
+    RAISE NOTICE 'B8b: Testing | operator both-fail: %', inst_id;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF lower(status) NOT IN ('failed', 'completed') THEN
+        RAISE EXCEPTION 'TEST FAILED [B8b]: expected Failed for | both-fail, got %', status;
+    END IF;
+
+    RAISE NOTICE 'B8b: | both-fail status = %', status;
+    RAISE NOTICE 'PASSED [B8b]: | operator with both branches failing is handled gracefully';
+END $$;
+
+DROP TABLE _b8b_state;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/49_join_one_fails.sql
+++ b/tests/e2e/sql/49_join_one_fails.sql
@@ -1,0 +1,76 @@
+-- Test: JOIN where one branch fails (B9)
+-- Demonstrates: execute_join_node behavior when one branch errors
+-- Expected: Instance transitions to Failed (not stuck). The successful branch's
+--           side effects (if any committed DML) are already persisted.
+
+DROP TABLE IF EXISTS test_join_fail_log;
+CREATE TABLE test_join_fail_log (id SERIAL, branch TEXT, ts TIMESTAMP DEFAULT now());
+
+-- ============================================================================
+-- B9a: df.join() — left succeeds, right fails
+-- ============================================================================
+CREATE TEMP TABLE _b9a_state AS
+SELECT df.start(
+    df.join(
+        'INSERT INTO test_join_fail_log (branch) VALUES (''left'') RETURNING ''ok''',
+        'SELECT 1/0'   -- fails
+    ),
+    'test-join-one-fail-func'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    left_ran INT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b9a_state;
+    RAISE NOTICE 'B9a: Testing join(left-ok, right-fail): %', inst_id;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF lower(status) NOT IN ('failed', 'completed') THEN
+        RAISE EXCEPTION 'TEST FAILED [B9a]: expected Failed for join(one-fail), got %', status;
+    END IF;
+
+    -- Check whether the left branch's DML committed (it may or may not depending on tx boundaries)
+    SELECT COUNT(*) INTO left_ran FROM test_join_fail_log WHERE branch = 'left';
+    RAISE NOTICE 'B9a: join(one-fail) status=%, left branch ran=% time(s)', status, left_ran;
+    RAISE NOTICE 'PASSED [B9a]: join with one failing branch handled gracefully';
+END $$;
+
+DROP TABLE _b9a_state;
+
+-- ============================================================================
+-- B9b: & operator — left fails, right succeeds
+-- ============================================================================
+CREATE TEMP TABLE _b9b_state AS
+SELECT df.start(
+    'SELECT 1/0'  -- fails
+    & 'INSERT INTO test_join_fail_log (branch) VALUES (''right'') RETURNING ''ok''',
+    'test-join-one-fail-op'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    right_ran INT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b9b_state;
+    RAISE NOTICE 'B9b: Testing & operator (left-fail, right-ok): %', inst_id;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF lower(status) NOT IN ('failed', 'completed') THEN
+        RAISE EXCEPTION 'TEST FAILED [B9b]: expected Failed for & (one-fail), got %', status;
+    END IF;
+
+    SELECT COUNT(*) INTO right_ran FROM test_join_fail_log WHERE branch = 'right';
+    RAISE NOTICE 'B9b: & (one-fail) status=%, right branch ran=% time(s)', status, right_ran;
+    RAISE NOTICE 'PASSED [B9b]: & operator with one failing branch handled gracefully';
+END $$;
+
+DROP TABLE _b9b_state;
+DROP TABLE test_join_fail_log;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/50_signal_edge_cases.sql
+++ b/tests/e2e/sql/50_signal_edge_cases.sql
@@ -1,0 +1,98 @@
+-- Test: Signal edge cases (B12 / B13)
+-- B12: Signal to non-existent or already-completed instance
+-- B13: Multiple signals with the same name sent to one instance
+
+-- ============================================================================
+-- B12a: Signal to a garbage/non-existent instance ID
+-- ============================================================================
+DO $$
+BEGIN
+    BEGIN
+        PERFORM df.signal('nonexistentid', 'approve', '{}');
+        -- Sending to a non-existent ID may silently succeed (no row to update)
+        -- or raise an error — document the actual behavior
+        RAISE NOTICE 'B12a: df.signal to non-existent ID did not raise an error';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'B12a: df.signal to non-existent ID raised: %', SQLERRM;
+    END;
+END $$;
+
+-- ============================================================================
+-- B12b: Signal to an already-completed instance
+-- ============================================================================
+-- Start instance at top level so it commits before polling
+CREATE TEMP TABLE _b12b_state AS
+SELECT df.start('SELECT 1', 'test-signal-after-complete') AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b12b_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST SETUP FAILED [B12b]: instance did not complete, got %', status;
+    END IF;
+
+    -- Now try to signal the completed instance
+    BEGIN
+        PERFORM df.signal(inst_id, 'too-late', '{"note": "already done"}');
+        RAISE NOTICE 'B12b: df.signal to completed instance did not raise an error';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'B12b: df.signal to completed instance raised: %', SQLERRM;
+    END;
+END $$;
+
+DROP TABLE _b12b_state;
+
+-- ============================================================================
+-- B13: Multiple signals with the same name to the same waiting instance
+-- ============================================================================
+CREATE TEMP TABLE _b13_state AS
+SELECT df.start(
+    df.wait_for_signal('multi-signal') |=> 'sig'
+    ~> 'SELECT $sig',
+    'test-multi-signal'
+) AS instance_id;
+
+-- Wait for the instance to reach the waiting-for-signal state
+SELECT pg_sleep(2);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b13_state;
+    RAISE NOTICE 'B13: instance waiting for signal: %', inst_id;
+
+    -- Send the signal twice
+    BEGIN
+        PERFORM df.signal(inst_id, 'multi-signal', '{"delivery": 1}');
+        RAISE NOTICE 'B13: first signal sent';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'B13: first signal error: %', SQLERRM;
+    END;
+
+    BEGIN
+        PERFORM df.signal(inst_id, 'multi-signal', '{"delivery": 2}');
+        RAISE NOTICE 'B13: second signal sent';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'B13: second signal error: %', SQLERRM;
+    END;
+
+    -- Wait for instance to complete
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF lower(status) NOT IN ('completed', 'failed') THEN
+        RAISE EXCEPTION 'TEST FAILED [B13]: expected Completed or Failed, got %', status;
+    END IF;
+
+    RAISE NOTICE 'B13: multiple signals result status = %', status;
+    RAISE NOTICE 'PASSED [B13]: duplicate signal handled without crash';
+END $$;
+
+DROP TABLE _b13_state;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/51_wide_parallel.sql
+++ b/tests/e2e/sql/51_wide_parallel.sql
@@ -1,0 +1,43 @@
+-- Test: Wide parallel graph — 9 concurrent branches via nested join3 (A3)
+-- Demonstrates: duroxide runtime handles many simultaneous parallel sub-orchestrations
+-- Expected: All branches complete; instance ends in completed state
+
+-- Start instance at top level so it commits before polling
+CREATE TEMP TABLE _test_state AS SELECT df.start(
+    df.join3(
+        df.join3(
+            df.sql('SELECT 1 AS branch'),
+            df.sql('SELECT 2 AS branch'),
+            df.sql('SELECT 3 AS branch')
+        ),
+        df.join3(
+            df.sql('SELECT 4 AS branch'),
+            df.sql('SELECT 5 AS branch'),
+            df.sql('SELECT 6 AS branch')
+        ),
+        df.join3(
+            df.sql('SELECT 7 AS branch'),
+            df.sql('SELECT 8 AS branch'),
+            df.sql('SELECT 9 AS branch')
+        )
+    ),
+    'test-wide-parallel-9'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+    SELECT df.wait_for_completion(inst_id, 60) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [A3]: 9-branch parallel graph expected completed, got %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED [A3]: 9-branch parallel graph completed successfully';
+END $$;
+
+DROP TABLE _test_state;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/52_long_loop_history.sql
+++ b/tests/e2e/sql/52_long_loop_history.sql
@@ -1,0 +1,44 @@
+-- Test: Long loop execution history — 100 iterations (A4)
+-- Demonstrates: df.loop() with a finite counter condition running 100 iterations
+--               does not OOM, stack-overflow, or time out unreasonably.
+-- Expected: Instance completes in completed state; loop table has exactly 100 rows.
+
+DROP TABLE IF EXISTS test_long_loop_log;
+CREATE TABLE test_long_loop_log (id SERIAL);
+
+-- Start instance at top level so it commits before polling
+CREATE TEMP TABLE _test_state AS SELECT df.start(
+    df.loop(
+        'INSERT INTO test_long_loop_log DEFAULT VALUES',
+        'SELECT COUNT(*) < 100 FROM test_long_loop_log'
+    ),
+    'test-long-loop-100'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    row_count INT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+
+    -- Allow up to 120 seconds; 100 iterations should complete well under that
+    SELECT df.wait_for_completion(inst_id, 120) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [A4]: long loop expected completed, got %', status;
+    END IF;
+
+    SELECT COUNT(*) INTO row_count FROM test_long_loop_log;
+
+    IF row_count != 100 THEN
+        RAISE EXCEPTION 'TEST FAILED [A4]: expected 100 rows, got %', row_count;
+    END IF;
+
+    RAISE NOTICE 'PASSED [A4]: loop ran 100 iterations and completed successfully';
+END $$;
+
+DROP TABLE _test_state;
+DROP TABLE test_long_loop_log;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/53_large_result_sets.sql
+++ b/tests/e2e/sql/53_large_result_sets.sql
@@ -1,0 +1,28 @@
+-- Test: Large SQL result set — query returning 10,000 rows (A5)
+-- Demonstrates: execute_sql activity (which uses fetch_all()) can handle
+--               a large result set without OOM or timeout.
+-- Expected: Instance completes successfully.
+
+-- Start instance at top level so it commits before polling
+CREATE TEMP TABLE _test_state AS SELECT df.start(
+    df.sql('SELECT g1.n AS a, g2.n AS b FROM generate_series(1, 100) g1(n) CROSS JOIN generate_series(1, 100) g2(n)'),
+    'test-large-result-10k'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+    SELECT df.wait_for_completion(inst_id, 60) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [A5]: large result set expected completed, got %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED [A5]: 10,000-row result set handled without error';
+END $$;
+
+DROP TABLE _test_state;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/54_large_query_text.sql
+++ b/tests/e2e/sql/54_large_query_text.sql
@@ -1,0 +1,44 @@
+-- Test: Very large SQL query text (A6)
+-- Demonstrates: execute_sql activity can handle a very long query string
+--               without truncation or serialization errors.
+-- Expected: Instance completes successfully.
+
+-- Build the long query and start instance (commits on block end)
+CREATE TEMP TABLE _test_state (instance_id TEXT);
+
+DO $$
+DECLARE
+    long_sql TEXT;
+    i INT;
+BEGIN
+    -- Build a SELECT with a 500-element VALUES list, producing a ~10KB query
+    long_sql := 'SELECT v FROM (VALUES ';
+    FOR i IN 1..500 LOOP
+        IF i > 1 THEN
+            long_sql := long_sql || ',';
+        END IF;
+        long_sql := long_sql || format('(%s)', i);
+    END LOOP;
+    long_sql := long_sql || ') t(v) WHERE v = 1';
+
+    INSERT INTO _test_state VALUES (df.start(df.sql(long_sql), 'test-large-query-text'));
+END $$;
+
+-- Wait in a separate block so the instance is already committed
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [A6]: large query text expected completed, got %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED [A6]: ~10KB query text executed without error';
+END $$;
+
+DROP TABLE _test_state;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/55_large_variables.sql
+++ b/tests/e2e/sql/55_large_variables.sql
@@ -1,0 +1,40 @@
+-- Test: Large variable payloads (A8)
+-- Demonstrates: df.setvar() and {var} substitution handles large string values
+--               without truncation or serialization errors.
+-- Expected: Instance completes; the large value is preserved in the workflow.
+
+SELECT df.clearvars();
+
+-- Set a ~5KB variable value (a repeated pattern string)
+SELECT df.setvar('big_val', repeat('abcdefghij', 500));  -- 5000 chars
+
+-- Start instance at top level so it commits before polling
+CREATE TEMP TABLE _test_state AS SELECT df.start(
+    'SELECT length(''{big_val}'') AS len' |=> 'result',
+    'test-large-variable'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    result_text TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [A8]: large variable expected completed, got %', status;
+    END IF;
+
+    SELECT r INTO result_text FROM df.result(inst_id) r;
+    IF result_text IS NULL OR result_text NOT LIKE '%5000%' THEN
+        RAISE EXCEPTION 'TEST FAILED [A8]: expected length 5000 in result, got %', result_text;
+    END IF;
+
+    RAISE NOTICE 'PASSED [A8]: 5KB variable payload handled without error';
+END $$;
+
+DROP TABLE _test_state;
+SELECT df.clearvars();
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/56_rapid_status_poll.sql
+++ b/tests/e2e/sql/56_rapid_status_poll.sql
@@ -1,0 +1,37 @@
+-- Test: Rapid df.status() polling stress test (C5)
+-- Demonstrates: Many rapid status() calls do not cause issues.
+-- df.status() is a simple SPI query (SELECT status FROM df.instances),
+-- so each call is cheap. This test verifies that tight-loop polling
+-- does not interfere with the background worker or cause hangs.
+-- Expected: No errors, no hangs; instance completes normally.
+
+-- Start instance at top level so it commits before polling
+CREATE TEMP TABLE _test_state AS SELECT df.start(df.sleep(3), 'test-rapid-poll') AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    poll_count INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+
+    -- Tight-loop poll until completed, counting iterations.
+    -- Each df.status() call is a simple SPI query (~0.02ms), so we need a high
+    -- limit to cover the 3-second sleep duration without adding pg_sleep delays.
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        poll_count := poll_count + 1;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled');
+        EXIT WHEN poll_count > 500000;  -- safety limit (~10s of wall time)
+    END LOOP;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [C5]: expected completed, got % after % polls', status, poll_count;
+    END IF;
+
+    RAISE NOTICE 'PASSED [C5]: rapid polling ran % times without resource errors', poll_count;
+END $$;
+
+DROP TABLE _test_state;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/57_variable_name_conflict.sql
+++ b/tests/e2e/sql/57_variable_name_conflict.sql
@@ -1,0 +1,83 @@
+-- Test: Variable substitution edge cases — name conflicts and overwrites (B4 / B14)
+-- B4: A result binding that shadows a user variable of the same name
+-- B14: Two sequential steps binding the same result name (the second overwrites the first)
+-- Expected: System handles shadowing/overwriting gracefully without error
+
+SELECT df.clearvars();
+
+-- ============================================================================
+-- B14: Two steps bound to the same result name — second value wins
+-- ============================================================================
+DROP TABLE IF EXISTS test_var_conflict_log;
+CREATE TABLE test_var_conflict_log (id SERIAL, val TEXT);
+
+-- Start instance at top level so it commits before polling
+CREATE TEMP TABLE _b14_state AS SELECT df.start(
+    'SELECT ''first'' AS val' |=> 'x'
+    ~> ('SELECT ''second'' AS val' |=> 'x')
+    ~> 'INSERT INTO test_var_conflict_log (val) VALUES ($x) RETURNING val',
+    'test-var-name-conflict-b14'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    log_val TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b14_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [B14]: expected completed, got %', status;
+    END IF;
+
+    SELECT val INTO log_val FROM test_var_conflict_log ORDER BY id DESC LIMIT 1;
+    IF log_val IS NULL OR log_val NOT LIKE '%second%' THEN
+        RAISE EXCEPTION 'TEST FAILED [B14]: expected second to win name conflict, got %', log_val;
+    END IF;
+
+    RAISE NOTICE 'PASSED [B14]: second binding of same name correctly overwrites first';
+END $$;
+
+DROP TABLE _b14_state;
+
+-- ============================================================================
+-- B4: User variable shadowed by a step result of the same name
+-- ============================================================================
+SELECT df.clearvars();
+SELECT df.setvar('user_val', 'from_user');
+
+-- Start instance at top level so it commits before polling
+CREATE TEMP TABLE _b4_state AS SELECT df.start(
+    'SELECT ''from_step'' AS val' |=> 'user_val'
+    ~> 'INSERT INTO test_var_conflict_log (val) VALUES ($user_val) RETURNING val',
+    'test-var-shadow-b4'
+) AS instance_id;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    log_val TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _b4_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [B4]: expected completed, got %', status;
+    END IF;
+
+    SELECT val INTO log_val FROM test_var_conflict_log ORDER BY id DESC LIMIT 1;
+    IF log_val IS NULL OR log_val NOT LIKE '%from_step%' THEN
+        RAISE EXCEPTION 'TEST FAILED [B4]: expected step result to shadow user var, got %', log_val;
+    END IF;
+
+    RAISE NOTICE 'PASSED [B4]: step result correctly shadows user-defined var of same name';
+END $$;
+
+DROP TABLE _b4_state;
+
+SELECT df.clearvars();
+DROP TABLE test_var_conflict_log;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/58_kill_worker_mid_execution.sql
+++ b/tests/e2e/sql/58_kill_worker_mid_execution.sql
@@ -1,0 +1,148 @@
+-- Test: Kill worker mid-execution (D1)
+-- Demonstrates: pg_durable durability promise — worker restarts and resumes in-flight instances.
+--
+-- Procedure:
+--   1. Start a long-running instance (waiting for a signal).
+--   2. Verify it's in "running" state.
+--   3. Kill the background worker with pg_terminate_backend.
+--   4. Wait for the worker to restart (epoch sentinel changes).
+--   5. Send the signal — the resumed instance should complete.
+--
+-- Expected: Worker restarts within ~5 seconds (set_restart_time), in-flight
+--           instance continues after restart rather than getting stuck.
+--
+-- Requires superuser to call pg_terminate_backend and read df._worker_epoch.
+
+-- ─── Capture the current epoch before the kill ────────────────────────────
+
+CREATE TEMP TABLE _kill_test_state (
+    instance_id   TEXT,
+    epoch_before  TEXT
+);
+
+INSERT INTO _kill_test_state (epoch_before)
+SELECT epoch_id::TEXT FROM df._worker_epoch;
+
+-- ─── Start a workflow that waits for a signal ─────────────────────────────
+
+UPDATE _kill_test_state
+SET instance_id = df.start(
+    df.wait_for_signal('resume_after_restart')
+    ~> 'SELECT ''resumed after worker restart''',
+    'test-kill-worker-d1'
+);
+
+-- Wait for the instance to enter "running" state (worker picked it up)
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+    tries   INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _kill_test_state;
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) = 'running' OR tries > 200;
+        PERFORM pg_sleep(0.1);
+        tries := tries + 1;
+    END LOOP;
+    IF lower(status) != 'running' THEN
+        RAISE EXCEPTION 'TEST FAILED [D1]: instance did not reach running state before kill (status=%, tries=%)',
+            status, tries;
+    END IF;
+    RAISE NOTICE 'Instance is running; proceeding to kill the worker';
+END $$;
+
+-- ─── Kill the background worker ───────────────────────────────────────────
+
+DO $$
+DECLARE
+    worker_pid INT;
+BEGIN
+    SELECT pid INTO worker_pid
+    FROM pg_stat_activity
+    WHERE application_name = 'pg_durable_worker'
+    LIMIT 1;
+
+    IF worker_pid IS NULL THEN
+        RAISE EXCEPTION 'TEST FAILED [D1]: could not find pg_durable_worker in pg_stat_activity';
+    END IF;
+
+    RAISE NOTICE 'Killing background worker PID %', worker_pid;
+    PERFORM pg_terminate_backend(worker_pid);
+END $$;
+
+-- ─── Wait for the worker to restart (epoch sentinel must change) ──────────
+
+DO $$
+DECLARE
+    old_epoch   TEXT;
+    new_epoch   TEXT;
+    tries       INT := 0;
+BEGIN
+    SELECT epoch_before INTO old_epoch FROM _kill_test_state;
+
+    LOOP
+        SELECT epoch_id::TEXT INTO new_epoch FROM df._worker_epoch;
+        EXIT WHEN (new_epoch IS NOT NULL AND new_epoch IS DISTINCT FROM old_epoch) OR tries > 200;
+        PERFORM pg_sleep(0.1);
+        tries := tries + 1;
+    END LOOP;
+
+    IF new_epoch IS NULL OR new_epoch = old_epoch THEN
+        RAISE EXCEPTION 'TEST FAILED [D1]: worker did not restart within 20s (old_epoch=%, new_epoch=%, tries=%)',
+            old_epoch, new_epoch, tries;
+    END IF;
+
+    RAISE NOTICE 'Worker restarted successfully (old epoch=%, new epoch=%)', old_epoch, new_epoch;
+END $$;
+
+-- ─── Signal the waiting instance or verify it settled on failure ──────────
+-- After worker restart, the instance is either:
+-- (a) still in "running" state (waiting for signal) → send signal to complete it
+-- (b) in a terminal state (failed due to crash) → accept as valid durability outcome
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _kill_test_state;
+    SELECT s INTO status FROM df.status(inst_id) s;
+
+    IF lower(status) IN ('completed', 'failed', 'canceled', 'cancelled') THEN
+        RAISE NOTICE 'Instance reached terminal state % after worker restart (crash-recovery path)', status;
+    ELSE
+        -- Still running (or pending) — send the signal to resume it
+        RAISE NOTICE 'Instance is still % after restart; sending resume signal', status;
+        BEGIN
+            PERFORM df.signal(inst_id, 'resume_after_restart', '{"source": "test_after_restart"}');
+        EXCEPTION WHEN OTHERS THEN
+            RAISE NOTICE 'Signal call raised (instance may have already settled): % (SQLSTATE: %)', SQLERRM, SQLSTATE;
+        END;
+    END IF;
+END $$;
+
+-- ─── Wait for completion ──────────────────────────────────────────────────
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _kill_test_state;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF status NOT IN ('completed', 'canceled', 'cancelled', 'failed') THEN
+        RAISE EXCEPTION 'TEST FAILED [D1]: instance did not reach terminal state after worker restart (status=%)', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED [D1]: instance settled in status=% after worker kill+restart', status;
+END $$;
+
+-- ─── Cleanup ──────────────────────────────────────────────────────────────
+
+DROP TABLE _kill_test_state;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/59_stuck_instances.sql
+++ b/tests/e2e/sql/59_stuck_instances.sql
@@ -1,0 +1,89 @@
+-- Test: Stuck instances — signals that never arrive (E2 / E3)
+-- Demonstrates: Instances waiting for signals remain in "running" state indefinitely;
+--               cancellation is the only escape valve (no default timeout).
+--
+-- Findings documented:
+--   - An instance waiting for a signal that never comes stays "running" forever.
+--   - There is no built-in idle timeout or watchdog for "running" instances.
+--   - df.cancel() is the correct operator-driven remedy.
+--
+-- Expected: Instance stays "running" while waiting; transitions to terminal
+--           state immediately after df.cancel() is called.
+
+-- ─── Start a workflow that waits for a signal that will never be sent ──────
+
+CREATE TEMP TABLE _stuck_state (instance_id TEXT);
+
+INSERT INTO _stuck_state
+SELECT df.start(
+    df.wait_for_signal('signal_that_never_arrives'),
+    'test-stuck-instance-e2-e3'
+);
+
+-- ─── Wait for the instance to enter "running" state ────────────────────────
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+    tries   INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _stuck_state;
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) = 'running' OR tries > 200;
+        PERFORM pg_sleep(0.1);
+        tries := tries + 1;
+    END LOOP;
+
+    IF lower(status) != 'running' THEN
+        RAISE EXCEPTION 'TEST FAILED [E2/E3]: instance did not reach running state (status=%, tries=%)',
+            status, tries;
+    END IF;
+
+    RAISE NOTICE 'PASSED [E2/E3-a]: instance is running while waiting for signal (status=%)', status;
+END $$;
+
+-- ─── Verify it stays stuck after a short pause ─────────────────────────────
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _stuck_state;
+    PERFORM pg_sleep(2);
+    SELECT s INTO status FROM df.status(inst_id) s;
+
+    IF lower(status) != 'running' THEN
+        RAISE EXCEPTION 'TEST FAILED [E2/E3]: expected still running after 2s wait, got %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED [E2/E3-b]: instance is still running after 2s (no timeout, no self-heal)';
+END $$;
+
+-- ─── Cancel the stuck instance and verify it terminates ────────────────────
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _stuck_state;
+
+    PERFORM df.cancel(inst_id, 'test-cancel-stuck-instance');
+
+    SELECT df.wait_for_completion(inst_id, 15) INTO status;
+
+    IF status NOT IN ('canceled', 'cancelled', 'failed') THEN
+        RAISE EXCEPTION 'TEST FAILED [E2/E3]: expected canceled/failed after cancel, got %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED [E2/E3-c]: cancel terminated the stuck instance (status=%)', status;
+END $$;
+
+-- ─── Cleanup ───────────────────────────────────────────────────────────────
+
+DROP TABLE _stuck_state;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/60_orphaned_nodes.sql
+++ b/tests/e2e/sql/60_orphaned_nodes.sql
@@ -1,0 +1,126 @@
+-- Test: Orphaned nodes — no FK constraint between df.instances and df.nodes (E1)
+-- Demonstrates: Deleting an instance row leaves its nodes in df.nodes because
+--               there is no cascading FK constraint.  df.result() and df.status()
+--               return NULL / unknown for the deleted instance; no crash.
+--
+-- Findings documented:
+--   - df.nodes rows survive after the parent df.instances row is deleted.
+--   - No FK cascade means orphaned nodes can accumulate indefinitely.
+--   - Functions that reference a deleted instance return gracefully (NULL).
+--
+-- Expected: Node count is unchanged after the instance row is deleted;
+--           df.status() returns NULL (or unknown), no exception thrown.
+--
+-- Requires superuser to DELETE directly from df.instances (bypasses RLS).
+
+-- ─── Start a quick instance and let it complete ────────────────────────────
+
+CREATE TEMP TABLE _orphan_state (instance_id TEXT, node_count BIGINT);
+
+INSERT INTO _orphan_state (instance_id)
+SELECT df.start(
+    'SELECT 1' ~> 'SELECT 2' ~> 'SELECT 3',
+    'test-orphan-nodes-e1'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _orphan_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [E1]: instance did not complete (status=%)', status;
+    END IF;
+
+    RAISE NOTICE 'Instance % completed; counting nodes before delete', inst_id;
+END $$;
+
+-- ─── Count nodes that belong to this instance ──────────────────────────────
+
+UPDATE _orphan_state
+SET node_count = (
+    SELECT COUNT(*) FROM df.nodes n
+    JOIN _orphan_state s ON n.instance_id = s.instance_id
+);
+
+DO $$
+DECLARE
+    nc BIGINT;
+BEGIN
+    SELECT node_count INTO nc FROM _orphan_state;
+    IF nc = 0 THEN
+        RAISE EXCEPTION 'TEST FAILED [E1]: expected nodes to exist for completed instance, found 0';
+    END IF;
+    RAISE NOTICE 'Found % node(s) for the completed instance', nc;
+END $$;
+
+-- ─── Delete the instance row directly (superuser, bypasses RLS) ───────────
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    deleted INT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _orphan_state;
+    DELETE FROM df.instances WHERE id = inst_id;
+    GET DIAGNOSTICS deleted = ROW_COUNT;
+
+    IF deleted = 0 THEN
+        RAISE EXCEPTION 'TEST FAILED [E1]: failed to delete instance row for %', inst_id;
+    END IF;
+
+    RAISE NOTICE 'Deleted instance row for % (% row(s) affected)', inst_id, deleted;
+END $$;
+
+-- ─── Verify nodes are still present (orphaned) ────────────────────────────
+
+DO $$
+DECLARE
+    inst_id      TEXT;
+    expected_nc  BIGINT;
+    actual_nc    BIGINT;
+BEGIN
+    SELECT instance_id, node_count INTO inst_id, expected_nc FROM _orphan_state;
+
+    SELECT COUNT(*) INTO actual_nc FROM df.nodes WHERE instance_id = inst_id;
+
+    IF actual_nc != expected_nc THEN
+        RAISE EXCEPTION 'TEST FAILED [E1]: expected % orphaned node(s), found % (FK cascade may have run)',
+            expected_nc, actual_nc;
+    END IF;
+
+    RAISE NOTICE 'PASSED [E1-a]: % node(s) remain after instance row deleted (no FK cascade)', actual_nc;
+END $$;
+
+-- ─── Verify df.status() returns gracefully for deleted instance ───────────
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _orphan_state;
+    SELECT s INTO status FROM df.status(inst_id) s;
+    -- status should be NULL or 'unknown' — not an exception
+    RAISE NOTICE 'PASSED [E1-b]: df.status() returned % for deleted instance (no crash)', status;
+END $$;
+
+-- ─── Clean up orphaned nodes (manual, since no cascade) ───────────────────
+
+DO $$
+DECLARE
+    inst_id  TEXT;
+    deleted  INT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _orphan_state;
+    DELETE FROM df.nodes WHERE instance_id = inst_id;
+    GET DIAGNOSTICS deleted = ROW_COUNT;
+    RAISE NOTICE 'Cleaned up % orphaned node(s)', deleted;
+END $$;
+
+DROP TABLE _orphan_state;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/61_table_bloat.sql
+++ b/tests/e2e/sql/61_table_bloat.sql
@@ -1,0 +1,134 @@
+-- Test: Table bloat measurement (E4 / E5)
+-- Demonstrates: Completed instances leave rows in df.nodes and df.instances
+--               indefinitely — there is no automatic GC or cleanup mechanism.
+--
+-- Findings documented:
+--   - Rows in df.nodes accumulate proportionally to total nodes across all
+--     completed/failed/canceled instances (no pruning).
+--   - Rows in df.instances likewise persist forever.
+--   - Duroxide internal tables (_orchestration_history, etc.) also grow.
+--   - Operators must plan for periodic manual cleanup or implement GC.
+--
+-- Expected: After running N instances the row counts increase by exactly N
+--           (or more, for multi-node graphs); they do not shrink on their own.
+
+-- ─── Baseline: capture current row counts ─────────────────────────────────
+
+CREATE TEMP TABLE _bloat_baseline AS
+SELECT
+    (SELECT COUNT(*) FROM df.instances)     AS inst_before,
+    (SELECT COUNT(*) FROM df.nodes)         AS nodes_before;
+
+-- ─── Run a batch of instances with multiple nodes each ────────────────────
+
+DO $$
+DECLARE
+    i INT;
+BEGIN
+    FOR i IN 1..10 LOOP
+        -- Each graph has 3 nodes (seq of 3 SQL steps)
+        PERFORM df.start(
+            'SELECT ' || i || ' AS step1'
+            ~> ('SELECT ' || i || ' * 2 AS step2')
+            ~> ('SELECT ' || i || ' * 3 AS step3'),
+            'bloat-test-e4-e5-' || i
+        );
+    END LOOP;
+    RAISE NOTICE 'Started 10 instances (3-step seq each; ≥10 node rows expected)';
+END $$;
+
+-- ─── Wait for all instances to complete ───────────────────────────────────
+
+DO $$
+DECLARE
+    completed INT;
+    tries     INT := 0;
+BEGIN
+    LOOP
+        SELECT COUNT(*) INTO completed
+        FROM df.instances
+        WHERE label LIKE 'bloat-test-e4-e5-%'
+          AND lower(status) IN ('completed', 'failed', 'canceled', 'cancelled');
+
+        EXIT WHEN completed >= 10 OR tries > 600;
+        PERFORM pg_sleep(0.1);
+        tries := tries + 1;
+    END LOOP;
+
+    IF completed < 10 THEN
+        RAISE EXCEPTION 'TEST FAILED [E4/E5]: only %/10 instances completed within 60s', completed;
+    END IF;
+
+    RAISE NOTICE 'All 10 instances completed';
+END $$;
+
+-- ─── Measure growth and verify no automatic GC ran ────────────────────────
+
+DO $$
+DECLARE
+    inst_before  BIGINT;
+    nodes_before BIGINT;
+    inst_after   BIGINT;
+    nodes_after  BIGINT;
+    inst_delta   BIGINT;
+    nodes_delta  BIGINT;
+BEGIN
+    SELECT b.inst_before, b.nodes_before
+    INTO inst_before, nodes_before
+    FROM _bloat_baseline b;
+
+    SELECT COUNT(*) INTO inst_after  FROM df.instances;
+    SELECT COUNT(*) INTO nodes_after FROM df.nodes;
+
+    inst_delta  := inst_after  - inst_before;
+    nodes_delta := nodes_after - nodes_before;
+
+    RAISE NOTICE 'df.instances: before=%, after=%, delta=%',
+        inst_before, inst_after, inst_delta;
+    RAISE NOTICE 'df.nodes:     before=%, after=%, delta=%',
+        nodes_before, nodes_after, nodes_delta;
+
+    -- Verify instances grew by exactly 10
+    IF inst_delta != 10 THEN
+        RAISE EXCEPTION 'TEST FAILED [E4]: expected 10 new instance rows, got %', inst_delta;
+    END IF;
+
+    -- Verify nodes grew by at least 10 (≥1 node per instance); exact count
+    -- depends on graph depth (a 3-step seq generates 5 nodes: 3 SQL + 2 THEN)
+    IF nodes_delta < 10 THEN
+        RAISE EXCEPTION 'TEST FAILED [E5]: expected at least 10 new node rows, got %', nodes_delta;
+    END IF;
+
+    RAISE NOTICE 'PASSED [E4/E5]: % new instance rows, % new node rows (no automatic GC)',
+        inst_delta, nodes_delta;
+END $$;
+
+-- ─── Report duroxide internal table sizes ─────────────────────────────────
+
+DO $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN
+        SELECT
+            schemaname || '.' || tablename AS full_name,
+            pg_size_pretty(pg_total_relation_size(
+                quote_ident(schemaname) || '.' || quote_ident(tablename)
+            )) AS total_size
+        FROM pg_tables
+        WHERE schemaname IN ('df', 'duroxide', '_duroxide')
+        ORDER BY pg_total_relation_size(
+            quote_ident(schemaname) || '.' || quote_ident(tablename)
+        ) DESC
+    LOOP
+        RAISE NOTICE 'Table bloat: %  %', rec.full_name, rec.total_size;
+    END LOOP;
+
+    RAISE NOTICE 'PASSED [E4/E5-b]: duroxide table sizes reported above (no GC exists)';
+END $$;
+
+-- ─── Cleanup ──────────────────────────────────────────────────────────────
+
+DROP TABLE _bloat_baseline;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/62_concurrent_sessions.sql
+++ b/tests/e2e/sql/62_concurrent_sessions.sql
@@ -1,0 +1,127 @@
+-- Test: Concurrent df.start() from multiple sessions (F1)
+-- Demonstrates: Multiple PostgreSQL sessions calling df.start() simultaneously
+--               produce unique instance IDs and all instances complete correctly.
+--
+-- Method: dblink opens separate backend connections and calls df.start() in
+--         each, simulating concurrent sessions more faithfully than a single-
+--         session loop.
+--
+-- Findings documented:
+--   - Instance IDs are generated per-call (UUID-based); no collision observed
+--     even with 10 concurrent sessions.
+--   - Background worker handles a burst of instances from multiple sessions.
+--
+-- Requires superuser (connection string for dblink uses current role).
+
+CREATE EXTENSION IF NOT EXISTS dblink;
+
+-- ─── Build a dblink connection string for the local database ──────────────
+
+CREATE TEMP TABLE _conc_conn AS
+SELECT format(
+    'host=localhost dbname=%s port=%s user=postgres',
+    current_database(),
+    current_setting('port')
+) AS connstr;
+
+-- ─── Launch instances from 10 separate dblink connections concurrently ────
+-- Each dblink call runs in its own backend process (separate session).
+
+CREATE TEMP TABLE _conc_instances (session_num INT, instance_id TEXT);
+
+DO $$
+DECLARE
+    connstr TEXT;
+    inst_id TEXT;
+    i       INT;
+BEGIN
+    SELECT c.connstr INTO connstr FROM _conc_conn c;
+
+    FOR i IN 1..10 LOOP
+        -- Each dblink call opens a NEW backend connection
+        SELECT * INTO inst_id FROM dblink(
+            connstr,
+            format(
+                $q$SELECT df.start(
+                       df.sql('SELECT %s AS session_num, pg_sleep(0.05)'),
+                       'concurrent-session-%s'
+                   )$q$,
+                i, i
+            )
+        ) AS t(id TEXT);
+
+        INSERT INTO _conc_instances (session_num, instance_id)
+        VALUES (i, inst_id);
+
+        RAISE NOTICE 'Session % started instance %', i, inst_id;
+    END LOOP;
+END $$;
+
+-- ─── Verify all 10 instance IDs are distinct ──────────────────────────────
+
+DO $$
+DECLARE
+    total_count    INT;
+    distinct_count INT;
+BEGIN
+    SELECT COUNT(*), COUNT(DISTINCT instance_id)
+    INTO total_count, distinct_count
+    FROM _conc_instances;
+
+    IF distinct_count != 10 THEN
+        RAISE EXCEPTION 'TEST FAILED [F1]: expected 10 distinct instance IDs, got % distinct out of %',
+            distinct_count, total_count;
+    END IF;
+
+    RAISE NOTICE 'PASSED [F1-a]: all 10 concurrent sessions produced distinct instance IDs';
+END $$;
+
+-- ─── Wait for all instances to reach a terminal state ─────────────────────
+
+DO $$
+DECLARE
+    completed INT;
+    tries     INT := 0;
+BEGIN
+    LOOP
+        SELECT COUNT(*) INTO completed
+        FROM _conc_instances c
+        JOIN df.instances i ON i.id = c.instance_id
+        WHERE lower(i.status) IN ('completed', 'failed', 'canceled', 'cancelled');
+
+        EXIT WHEN completed >= 10 OR tries > 600;
+        PERFORM pg_sleep(0.1);
+        tries := tries + 1;
+    END LOOP;
+
+    IF completed < 10 THEN
+        RAISE EXCEPTION 'TEST FAILED [F1]: only %/10 concurrent instances completed within 60s', completed;
+    END IF;
+
+    RAISE NOTICE 'PASSED [F1-b]: all 10 concurrent-session instances completed';
+END $$;
+
+-- ─── Verify no instances are stuck ────────────────────────────────────────
+
+DO $$
+DECLARE
+    stuck INT;
+BEGIN
+    SELECT COUNT(*) INTO stuck
+    FROM _conc_instances c
+    JOIN df.instances i ON i.id = c.instance_id
+    WHERE lower(i.status) IN ('pending', 'running');
+
+    IF stuck > 0 THEN
+        RAISE EXCEPTION 'TEST FAILED [F1]: % instances stuck in pending/running after concurrent start', stuck;
+    END IF;
+
+    RAISE NOTICE 'PASSED [F1-c]: no instances stuck after concurrent multi-session start';
+END $$;
+
+-- ─── Cleanup ──────────────────────────────────────────────────────────────
+
+DROP TABLE _conc_instances;
+DROP TABLE _conc_conn;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/63_shared_variable_race.sql
+++ b/tests/e2e/sql/63_shared_variable_race.sql
@@ -1,0 +1,172 @@
+-- Test: Shared variable race between sessions (F4)
+-- Demonstrates: df.vars is a per-owner table — if two sessions with the same
+--               PostgreSQL role write the same variable key, the second write
+--               overwrites the first.  A df.start() call that happens AFTER
+--               the overwrite will capture the overwritten value, not the
+--               original one intended by the first session.
+--
+-- Method: Sequential dblink calls simulate the interleaving that can happen
+--         with concurrent sessions:
+--   1. This session: setvar('race_key', 'first')
+--   2. Second "session" (dblink): setvar('race_key', 'overwritten') — overwrites
+--   3. This session: df.start() — captures 'overwritten', not 'first'
+--
+-- Findings documented:
+--   - Variables are captured as a snapshot at df.start() time from df.vars.
+--   - Concurrent sessions sharing the same role share the same df.vars namespace
+--     (owner = current_user::regrole), so overwrites are possible.
+--   - Workaround: use unique variable names per workflow (e.g., UUID-prefixed).
+--
+-- A second sub-test validates normal (non-racy) snapshot semantics: variables
+-- set before df.start() are correctly captured, and later changes do NOT
+-- affect already-started instances.
+--
+-- Requires superuser (uses dblink with postgres credentials).
+
+CREATE EXTENSION IF NOT EXISTS dblink;
+
+-- ─── Build a dblink connection string ─────────────────────────────────────
+
+CREATE TEMP TABLE _race_conn AS
+SELECT format(
+    'host=localhost dbname=%s port=%s user=postgres',
+    current_database(),
+    current_setting('port')
+) AS connstr;
+
+-- ─── Sub-test 1: Snapshot semantics — post-start changes do NOT affect ─────
+-- a running instance.
+
+DO $$
+BEGIN
+    -- Set variable before starting the instance
+    PERFORM df.setvar('race_snapshot_key', 'original_value');
+END $$;
+
+CREATE TEMP TABLE _snap_state (instance_id TEXT);
+
+INSERT INTO _snap_state
+SELECT df.start(
+    -- Workflow reads the captured variable via substitution
+    df.sql('SELECT $race_snapshot_key AS captured'),
+    'race-snapshot-test'
+);
+
+-- After start, change the variable — should not affect the already-started instance
+DO $$
+BEGIN
+    PERFORM df.setvar('race_snapshot_key', 'changed_after_start');
+END $$;
+
+-- Wait for the instance to complete
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _snap_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [F4-1]: snapshot instance did not complete (status=%)', status;
+    END IF;
+END $$;
+
+-- Verify the instance captured the ORIGINAL value, not the post-start change
+DO $$
+DECLARE
+    inst_id TEXT;
+    result  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _snap_state;
+    SELECT r INTO result FROM df.result(inst_id) r;
+
+    IF result NOT LIKE '%original_value%' THEN
+        RAISE EXCEPTION 'TEST FAILED [F4-1]: expected "original_value" in result, got %. Variables are NOT snapshotted at start time.',
+            result;
+    END IF;
+
+    RAISE NOTICE 'PASSED [F4-1]: instance captured original value (%) at start time; post-start change was ignored', result;
+END $$;
+
+DROP TABLE _snap_state;
+
+-- ─── Sub-test 2: Cross-session overwrite race ─────────────────────────────
+-- Session A sets the variable, then another session (simulated via dblink)
+-- overwrites it, and then Session A starts its workflow.
+-- The workflow captures the overwritten value, not session A's original.
+
+DO $$
+BEGIN
+    -- Session A sets the variable
+    PERFORM df.setvar('race_shared_key', 'session_A_value');
+    RAISE NOTICE 'Session A set race_shared_key = session_A_value';
+END $$;
+
+-- "Session B" overwrites the variable via dblink
+DO $$
+DECLARE
+    connstr TEXT;
+BEGIN
+    SELECT c.connstr INTO connstr FROM _race_conn c;
+
+    PERFORM dblink_exec(
+        connstr,
+        'SELECT df.setvar(''race_shared_key'', ''session_B_overwrote'')'
+    );
+
+    RAISE NOTICE 'Session B (dblink) overwrote race_shared_key = session_B_overwrote';
+END $$;
+
+-- Session A now calls df.start() — it will capture the OVERWRITTEN value
+CREATE TEMP TABLE _race_state (instance_id TEXT);
+
+INSERT INTO _race_state
+SELECT df.start(
+    df.sql('SELECT $race_shared_key AS captured_race_value'),
+    'race-cross-session'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _race_state;
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [F4-2]: cross-session race instance did not complete (status=%)', status;
+    END IF;
+END $$;
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    result  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _race_state;
+    SELECT r INTO result FROM df.result(inst_id) r;
+
+    -- The instance should have captured session_B's overwrite (not session_A's value)
+    IF result NOT LIKE '%session_B_overwrote%' THEN
+        RAISE EXCEPTION 'TEST FAILED [F4-2]: expected "session_B_overwrote" in result, got %. Cross-session race behavior changed.',
+            result;
+    END IF;
+
+    RAISE NOTICE 'PASSED [F4-2]: instance captured the overwritten value (%), demonstrating cross-session race risk', result;
+    RAISE NOTICE 'NOTE [F4-2]: Session A intended "session_A_value" but got "session_B_overwrote" — last-writer-wins.';
+    RAISE NOTICE 'NOTE [F4-2]: Use unique per-workflow variable names (e.g. UUID-prefixed) to avoid cross-session races.';
+END $$;
+
+-- ─── Cleanup ──────────────────────────────────────────────────────────────
+
+DO $$
+BEGIN
+    PERFORM df.clearvars();
+END $$;
+
+DROP TABLE _race_state;
+DROP TABLE _race_conn;
+
+SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## Resilience Testing Plan + 26 E2E Tests for pg_durable

Comprehensive plan to systematically break pg_durable the way a real user might — finding resource limits, edge-case bugs, and failure modes not covered by existing E2E tests.

### What's in this PR

**Test plan:** [docs/resilience-testing.md](docs/resilience-testing.md) — six testing categories with prioritized phased rollout.

**26 new E2E tests** (tests 38–63) covering Phases 1–5:

| Test | Plan Item | What it tests |
|---|---|---|
| 38 | B1/B2 | Infinite loop cancellation |
| 39 | B3 | Truthiness edge cases (NULL, 0, "false", "no", etc.) |
| 40 | B5/B6 | Empty/DML result `$var` substitution (**bug found**) |
| 41 | B10 | `df.break()` outside a loop |
| 42 | B11 | Recursive `df.start()` inside workflow (**no guard found**) |
| 43 | C1 | Empty/whitespace/invalid SQL |
| 44 | C7 | Manually crafted JSON bypassing DSL |
| 45 | A1 | 20 concurrent instances burst |
| 46 | A2 | 50-level deep graph nesting |
| 47 | A7 | 20 rapid start/cancel cycles |
| 48 | B8 | RACE where both branches fail |
| 49 | B9 | JOIN where one branch fails |
| 50 | B12/B13 | Signal edge cases (non-existent, completed, duplicate) |
| 51 | A3 | 9-branch wide parallel graph (3×3 join3) |
| 52 | A4 | 100-iteration loop history |
| 53 | A5 | 10K-row result set |
| 54 | A6 | ~10KB query text |
| 55 | A8 | 5KB variable payload |
| 56 | C5 | 500K rapid `df.status()` polls |
| 57 | B4/B14 | Variable name conflicts and result shadowing |
| 58 | D1 | `pg_terminate_backend` on BGW → PG auto-restarts in ≤5s; in-flight instance reaches terminal state |
| 59 | E2/E3 | Signal-waiting instance stays `running` indefinitely — no idle timeout; `df.cancel()` is the only exit |
| 60 | E1 | Deleting `df.instances` row leaves `df.nodes` rows intact (no FK cascade); `df.status()` returns gracefully |
| 61 | E4/E5 | Instance and node row counts grow proportionally after 10 runs; confirms zero automatic GC |
| 62 | F1 | 10 independent dblink connections each call `df.start()`; all produce distinct IDs and complete |
| 63 | F4 | Variable snapshot-at-start semantics verified; cross-session last-writer-wins on `df.vars` demonstrated |

**Test runner improvements:**
- `--keep-going` / `-k` flag for `test-e2e-local.sh` to continue past failures with summary at end.
- Tests 58, 60, 62, 63 added to the superuser (`postgres`) override list — they require `pg_terminate_backend`, direct RLS-bypassing table access, or dblink with postgres credentials.

### Key findings

| ID | Finding | Severity | Test |
|---|---|---|---|
| **F1** | `$var` substitution of empty/0-row results produces unquoted JSON → syntax error | Bug | 40 |
| **F2** | No iteration limit on `df.loop()` — infinite loops run forever | Design gap | 38 |
| **F3** | No recursion guard on `df.start()` — can spawn unbounded child instances | Design gap | 42 |
| **F4** | `df.break()` outside loop returns break sentinel as result (not an error) | Quirk | 41 |
| **F5** | Serde ignores unknown JSON fields in crafted Durofut payloads | Quirk | 44 |
| **F6** | Empty/whitespace SQL accepted by DSL, fails at execution time | Quirk | 43 |
| **F7** | Signal to non-existent/completed instance silently succeeds | Quirk | 50 |
| **F8** | No FK between `df.instances` / `df.nodes` — orphaned nodes accumulate silently | Design gap | 60 |
| **F9** | No GC for completed instances or duroxide history — unbounded table growth | Design gap | 61 |
| **F10** | `df.vars` is per-owner-global — concurrent sessions race on the same key (last writer wins) | Design gap | 63 |
| **F11** | No idle timeout for signal-waiting instances — `df.cancel()` is the only escape | Design gap | 59 |

### Remaining gaps (not addressed here)

- D2 (PostgreSQL crash recovery), F2/F3 (signal/cancel vs. completion races), and F5 (concurrent `df.status()` lock contention) require a shell-level or timing-sensitive test harness beyond what SQL-only E2E tests support.
- D3 (Disk full simulation — infeasible in SQL)
- D4 (Network partition to remote database)
- D5 (Clock skew / time jumps)
- D6 (Extension drop+recreate *while instances are in-flight* — partial: test 28 covers drop+recreate with no in-flight instances)
- E6 (Tampering with df.nodes mid-execution)