### PR TITLE
Scope df.vars per-user via owner column + RLS

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,7 +89,9 @@ The new `.so` must work against **all** previous versions' schemas (same major v
 
 **Changing the extension schema:** If the upgrade script doesn't exist yet, follow the "Preparing for the next version" section in [docs/upgrade-testing.md](../docs/upgrade-testing.md). Then: add DDL to the upgrade script (`sql/pg_durable--<prev>--<current>.sql`), ensure `.so` backward compat with all previous schemas, and add a section to "Version-Specific Changes" in [docs/upgrade-testing.md](../docs/upgrade-testing.md)
 
-**Writing a spec or design doc:** Include an "Upgrade & Migration" section covering: backward compatibility impact (B1 — will the new `.so` work against all previous schemas?), upgrade script DDL needed, and any runtime schema detection required. See [docs/upgrade-testing.md](../docs/upgrade-testing.md) for the full upgrade testing strategy.
+For Scenario A, treat the upgrade path as the contract for already-shipped versions: before release, fresh install for the new version should match what an existing customer gets by installing the previous version and applying the upgrade chain.
+
+**Writing a spec or design doc:** Include an "Upgrade & Migration" section covering: backward compatibility impact (B1 — will the new `.so` work against all previous schemas?), upgrade script DDL needed, and any runtime schema detection required. See [docs/upgrade-testing.md](..docs/upgrade-testing.md) for the full upgrade testing strategy.
 
 ## Duroxide Migration Sync Workflow
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,7 +91,7 @@ The new `.so` must work against **all** previous versions' schemas (same major v
 
 For Scenario A, treat the upgrade path as the contract for already-shipped versions: before release, fresh install for the new version should match what an existing customer gets by installing the previous version and applying the upgrade chain.
 
-**Writing a spec or design doc:** Include an "Upgrade & Migration" section covering: backward compatibility impact (B1 — will the new `.so` work against all previous schemas?), upgrade script DDL needed, and any runtime schema detection required. See [docs/upgrade-testing.md](..docs/upgrade-testing.md) for the full upgrade testing strategy.
+**Writing a spec or design doc:** Include an "Upgrade & Migration" section covering: backward compatibility impact (B1 — will the new `.so` work against all previous schemas?), upgrade script DDL needed, and any runtime schema detection required. See [docs/upgrade-testing.md](../docs/upgrade-testing.md) for the full upgrade testing strategy.
 
 ## Duroxide Migration Sync Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+Pre-1.0 note: while `pg_durable` is in major version `0`, minor releases may include breaking changes.
+
+## v0.2.0 (in development)
+
+- Breaking change: `df.vars` now uses per-user scoping via RLS. After upgrading from `v0.1.1`, variables that were already defined become visible only to the role that ran `ALTER EXTENSION pg_durable UPDATE`.
+
+## v0.1.1 (Released)
+
+- Tag: [v0.1.1](https://github.com/microsoft/pg_durable/releases/tag/v0.1.1)
+- Commit: `b83dc78828b4f5a4d6fb03a6b97cc46fff834df9`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Pre-1.0 note: while `pg_durable` is in major version `0`, minor releases may inc
 
 ## v0.2.0 (in development)
 
-- Breaking change: `df.vars` now uses per-user scoping via RLS. After upgrading from `v0.1.1`, variables that were already defined become visible only to the role that ran `ALTER EXTENSION pg_durable UPDATE`.
+- Breaking change: `df.vars` now uses per-user scoping via RLS. After upgrading from `v0.1.1`, all pre-existing variables are re-homed to the role that ran `ALTER EXTENSION pg_durable UPDATE`; other users will lose access to any variables they had set before the upgrade.
 
 ## v0.1.1 (Released)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codepage"
@@ -1464,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "owo-colors"
@@ -2766,9 +2766,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO app_role;
 - The background worker role (`pg_durable.worker_role` GUC, default: `azuresu`) **must be a superuser** — it bypasses RLS to manage all users' instances
 - Users get `SELECT` + `INSERT` on `df.instances` / `df.nodes`, column-level `UPDATE (status, updated_at)` on instances for `df.cancel()`
 - Identity columns (`submitted_by`, `login_role`) cannot be modified by users
-- **`df.vars` is currently a shared global table with no per-user isolation** — any role can read or overwrite any other user's variables. Do not store secrets in `df.vars`. Per-user scoping is planned. In multi-tenant environments, consider revoking `df.vars` grants from `PUBLIC`
+- **`df.vars` uses per-user scoping** — each user has their own variable namespace via an `owner` column and RLS. Superusers bypass RLS but DSL functions still scope to the calling user via explicit filters. Avoid storing secrets in plain text
 
 ## Continuous Integration
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1469,24 +1469,6 @@ If the user who submitted a function is dropped **before execution**:
 
 ### Current Limitations
 
-#### Shared Variables
-
-The `df.vars` table is currently **shared across all users**:
-
-```sql
--- User alice sets a variable
-SET SESSION AUTHORIZATION alice;
-SELECT df.setvar('api_key', 'alice-secret');
-
--- User bob can read it! ⚠️
-SET SESSION AUTHORIZATION bob;
-SELECT df.getvar('api_key');  -- Returns 'alice-secret'
-```
-
-**Workaround:** Use namespaced variable names: `df.setvar('alice.api_key', ...)`
-
-**Future:** User-scoped variables with row-level security (RLS) are planned.
-
 #### HTTP Requests
 
 HTTP requests (`df.http()`) currently execute with the **background worker's privileges**, not the submitting user's privileges:
@@ -1508,7 +1490,7 @@ Row-level security (RLS) restricts each user to their own instances and nodes:
 ### Security Best Practices
 
 1. **Worker role must be superuser** — The background worker role (`pg_durable.worker_role`) must be a superuser to bypass RLS and manage all instances
-2. **Review df.vars usage** — Variables are currently shared across all users; avoid storing secrets
+2. **Review df.vars usage** — Variables are scoped per-user via RLS, but avoid storing secrets in plain text
 3. **Use labels carefully** — Instance labels are visible only to the submitting user (RLS-filtered) and superusers
 4. **Monitor instances** — Superusers can use `df.list_instances()` to see all users' instances; regular users see only their own
 
@@ -1530,7 +1512,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO PUBLIC;
 
 Users get `SELECT` and `INSERT` on `df.instances` and `df.nodes` (required for `df.start()`, `df.status()`, `df.result()`). Column-level `UPDATE` on `(status, updated_at)` allows `df.cancel()` to set status. No full `UPDATE` or `DELETE` — identity columns (`submitted_by`, `login_role`) and structural columns are protected.
 
-> **Warning:** `df.vars` is currently a shared global table with no RLS — any database role can read or overwrite any other user's variables. Do not store secrets or security-sensitive configuration in `df.vars`. Per-user variable scoping (via RLS) is planned for a future release. In multi-tenant environments, consider revoking `df.vars` grants from `PUBLIC` and granting only to trusted roles.
+> **Note:** `df.vars` uses per-user scoping via an `owner` column and RLS — each user can only read and write their own variables. Superusers bypass RLS but the DSL functions (`df.setvar()`, `df.getvar()`, etc.) still scope to the calling user via explicit filters. Avoid storing secrets in plain text.
 
 To restrict access to specific roles instead of all users:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -318,7 +318,7 @@ SELECT df.result('a1b2c3d4');
 
 ### df.setvar(name, value)
 
-Sets a workflow variable (before `df.start()`).
+Sets a workflow variable for the current user (before `df.start()`). Each user has their own variable namespace — variables set by one user are invisible to others.
 
 | Parameter | Type | Auto-wrap | Description |
 |-----------|------|-----------|-------------|
@@ -333,7 +333,7 @@ SELECT df.setvar('api_url', 'https://api.example.com');
 
 ### df.getvar(name)
 
-Gets a workflow variable.
+Gets a workflow variable owned by the current user.
 
 | Parameter | Type | Auto-wrap | Description |
 |-----------|------|-----------|-------------|
@@ -347,7 +347,7 @@ SELECT df.getvar('api_url');
 
 ### df.unsetvar(name)
 
-Removes a workflow variable.
+Removes a workflow variable owned by the current user.
 
 | Parameter | Type | Auto-wrap | Description |
 |-----------|------|-----------|-------------|
@@ -361,7 +361,7 @@ SELECT df.unsetvar('api_url');
 
 ### df.clearvars()
 
-Clears all workflow variables.
+Clears all workflow variables owned by the current user.
 
 ```sql
 SELECT df.clearvars();

--- a/docs/rls.md
+++ b/docs/rls.md
@@ -38,7 +38,7 @@ RLS solves this: keep the DML grants (users need them for the SPI calls inside `
 |-------|-------------|--------|
 | `df.instances` | **Yes** | Contains per-user workflow state; has `submitted_by` column |
 | `df.nodes` | **Yes** | Contains per-user node definitions; has `submitted_by` column |
-| `df.vars` | **Decision needed** | Currently global; spec proposes per-user scoping |
+| `df.vars` | **Yes** | Per-user variable isolation; has `owner` column |
 
 ### Out of scope
 
@@ -64,10 +64,10 @@ These `df.*` functions access `df.instances` or `df.nodes` via SPI (which runs a
 | `df.list_instances()` | `df.instances` (SELECT for labels) | Read | User sees only own labels |
 | `df.instance_info()` | `df.instances` (SELECT for label) | Read | User sees only own |
 | `df.instance_nodes()` | `df.nodes` (SELECT) | Read | User sees only own |
-| `df.setvar()` | `df.vars` (INSERT/UPDATE) | Write | Depends on vars design |
-| `df.getvar()` | `df.vars` (SELECT) | Read | Depends on vars design |
-| `df.unsetvar()` | `df.vars` (DELETE) | Write | Depends on vars design |
-| `df.clearvars()` | `df.vars` (DELETE) | Write | Depends on vars design |
+| `df.setvar()` | `df.vars` (INSERT/UPDATE) | Write | User can only set own vars (RLS + explicit owner filter) |
+| `df.getvar()` | `df.vars` (SELECT) | Read | User can only read own vars (RLS + explicit owner filter) |
+| `df.unsetvar()` | `df.vars` (DELETE) | Write | User can only delete own vars (RLS + explicit owner filter) |
+| `df.clearvars()` | `df.vars` (DELETE) | Write | User can only clear own vars (RLS + explicit owner filter) |
 
 ### Background worker access (NOT affected by RLS)
 
@@ -159,14 +159,23 @@ There are no "unlinked" or "orphan" nodes with `submitted_by = NULL`. Every row 
 
 ### Decision 5: `df.vars` scoping
 
-Currently `df.vars` is a global key-value table with no user scoping. The security spec (Section 4.3) identifies this as a cross-user integrity/confidentiality issue and proposes two options:
+`df.vars` was originally a global key-value table with no user scoping. The security spec (Section 4.3) identified this as a cross-user integrity/confidentiality issue.
 
-**(A) Per-user scoping with `owner` column + RLS**:
+**Decision**: Option A — per-user scoping with `owner` column + RLS. ✅ Implemented in v0.2.0.
+
+**Schema** (fresh install):
 ```sql
-ALTER TABLE df.vars ADD COLUMN owner REGROLE NOT NULL DEFAULT current_user::regrole;
--- Change PK from (name) to (owner, name)
-ALTER TABLE df.vars DROP CONSTRAINT vars_pkey;
-ALTER TABLE df.vars ADD PRIMARY KEY (owner, name);
+CREATE TABLE IF NOT EXISTS df.vars (
+    owner REGROLE NOT NULL DEFAULT current_user::regrole,
+    name TEXT NOT NULL,
+    value TEXT,
+    PRIMARY KEY (owner, name)
+);
+```
+
+**RLS policy**:
+```sql
+ALTER TABLE df.vars ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY vars_user_isolation ON df.vars
     FOR ALL
@@ -174,18 +183,16 @@ CREATE POLICY vars_user_isolation ON df.vars
     WITH CHECK (owner = current_user::regrole);
 ```
 
-**(B) Admin-only** (revoke DML from non-admin users):
+**Upgrade script** (`pg_durable--0.1.1--0.2.0.sql`):
 ```sql
-REVOKE ALL ON df.vars FROM PUBLIC;
--- Only admins can set variables
+ALTER TABLE df.vars ADD COLUMN owner REGROLE NOT NULL DEFAULT current_user::regrole;
+ALTER TABLE df.vars DROP CONSTRAINT vars_pkey;
+ALTER TABLE df.vars ADD PRIMARY KEY (owner, name);
+ALTER TABLE df.vars ENABLE ROW LEVEL SECURITY;
+CREATE POLICY vars_user_isolation ON df.vars ...;
 ```
 
-**Analysis**:
-- Option A is the multi-tenant-safe approach. But it requires a schema migration and changes to how `df.start()` captures vars (must filter by `owner`).
-- Option B is simpler but breaks any use case where non-admin users parameterize workflows.
-- A third option: **defer vars scoping** to a separate PR. RLS on `df.instances` and `df.nodes` is the higher-priority isolation fix. Vars scoping is a separate concern that can be addressed incrementally.
-
-**Decision**: Defer vars scoping to a follow-up PR. ✅ Decided. This PR focuses on `df.instances` and `df.nodes` only.
+**Superuser behavior**: Superusers bypass RLS, so they can see all users' variables via direct table queries. However, `df.start()`, `df.getvar()`, `df.setvar()`, `df.unsetvar()`, and `df.clearvars()` all use explicit `WHERE owner = current_user::regrole` filters in their SQL. This ensures that even superusers only interact with their own variables through the DSL functions — RLS is defense-in-depth for non-superusers, while the explicit filter provides correct scoping for all users including superusers.
 
 ### Decision 6: Worker role RLS bypass
 
@@ -298,7 +305,20 @@ CREATE POLICY nodes_user_isolation ON df.nodes
 
 No `submitted_by IS NULL` clause is needed — all nodes are inserted by `df.start()` with `submitted_by` already set (see Decision 4).
 
-### 4.3 Worker bypass
+### 4.3 `df.vars`
+
+```sql
+ALTER TABLE df.vars ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY vars_user_isolation ON df.vars
+    FOR ALL
+    USING (owner = current_user::regrole)
+    WITH CHECK (owner = current_user::regrole);
+```
+
+The `owner` column defaults to `current_user::regrole` on INSERT, so `df.setvar()` automatically assigns ownership. All DSL functions (`df.getvar()`, `df.unsetvar()`, `df.clearvars()`, and `df.start()` vars capture) also include explicit `WHERE owner = current_user::regrole` filters for correct behavior when RLS is bypassed (superusers).
+
+### 4.4 Worker bypass
 
 The worker role must be a superuser (see Decision 6). Superusers bypass RLS automatically — no additional configuration needed.
 
@@ -308,7 +328,7 @@ The worker role must be a superuser (see Decision 6). Superusers bypass RLS auto
 -- Superusers bypass all permission checks including RLS.
 ```
 
-### 4.4 `FORCE ROW LEVEL SECURITY`
+### 4.5 `FORCE ROW LEVEL SECURITY`
 
 `ENABLE ROW LEVEL SECURITY` only applies RLS to non-owner roles. If the table owner queries the table, RLS is bypassed. `FORCE ROW LEVEL SECURITY` makes RLS apply even to the table owner.
 
@@ -354,11 +374,15 @@ ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
    - Update `27_user_isolation.sql` to test RLS-enforced isolation
    - Add new RLS-specific tests
 
-### Phase 2: Variables scoping (future PR)
+### Phase 2: Variables scoping ✅ Implemented (v0.2.0)
 
-- Add `owner` column to `df.vars`
-- Migrate to per-user variable scoping
-- Add RLS policies for `df.vars`
+- Added `owner REGROLE` column to `df.vars` with `DEFAULT current_user::regrole`
+- Changed PK from `(name)` to `(owner, name)` for per-user namespace
+- Added RLS policy `vars_user_isolation` on `df.vars`
+- Updated all DSL functions (`setvar`, `getvar`, `unsetvar`, `clearvars`) with explicit `owner` filters
+- Updated `df.start()` vars capture to filter by `owner = current_user::regrole`
+- Created upgrade script `sql/pg_durable--0.1.1--0.2.0.sql`
+- Added E2E test `38_rls_vars.sql`
 
 ---
 
@@ -368,7 +392,7 @@ All decisions have been resolved. No open questions remain.
 
 ### Resolved decisions
 
-- **Decision 5 (vars scoping)**: Deferred to follow-up PR. This PR focuses on `df.instances` and `df.nodes`. ✅
+- **Decision 5 (vars scoping)**: Option A implemented — per-user scoping with `owner` column + RLS. ✅ Implemented in v0.2.0.
 - **Decision 6 (worker bypass)**: Worker role must be a superuser → bypasses RLS automatically. ✅
 - **Decision 7 (cancel/signal ownership)**: Explicit ownership check before duroxide client call. ✅
 - **Decision 8 (auto-grants)**: GRANT to PUBLIC in `CREATE EXTENSION` with column-level UPDATE on `(status, updated_at)` for instances, no DELETE on instances/nodes. ✅
@@ -419,13 +443,18 @@ RESET SESSION AUTHORIZATION;
 - Verify the background worker can load/update instances from any user
 - Verify workflows complete successfully with RLS enabled
 
-**Test: `df.vars` behavior** (if per-user scoping is implemented)
+**Test: `df.vars` per-user isolation** (implemented in `38_rls_vars.sql`)
 ```sql
 SET SESSION AUTHORIZATION alice;
 SELECT df.setvar('key', 'alice-value');
 RESET SESSION AUTHORIZATION;
 
 SET SESSION AUTHORIZATION bob;
-SELECT df.getvar('key');  -- Should return NULL (per-user) or 'alice-value' (global)
+SELECT df.getvar('key');  -- Returns NULL (per-user scoping)
+SELECT df.setvar('key', 'bob-value');  -- Bob gets his own 'key'
 RESET SESSION AUTHORIZATION;
+
+-- Each user's df.start() captures only their own vars
+-- df.clearvars() only clears the calling user's variables
+-- Superuser sees all vars via direct table access but df.start() captures only own
 ```

--- a/docs/rls.md
+++ b/docs/rls.md
@@ -334,14 +334,14 @@ The worker role must be a superuser (see Decision 6). Superusers bypass RLS auto
 
 Question: Should we use `FORCE`? In pg_durable, the table "owner" is whoever ran `CREATE EXTENSION` (typically the superuser). `FORCE` would make RLS apply even to the superuser, which may be undesirable for debugging. However, without `FORCE`, the superuser sees all rows — which is expected admin behavior.
 
-**Recommendation**: Do NOT use `FORCE ROW LEVEL SECURITY`. Superusers should see all rows (standard PostgreSQL convention). The spec already notes that superusers are trusted (they install the extension).
+**Recommendation**: Do NOT use `FORCE ROW LEVEL SECURITY` on any `df.*` table (`df.instances`, `df.nodes`, `df.vars`). Superusers should see all rows (standard PostgreSQL convention). The spec already notes that superusers are trusted (they install the extension). Additionally, the background worker runs as a superuser (see Decision 6) and must bypass RLS to manage all users' data — `FORCE` would break worker access.
 
 Revised:
 ```sql
 ALTER TABLE df.instances ENABLE ROW LEVEL SECURITY;
--- No FORCE — superuser/table-owner bypasses RLS (standard behavior)
-
 ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE df.vars ENABLE ROW LEVEL SECURITY;
+-- No FORCE on any table — superuser/table-owner bypasses RLS (standard behavior)
 ```
 
 ---

--- a/docs/rls.md
+++ b/docs/rls.md
@@ -64,7 +64,7 @@ These `df.*` functions access `df.instances` or `df.nodes` via SPI (which runs a
 | `df.list_instances()` | `df.instances` (SELECT for labels) | Read | User sees only own labels |
 | `df.instance_info()` | `df.instances` (SELECT for label) | Read | User sees only own |
 | `df.instance_nodes()` | `df.nodes` (SELECT) | Read | User sees only own |
-| `df.setvar()` | `df.vars` (INSERT/UPDATE) | Write | User can only set own vars (RLS + explicit owner filter) |
+| `df.setvar()` | `df.vars` (INSERT/UPDATE) | Write | User can only set own vars (RLS + owner DEFAULT + ON CONFLICT) |
 | `df.getvar()` | `df.vars` (SELECT) | Read | User can only read own vars (RLS + explicit owner filter) |
 | `df.unsetvar()` | `df.vars` (DELETE) | Write | User can only delete own vars (RLS + explicit owner filter) |
 | `df.clearvars()` | `df.vars` (DELETE) | Write | User can only clear own vars (RLS + explicit owner filter) |
@@ -166,9 +166,9 @@ There are no "unlinked" or "orphan" nodes with `submitted_by = NULL`. Every row 
 **Schema** (fresh install):
 ```sql
 CREATE TABLE IF NOT EXISTS df.vars (
-    owner REGROLE NOT NULL DEFAULT current_user::regrole,
     name TEXT NOT NULL,
     value TEXT,
+    owner REGROLE NOT NULL DEFAULT current_user::regrole,
     PRIMARY KEY (owner, name)
 );
 ```
@@ -192,7 +192,7 @@ ALTER TABLE df.vars ENABLE ROW LEVEL SECURITY;
 CREATE POLICY vars_user_isolation ON df.vars ...;
 ```
 
-**Superuser behavior**: Superusers bypass RLS, so they can see all users' variables via direct table queries. However, `df.start()`, `df.getvar()`, `df.setvar()`, `df.unsetvar()`, and `df.clearvars()` all use explicit `WHERE owner = current_user::regrole` filters in their SQL. This ensures that even superusers only interact with their own variables through the DSL functions — RLS is defense-in-depth for non-superusers, while the explicit filter provides correct scoping for all users including superusers.
+**Superuser behavior**: Superusers bypass RLS, so they can see all users' variables via direct table queries. However, read/delete functions (`df.getvar()`, `df.unsetvar()`, `df.clearvars()`) and `df.start()` vars capture use explicit `WHERE owner = current_user::regrole` filters, while `df.setvar()` scopes ownership via the column DEFAULT and `ON CONFLICT (owner, name)`. This ensures that even superusers only interact with their own variables through the DSL functions — RLS is defense-in-depth for non-superusers, while the explicit scoping provides correct behavior for all users including superusers.
 
 ### Decision 6: Worker role RLS bypass
 
@@ -316,7 +316,7 @@ CREATE POLICY vars_user_isolation ON df.vars
     WITH CHECK (owner = current_user::regrole);
 ```
 
-The `owner` column defaults to `current_user::regrole` on INSERT, so `df.setvar()` automatically assigns ownership. All DSL functions (`df.getvar()`, `df.unsetvar()`, `df.clearvars()`, and `df.start()` vars capture) also include explicit `WHERE owner = current_user::regrole` filters for correct behavior when RLS is bypassed (superusers).
+The `owner` column defaults to `current_user::regrole` on INSERT, so `df.setvar()` automatically assigns ownership via the column DEFAULT and `ON CONFLICT (owner, name)`. Read/delete functions (`df.getvar()`, `df.unsetvar()`, `df.clearvars()`) and `df.start()` vars capture include explicit `WHERE owner = current_user::regrole` filters for correct behavior when RLS is bypassed (superusers).
 
 ### 4.4 Worker bypass
 

--- a/docs/spec-security-model.md
+++ b/docs/spec-security-model.md
@@ -278,7 +278,7 @@ See [spec-ssrf-protection.md](spec-ssrf-protection.md) for the full specificatio
 
 **Threat**: `df.vars` is a key-value table. Without per-user scoping, users can override or read each other's variables, potentially redirecting workflows.
 
-**Mitigation (implemented)**: `df.vars` has an `owner REGROLE` column with `DEFAULT current_user::regrole` and a composite primary key `(owner, name)`. RLS policy `vars_user_isolation` restricts each user to their own variables. All DSL functions (`df.setvar()`, `df.getvar()`, `df.unsetvar()`, `df.clearvars()`) and `df.start()` vars capture include explicit `WHERE owner = current_user::regrole` filters, ensuring correct scoping even for superusers who bypass RLS. See [rls.md, Decision 5](rls.md).
+**Mitigation (implemented)**: `df.vars` has an `owner REGROLE` column with `DEFAULT current_user::regrole` and a composite primary key `(owner, name)`. RLS policy `vars_user_isolation` restricts each user to their own variables. `df.setvar()` scopes ownership via the column DEFAULT and `ON CONFLICT (owner, name)`; read/delete functions (`df.getvar()`, `df.unsetvar()`, `df.clearvars()`) and `df.start()` vars capture use explicit `WHERE owner = current_user::regrole` filters. This ensures correct scoping even for superusers who bypass RLS. See [rls.md, Decision 5](rls.md).
 
 **Residual Risk**: Low — per-user scoping is enforced at both the RLS and application layers.
 

--- a/docs/spec-security-model.md
+++ b/docs/spec-security-model.md
@@ -98,7 +98,7 @@ The security guarantee is: **only superusers can install the extension**, theref
 | **T4**: Information Disclosure via df.* Tables | **HIGH** | Implemented | RLS on `df.instances` and `df.nodes` — see [rls.md](rls.md) |
 | **T9**: Unauthorized HTTP Access | **HIGH** | Not implemented | `REVOKE EXECUTE` + admin allowlist (future spec) |
 | **T11**: Secret Exfiltration | **HIGH** | Not implemented | Additive feature; no table/API exists yet |
-| **T10**: Cross-User Variable Injection | **MEDIUM-HIGH** | Partially implemented | Instance/node isolation via RLS; `df.vars` scoping deferred — see [rls.md](rls.md) |
+| **T10**: Cross-User Variable Injection | **MEDIUM-HIGH** | Implemented | Per-user `df.vars` scoping via `owner` column + RLS — see [rls.md](rls.md) |
 | **T5**: Denial of Service | **MEDIUM** | Not implemented | Rate limiting; deferred |
 | **T6**: Worker Code Vulnerability | **MEDIUM** | Mitigated by design | Relies on code review |
 | **T0**: SECURITY DEFINER Misuse | **MEDIUM** | Documentation-only | Expected PG behavior |
@@ -274,13 +274,13 @@ See [spec-ssrf-protection.md](spec-ssrf-protection.md) for the full specificatio
 
 #### T10: Cross-User Variable Injection via df.vars
 
-**Severity**: MEDIUM-HIGH  |  **Status**: Partially implemented
+**Severity**: MEDIUM-HIGH  |  **Status**: Implemented
 
-**Threat**: `df.vars` is a global key-value table. Without per-user scoping, users can override or read each other's variables, potentially redirecting workflows.
+**Threat**: `df.vars` is a key-value table. Without per-user scoping, users can override or read each other's variables, potentially redirecting workflows.
 
-**Mitigation (partially implemented)**: Instance and node isolation is enforced via RLS on `df.instances` and `df.nodes` (see T4). Per-user `df.vars` scoping (adding an `owner` column + RLS) is deferred to a follow-up PR — see [rls.md, Decision 5](rls.md).
+**Mitigation (implemented)**: `df.vars` has an `owner REGROLE` column with `DEFAULT current_user::regrole` and a composite primary key `(owner, name)`. RLS policy `vars_user_isolation` restricts each user to their own variables. All DSL functions (`df.setvar()`, `df.getvar()`, `df.unsetvar()`, `df.clearvars()`) and `df.start()` vars capture include explicit `WHERE owner = current_user::regrole` filters, ensuring correct scoping even for superusers who bypass RLS. See [rls.md, Decision 5](rls.md).
 
-**Residual Risk**: Medium — `df.vars` remains globally shared until Phase 2.
+**Residual Risk**: Low — per-user scoping is enforced at both the RLS and application layers.
 
 ---
 
@@ -334,7 +334,7 @@ pg_durable supports workflow variables via `df.setvar()/df.getvar()/df.unsetvar(
 
 **Security requirement**: Variables MUST NOT be global, cross-user state.
 
-**Current status**: Per-user `df.vars` scoping is deferred to a follow-up PR. Instance and node isolation is enforced via RLS (see T4). See [rls.md, Decision 5](rls.md) for the deferred design.
+**Current status**: Implemented. `df.vars` has per-user scoping via an `owner REGROLE` column with RLS. Each user has their own variable namespace. Variables are captured at `df.start()` time from the calling user's namespace only. See [rls.md, Decision 5](rls.md).
 
 ---
 

--- a/docs/upgrade-testing.md
+++ b/docs/upgrade-testing.md
@@ -29,6 +29,8 @@ All three scenarios scope to versions within the same major version:
 
 **Goal:** Verify that `ALTER EXTENSION UPDATE` produces an identical schema to a fresh `CREATE EXTENSION`.
 
+**Contract:** For a not-yet-released version, the fresh-install schema is expected to match what an existing customer would get by starting from the immediately previous shipped version and applying the shipped upgrade chain to the new version. In other words, Scenario A treats the upgrade result as the reference shape for already-shipped versions. If fresh install and upgrade differ before release, prefer aligning the new version's fresh-install DDL with the upgrade path unless there is a deliberate reason to change the contract.
+
 **Method:**
 1. Install current `.so` and all upgrade SQL files
 2. In a clean test database, run `CREATE EXTENSION pg_durable VERSION '<prev>'` → `ALTER EXTENSION pg_durable UPDATE TO '<current>'`, then capture a schema snapshot
@@ -187,4 +189,9 @@ what the upgrade script handles, and any backward compatibility considerations.
 
 ### v0.1.1 → v0.2.0
 
-_(No changes yet — upgrade script is empty. Subsequent PRs will add changes here.)_
+#### #53 per-user df.vars scoping via owner column + RLS
+- **DDL change:** `df.vars` adds `owner REGROLE NOT NULL DEFAULT current_user::regrole`, changes the primary key from `(name)` to `(owner, name)`, enables RLS, and adds the `vars_user_isolation` policy.
+- **Scenario A considerations:** The schema comparison must verify the new column, its default, the new primary key definition, RLS enabled state, the `vars_user_isolation` policy, and table grants. Because the upgrade script adds `owner` with `ALTER TABLE ... ADD COLUMN`, upgraded schemas place `owner` after the existing columns. Fresh-install DDL for v0.2.0 has been aligned to that order so Scenario A continues to compare `ordinal_position`.
+- **Scenario B1 considerations:** This change touches the highest-risk upgrade surface because the Rust code now queries `df.vars.owner` and uses `ON CONFLICT (owner, name)`. The new `.so` still has to work against the v0.1.1 schema, which has neither the `owner` column nor the `(owner, name)` primary key. The implementation therefore uses the installed extension version as the compatibility boundary: v0.1.x stays in legacy global-vars mode, while v0.2.0+ uses owner-scoped queries.
+- **Scenario B2 considerations:** The upgrade script assigns all pre-existing `df.vars` rows to the role running `ALTER EXTENSION` via the `DEFAULT current_user::regrole` backfill. Upgrade tests verify that existing vars remain readable after upgrade for the role that performed the upgrade, that the migrated row is re-homed to that upgrade-running role, and that new post-upgrade writes/executions use owner-scoped semantics. This migration does not preserve per-user ownership for legacy rows; it intentionally re-homes them to the upgrade runner.
+- **Current status on this branch:** `scripts/test-upgrade.sh` now passes all Scenario A, B1, and B2 checks for this change.

--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -315,6 +315,7 @@ for run in $(seq 1 $REPEAT_COUNT); do
         # 34 creates/drops a database for multi-database testing
         # 35 reads df._worker_epoch (internal table)
         # 37 tests RLS policies, including for superuser, changes users
+        # 38 tests per-user vars RLS isolation, changes users
         PSQL_USER="$E2E_USER"
         if [[ "$test_name" == "00_requires_shared_preload" \
            || "$test_name" == "22_cross_connection" \
@@ -326,7 +327,8 @@ for run in $(seq 1 $REPEAT_COUNT); do
            || "$test_name" == "29_database_validation" \
            || "$test_name" == "34_multi_database" \
            || "$test_name" == "35_heartbeat_liveness" \
-           || "$test_name" == "37_rls" ]]; then
+           || "$test_name" == "37_rls" \
+           || "$test_name" == "38_rls_vars" ]]; then
             PSQL_USER="$PG_USER"
         fi
         

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -732,6 +732,7 @@ test_b2_data_survives_upgrade() {
 
     # Step 3: Verify pre-upgrade data is still accessible under the new schema
     assert_sql_equals "SELECT df.getvar('b2_key');" "b2_value" &&
+    assert_sql_equals "SELECT owner::text FROM df.vars WHERE name = 'b2_key';" "postgres" &&
     assert_sql_equals "SELECT msg FROM test_upgrade_b2_log WHERE kind = 'pre' ORDER BY id DESC LIMIT 1;" "b2_value"
 }
 

--- a/sql/pg_durable--0.1.1--0.2.0.sql
+++ b/sql/pg_durable--0.1.1--0.2.0.sql
@@ -5,4 +5,34 @@
 -- Each schema-changing PR should add its DDL here.
 -- See docs/upgrade-testing.md for the upgrade testing plan.
 
--- (no changes yet)
+-- Changes:
+--   - df.vars: Add per-user scoping via `owner` column + RLS
+--     (Implements rls.md Decision 5, Option A)
+--
+-- Run with: ALTER EXTENSION pg_durable UPDATE TO '0.2.0';
+
+-- ============================================================================
+-- 1. Migrate df.vars schema: add owner column, change PK
+-- ============================================================================
+
+-- Add the owner column with a default. Existing rows get the current user
+-- (the superuser running ALTER EXTENSION). Since vars are ephemeral
+-- (set before df.start(), captured at start time), stale rows in this table
+-- are unlikely to matter. If they do, admins should reassign ownership
+-- manually before upgrading.
+ALTER TABLE df.vars ADD COLUMN owner REGROLE NOT NULL DEFAULT current_user::regrole;
+
+-- Change PK from (name) to (owner, name)
+ALTER TABLE df.vars DROP CONSTRAINT vars_pkey;
+ALTER TABLE df.vars ADD PRIMARY KEY (owner, name);
+
+-- ============================================================================
+-- 2. Enable RLS on df.vars
+-- ============================================================================
+
+ALTER TABLE df.vars ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY vars_user_isolation ON df.vars
+    FOR ALL
+    USING (owner = current_user::regrole)
+    WITH CHECK (owner = current_user::regrole);

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -5,6 +5,9 @@ use cron::Schedule as CronSchedule;
 use pgrx::prelude::*;
 use std::str::FromStr;
 
+use std::cell::RefCell;
+use std::time::Instant;
+
 use crate::client::start_durable_function;
 use crate::types::{short_id, Durofut, FunctionInput};
 
@@ -63,10 +66,30 @@ fn parse_semver(version: &str) -> Option<(u32, u32, u32)> {
 }
 
 fn installed_extension_version() -> String {
-    Spi::get_one::<String>("SELECT extversion FROM pg_extension WHERE extname = 'pg_durable'")
+    thread_local! {
+        static CACHE: RefCell<Option<(String, Instant)>> = const { RefCell::new(None) };
+    }
+    const TTL_SECS: u64 = 5;
+
+    CACHE.with(|cache| {
+        let cached = cache.borrow();
+        if let Some((ref version, ref ts)) = *cached {
+            if ts.elapsed().as_secs() < TTL_SECS {
+                return version.clone();
+            }
+        }
+        drop(cached);
+
+        let version = Spi::get_one::<String>(
+            "SELECT extversion FROM pg_extension WHERE extname = 'pg_durable'",
+        )
         .ok()
         .flatten()
-        .unwrap_or_else(|| pgrx::error!("pg_durable extension metadata not found"))
+        .unwrap_or_else(|| pgrx::error!("pg_durable extension metadata not found"));
+
+        *cache.borrow_mut() = Some((version.clone(), Instant::now()));
+        version
+    })
 }
 
 fn owner_scoped_vars_enabled() -> bool {

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -891,3 +891,39 @@ pub fn wait_for_completion(
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_semver;
+
+    #[test]
+    fn test_parse_semver_basic() {
+        assert_eq!(parse_semver("0.1.1"), Some((0, 1, 1)));
+        assert_eq!(parse_semver("0.2.0"), Some((0, 2, 0)));
+        assert_eq!(parse_semver("1.0.0"), Some((1, 0, 0)));
+        assert_eq!(parse_semver("12.34.56"), Some((12, 34, 56)));
+    }
+
+    #[test]
+    fn test_parse_semver_with_prerelease_suffix() {
+        assert_eq!(parse_semver("0.2.0-rc1"), Some((0, 2, 0)));
+        assert_eq!(parse_semver("1.0.0-beta.2"), Some((1, 0, 0)));
+    }
+
+    #[test]
+    fn test_parse_semver_invalid() {
+        assert_eq!(parse_semver(""), None);
+        assert_eq!(parse_semver("0"), None);
+        assert_eq!(parse_semver("0.1"), None);
+        assert_eq!(parse_semver("abc.def.ghi"), None);
+        assert_eq!(parse_semver("0.1.abc"), None);
+    }
+
+    #[test]
+    fn test_parse_semver_comparison() {
+        assert!(parse_semver("0.2.0").unwrap() >= (0, 2, 0));
+        assert!(parse_semver("0.1.1").unwrap() < (0, 2, 0));
+        assert!(parse_semver("0.3.0").unwrap() >= (0, 2, 0));
+        assert!(parse_semver("1.0.0").unwrap() >= (0, 2, 0));
+    }
+}

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -49,8 +49,41 @@ pub fn debug_connection() -> String {
 // Variable Functions
 // ============================================================================
 
+fn parse_semver(version: &str) -> Option<(u32, u32, u32)> {
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch_part = parts.next()?;
+    let patch_digits = patch_part
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect::<String>();
+    let patch = patch_digits.parse().ok()?;
+    Some((major, minor, patch))
+}
+
+fn installed_extension_version() -> String {
+    Spi::get_one::<String>("SELECT extversion FROM pg_extension WHERE extname = 'pg_durable'")
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| pgrx::error!("pg_durable extension metadata not found"))
+}
+
+fn owner_scoped_vars_enabled() -> bool {
+    let extversion = installed_extension_version();
+    let ext_semver = parse_semver(&extversion).unwrap_or_else(|| {
+        pgrx::error!(
+            "Unsupported pg_durable extension version format: {}",
+            extversion
+        )
+    });
+
+    ext_semver >= (0, 2, 0)
+}
+
 /// Sets a workflow variable. Must be called BEFORE df.start(), not inside a workflow.
 /// Variables are captured at df.start() and remain immutable during execution.
+/// Each user has their own variable namespace (owner = current_user).
 #[pg_extern(schema = "df")]
 pub fn setvar(name: &str, value: &str) -> String {
     // Check if we're inside a workflow execution
@@ -58,12 +91,21 @@ pub fn setvar(name: &str, value: &str) -> String {
         pgrx::error!("df.setvar() cannot be called inside a workflow - set variables before starting the workflow");
     }
 
-    let sql = format!(
-        "INSERT INTO df.vars (name, value) VALUES ('{}', '{}')
-         ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value",
-        name.replace('\'', "''"),
-        value.replace('\'', "''")
-    );
+    let escaped_name = name.replace('\'', "''");
+    let escaped_value = value.replace('\'', "''");
+    let sql = if owner_scoped_vars_enabled() {
+        format!(
+            "INSERT INTO df.vars (name, value) VALUES ('{}', '{}')
+             ON CONFLICT (owner, name) DO UPDATE SET value = EXCLUDED.value",
+            escaped_name, escaped_value
+        )
+    } else {
+        format!(
+            "INSERT INTO df.vars (name, value) VALUES ('{}', '{}')
+             ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value",
+            escaped_name, escaped_value
+        )
+    };
     if let Err(e) = Spi::run(&sql) {
         pgrx::error!("Failed to set variable: {:?}", e);
     }
@@ -71,16 +113,23 @@ pub fn setvar(name: &str, value: &str) -> String {
 }
 
 /// Gets a workflow variable value.
+/// Returns the variable owned by the current user.
 #[pg_extern(schema = "df")]
 pub fn getvar(name: &str) -> Option<String> {
-    let sql = format!(
-        "SELECT value FROM df.vars WHERE name = '{}'",
-        name.replace('\'', "''")
-    );
+    let escaped_name = name.replace('\'', "''");
+    let sql = if owner_scoped_vars_enabled() {
+        format!(
+            "SELECT value FROM df.vars WHERE name = '{}' AND owner = current_user::regrole",
+            escaped_name
+        )
+    } else {
+        format!("SELECT value FROM df.vars WHERE name = '{}'", escaped_name)
+    };
     Spi::get_one::<String>(&sql).ok().flatten()
 }
 
 /// Removes a workflow variable.
+/// Only removes variables owned by the current user.
 #[pg_extern(schema = "df")]
 pub fn unsetvar(name: &str) -> String {
     // Check if we're inside a workflow execution
@@ -88,17 +137,22 @@ pub fn unsetvar(name: &str) -> String {
         pgrx::error!("df.unsetvar() cannot be called inside a workflow - manage variables before starting the workflow");
     }
 
-    let sql = format!(
-        "DELETE FROM df.vars WHERE name = '{}'",
-        name.replace('\'', "''")
-    );
+    let escaped_name = name.replace('\'', "''");
+    let sql = if owner_scoped_vars_enabled() {
+        format!(
+            "DELETE FROM df.vars WHERE name = '{}' AND owner = current_user::regrole",
+            escaped_name
+        )
+    } else {
+        format!("DELETE FROM df.vars WHERE name = '{}'", escaped_name)
+    };
     if let Err(e) = Spi::run(&sql) {
         pgrx::error!("Failed to unset variable: {:?}", e);
     }
     "OK".to_string()
 }
 
-/// Clears all workflow variables.
+/// Clears all workflow variables owned by the current user.
 #[pg_extern(schema = "df")]
 pub fn clearvars() -> String {
     // Check if we're inside a workflow execution
@@ -106,7 +160,13 @@ pub fn clearvars() -> String {
         pgrx::error!("df.clearvars() cannot be called inside a workflow - manage variables before starting the workflow");
     }
 
-    if let Err(e) = Spi::run("DELETE FROM df.vars") {
+    let sql = if owner_scoped_vars_enabled() {
+        "DELETE FROM df.vars WHERE owner = current_user::regrole"
+    } else {
+        "DELETE FROM df.vars"
+    };
+
+    if let Err(e) = Spi::run(sql) {
         pgrx::error!("Failed to clear variables: {:?}", e);
     }
     "OK".to_string()
@@ -640,10 +700,18 @@ pub fn start(
         pgrx::error!("Failed to create instance: {:?}", e);
     }
 
-    // Capture vars from df.vars table
+    // Capture vars from df.vars using the installed extension version as the
+    // compatibility boundary: pre-0.2.0 uses legacy global vars, 0.2.0+ uses
+    // owner-scoped vars.
+    let vars_query = if owner_scoped_vars_enabled() {
+        "SELECT name, value FROM df.vars WHERE owner = current_user::regrole"
+    } else {
+        "SELECT name, value FROM df.vars"
+    };
+
     let vars: std::collections::HashMap<String, String> = Spi::connect(|client| {
         let mut vars = std::collections::HashMap::new();
-        if let Ok(table) = client.select("SELECT name, value FROM df.vars", None, &[]) {
+        if let Ok(table) = client.select(vars_query, None, &[]) {
             for row in table {
                 if let (Ok(Some(name)), Ok(Some(value))) =
                     (row.get::<String>(1), row.get::<String>(2))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,9 +131,12 @@ CREATE INDEX IF NOT EXISTS idx_instances_status ON df.instances(status);
 CREATE INDEX IF NOT EXISTS idx_nodes_instance ON df.nodes(instance_id);
 
 -- Table to store workflow variables (captured at df.start())
+-- Per-user scoping: each user has their own variable namespace.
 CREATE TABLE IF NOT EXISTS df.vars (
-    name TEXT PRIMARY KEY,
-    value TEXT
+    name TEXT NOT NULL,
+    value TEXT,
+    owner REGROLE NOT NULL DEFAULT current_user::regrole,
+    PRIMARY KEY (owner, name)
 );
 
 -- Sentinel table: the background worker writes its epoch_id here after
@@ -171,6 +174,14 @@ CREATE POLICY nodes_user_isolation ON df.nodes
     FOR ALL
     USING (submitted_by = current_user::regrole)
     WITH CHECK (submitted_by = current_user::regrole);
+
+-- Enable RLS on df.vars (per-user variable isolation)
+ALTER TABLE df.vars ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY vars_user_isolation ON df.vars
+    FOR ALL
+    USING (owner = current_user::regrole)
+    WITH CHECK (owner = current_user::regrole);
 
 -- Auto-grant permissions to PUBLIC (safe with RLS enabled)
 GRANT USAGE ON SCHEMA df TO PUBLIC;

--- a/tests/e2e/sql/38_rls_vars.sql
+++ b/tests/e2e/sql/38_rls_vars.sql
@@ -1,0 +1,308 @@
+-- Test: Per-User Variable Isolation (RLS on df.vars)
+--
+-- Validates that df.vars is scoped per-user via the `owner` column + RLS:
+-- 1. Alice's variables are invisible to Bob
+-- 2. Bob cannot read Alice's variables via df.getvar()
+-- 3. Each user's df.start() captures only their own vars
+-- 4. df.clearvars() only clears the calling user's variables
+-- 5. Superuser sees all variables (RLS bypass) but df.start() captures
+--    only their own (explicit owner filter in code)
+--
+-- Must run as SUPERUSER because it uses SET SESSION AUTHORIZATION.
+
+-- ============================================================================
+-- Setup: Create two test users
+-- ============================================================================
+DO $setup$
+BEGIN
+    PERFORM pg_terminate_backend(pid)
+      FROM pg_stat_activity
+      WHERE usename IN ('vars_alice', 'vars_bob')
+        AND pid <> pg_backend_pid();
+
+    BEGIN DROP OWNED BY vars_alice; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP OWNED BY vars_bob;   EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE vars_alice;     EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE vars_bob;       EXCEPTION WHEN undefined_object THEN NULL; END;
+END $setup$;
+
+CREATE ROLE vars_alice LOGIN;
+CREATE ROLE vars_bob   LOGIN;
+
+GRANT TEMPORARY ON DATABASE postgres TO vars_alice, vars_bob;
+
+-- Create a shared results table (owned by superuser so both users can INSERT)
+DROP TABLE IF EXISTS vars_test_results;
+CREATE TABLE vars_test_results (id SERIAL PRIMARY KEY, username TEXT, msg TEXT);
+GRANT SELECT, INSERT ON vars_test_results TO PUBLIC;
+GRANT USAGE ON SEQUENCE vars_test_results_id_seq TO PUBLIC;
+
+-- ============================================================================
+-- Test 1: Per-user variable isolation via direct table access
+-- ============================================================================
+
+-- Alice sets a variable
+SET SESSION AUTHORIZATION vars_alice;
+SELECT df.setvar('color', 'red');
+RESET SESSION AUTHORIZATION;
+
+-- Bob sets the same-named variable with a different value
+SET SESSION AUTHORIZATION vars_bob;
+SELECT df.setvar('color', 'blue');
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    alice_val TEXT;
+    bob_val TEXT;
+    alice_count INT;
+    bob_count INT;
+BEGIN
+    -- Alice should see only her variable
+    SET SESSION AUTHORIZATION vars_alice;
+    SELECT df.getvar('color') INTO alice_val;
+    SELECT count(*) INTO alice_count FROM df.vars;
+    RESET SESSION AUTHORIZATION;
+
+    -- Bob should see only his variable
+    SET SESSION AUTHORIZATION vars_bob;
+    SELECT df.getvar('color') INTO bob_val;
+    SELECT count(*) INTO bob_count FROM df.vars;
+    RESET SESSION AUTHORIZATION;
+
+    IF alice_val != 'red' THEN
+        RAISE EXCEPTION 'TEST 1 FAILED: Alice expected "red", got "%"', alice_val;
+    END IF;
+
+    IF bob_val != 'blue' THEN
+        RAISE EXCEPTION 'TEST 1 FAILED: Bob expected "blue", got "%"', bob_val;
+    END IF;
+
+    IF alice_count != 1 THEN
+        RAISE EXCEPTION 'TEST 1 FAILED: Alice should see 1 var, saw %', alice_count;
+    END IF;
+
+    IF bob_count != 1 THEN
+        RAISE EXCEPTION 'TEST 1 FAILED: Bob should see 1 var, saw %', bob_count;
+    END IF;
+
+    RAISE NOTICE 'Test 1 PASSED: Per-user variable isolation (same key, different values)';
+END $$;
+
+-- ============================================================================
+-- Test 2: df.start() captures only the calling user's variables
+-- ============================================================================
+
+-- Alice starts a workflow that uses her variable
+SET SESSION AUTHORIZATION vars_alice;
+CREATE TEMP TABLE _vars_alice_state (instance_id TEXT);
+INSERT INTO _vars_alice_state SELECT df.start(
+    'INSERT INTO vars_test_results (username, msg) VALUES (''alice'', ''{color}'')' ::text,
+    'vars-alice-color'
+);
+RESET SESSION AUTHORIZATION;
+
+-- Bob starts a workflow that uses his variable
+SET SESSION AUTHORIZATION vars_bob;
+CREATE TEMP TABLE _vars_bob_state (instance_id TEXT);
+INSERT INTO _vars_bob_state SELECT df.start(
+    'INSERT INTO vars_test_results (username, msg) VALUES (''bob'', ''{color}'')' ::text,
+    'vars-bob-color'
+);
+RESET SESSION AUTHORIZATION;
+
+-- Wait for both to complete
+DO $$
+DECLARE
+    alice_id TEXT;
+    bob_id TEXT;
+    s TEXT;
+BEGIN
+    SELECT instance_id INTO alice_id FROM _vars_alice_state;
+    SELECT instance_id INTO bob_id FROM _vars_bob_state;
+
+    SELECT df.wait_for_completion(alice_id, 30) INTO s;
+    IF s != 'completed' THEN
+        RAISE EXCEPTION 'TEST 2 FAILED: Alice workflow status = %', s;
+    END IF;
+
+    SELECT df.wait_for_completion(bob_id, 30) INTO s;
+    IF s != 'completed' THEN
+        RAISE EXCEPTION 'TEST 2 FAILED: Bob workflow status = %', s;
+    END IF;
+END $$;
+
+-- Verify each workflow used the correct user's variable
+DO $$
+DECLARE
+    alice_msg TEXT;
+    bob_msg TEXT;
+BEGIN
+    SELECT msg INTO alice_msg FROM vars_test_results WHERE username = 'alice' ORDER BY id DESC LIMIT 1;
+    SELECT msg INTO bob_msg FROM vars_test_results WHERE username = 'bob' ORDER BY id DESC LIMIT 1;
+
+    IF alice_msg != 'red' THEN
+        RAISE EXCEPTION 'TEST 2 FAILED: Alice workflow should have used "red", got "%"', alice_msg;
+    END IF;
+
+    IF bob_msg != 'blue' THEN
+        RAISE EXCEPTION 'TEST 2 FAILED: Bob workflow should have used "blue", got "%"', bob_msg;
+    END IF;
+
+    RAISE NOTICE 'Test 2 PASSED: df.start() captures only the calling user''s vars';
+END $$;
+
+-- ============================================================================
+-- Test 3: df.clearvars() only clears the calling user's variables
+-- ============================================================================
+
+-- Alice clears her vars
+SET SESSION AUTHORIZATION vars_alice;
+SELECT df.clearvars();
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    alice_val TEXT;
+    bob_val TEXT;
+BEGIN
+    -- Alice's var should be gone
+    SET SESSION AUTHORIZATION vars_alice;
+    SELECT df.getvar('color') INTO alice_val;
+    RESET SESSION AUTHORIZATION;
+
+    -- Bob's var should still exist
+    SET SESSION AUTHORIZATION vars_bob;
+    SELECT df.getvar('color') INTO bob_val;
+    RESET SESSION AUTHORIZATION;
+
+    IF alice_val IS NOT NULL THEN
+        RAISE EXCEPTION 'TEST 3 FAILED: Alice''s var should be gone after clearvars, got "%"', alice_val;
+    END IF;
+
+    IF bob_val != 'blue' THEN
+        RAISE EXCEPTION 'TEST 3 FAILED: Bob''s var should survive Alice''s clearvars, got "%"', bob_val;
+    END IF;
+
+    RAISE NOTICE 'Test 3 PASSED: df.clearvars() only clears the calling user''s variables';
+END $$;
+
+-- ============================================================================
+-- Test 4: df.unsetvar() only removes the calling user's variable
+-- ============================================================================
+
+-- Re-create Alice's variable
+SET SESSION AUTHORIZATION vars_alice;
+SELECT df.setvar('shared_key', 'alice_value');
+RESET SESSION AUTHORIZATION;
+
+SET SESSION AUTHORIZATION vars_bob;
+SELECT df.setvar('shared_key', 'bob_value');
+-- Bob tries to unset 'shared_key' — should only remove his own
+SELECT df.unsetvar('shared_key');
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    alice_val TEXT;
+    bob_val TEXT;
+BEGIN
+    SET SESSION AUTHORIZATION vars_alice;
+    SELECT df.getvar('shared_key') INTO alice_val;
+    RESET SESSION AUTHORIZATION;
+
+    SET SESSION AUTHORIZATION vars_bob;
+    SELECT df.getvar('shared_key') INTO bob_val;
+    RESET SESSION AUTHORIZATION;
+
+    IF alice_val != 'alice_value' THEN
+        RAISE EXCEPTION 'TEST 4 FAILED: Alice''s shared_key should survive Bob''s unsetvar, got "%"', alice_val;
+    END IF;
+
+    IF bob_val IS NOT NULL THEN
+        RAISE EXCEPTION 'TEST 4 FAILED: Bob''s shared_key should be removed, got "%"', bob_val;
+    END IF;
+
+    RAISE NOTICE 'Test 4 PASSED: df.unsetvar() only removes the calling user''s variable';
+END $$;
+
+-- ============================================================================
+-- Test 5: Superuser sees all variables (RLS bypass) but df.start()
+--         captures only superuser's own vars
+-- ============================================================================
+
+-- Set up: Alice has 'shared_key', Bob has nothing, superuser sets its own var
+SET SESSION AUTHORIZATION vars_bob;
+SELECT df.clearvars();
+RESET SESSION AUTHORIZATION;
+
+-- Superuser sets its own variable
+SELECT df.setvar('su_var', 'superuser_value');
+
+DO $$
+DECLARE
+    total_count INT;
+BEGIN
+    -- Superuser should see ALL vars (bypasses RLS): Alice's + superuser's
+    SELECT count(*) INTO total_count FROM df.vars;
+
+    IF total_count < 2 THEN
+        RAISE EXCEPTION 'TEST 5 FAILED: Superuser should see at least 2 vars (alice + su), saw %', total_count;
+    END IF;
+
+    RAISE NOTICE 'Test 5 PASSED: Superuser sees all variables (% total)', total_count;
+END $$;
+
+-- Superuser starts a workflow — should capture only its own vars, not Alice's
+TRUNCATE vars_test_results;
+
+CREATE TEMP TABLE _vars_su_state (instance_id TEXT);
+INSERT INTO _vars_su_state SELECT df.start(
+    'INSERT INTO vars_test_results (username, msg) VALUES (''superuser'', ''{su_var}'')' ::text,
+    'vars-su-test'
+);
+
+DO $$
+DECLARE
+    su_id TEXT;
+    s TEXT;
+    su_msg TEXT;
+BEGIN
+    SELECT instance_id INTO su_id FROM _vars_su_state;
+    SELECT df.wait_for_completion(su_id, 30) INTO s;
+
+    IF s != 'completed' THEN
+        RAISE EXCEPTION 'TEST 5b FAILED: Superuser workflow status = %', s;
+    END IF;
+
+    SELECT msg INTO su_msg FROM vars_test_results WHERE username = 'superuser' ORDER BY id DESC LIMIT 1;
+
+    IF su_msg != 'superuser_value' THEN
+        RAISE EXCEPTION 'TEST 5b FAILED: Superuser workflow should use "superuser_value", got "%"', su_msg;
+    END IF;
+
+    RAISE NOTICE 'Test 5b PASSED: Superuser df.start() captures only its own vars';
+END $$;
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+DROP TABLE IF EXISTS _vars_alice_state;
+DROP TABLE IF EXISTS _vars_bob_state;
+DROP TABLE IF EXISTS _vars_su_state;
+DROP TABLE IF EXISTS vars_test_results;
+
+-- Clear all vars (as superuser, bypasses RLS)
+DELETE FROM df.vars WHERE owner IN ('vars_alice'::regrole, 'vars_bob'::regrole);
+-- Clear superuser's vars
+SELECT df.clearvars();
+
+DO $cleanup$
+BEGIN
+    BEGIN DROP OWNED BY vars_alice; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP OWNED BY vars_bob;   EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE vars_alice;     EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN DROP ROLE vars_bob;       EXCEPTION WHEN undefined_object THEN NULL; END;
+END $cleanup$;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/38_rls_vars.sql
+++ b/tests/e2e/sql/38_rls_vars.sql
@@ -243,11 +243,11 @@ DO $$
 DECLARE
     total_count INT;
 BEGIN
-    -- Superuser should see ALL vars (bypasses RLS): Alice's + superuser's
+    -- Superuser should see exactly 2 vars (bypasses RLS): Alice's shared_key + superuser's su_var
     SELECT count(*) INTO total_count FROM df.vars;
 
-    IF total_count < 2 THEN
-        RAISE EXCEPTION 'TEST 5 FAILED: Superuser should see at least 2 vars (alice + su), saw %', total_count;
+    IF total_count != 2 THEN
+        RAISE EXCEPTION 'TEST 5 FAILED: Superuser should see exactly 2 vars (alice + su), saw %', total_count;
     END IF;
 
     RAISE NOTICE 'Test 5 PASSED: Superuser sees all variables (% total)', total_count;


### PR DESCRIPTION
## Summary

Add per-user scoping to `df.vars` with an `owner` column and RLS.

## What changed

- Add `owner REGROLE` and `(owner, name)` PK for `df.vars`
- Add `sql/pg_durable--0.1.1--0.2.0.sql` and align fresh install with the upgrade path
- Keep the new `.so` compatible with the v0.1.1 schema for `df.vars` APIs and `df.start()`
- Add upgrade-test coverage for Scenario A/B1/B2, including migrated var ownership
- Add docs and changelog notes for the post-upgrade vars visibility change

## Breaking change

After upgrading from `v0.1.1`, variables that already existed before `ALTER EXTENSION pg_durable UPDATE` become visible only to the role that ran the upgrade.

## Validation

- `./scripts/test-upgrade.sh --pg-version 17`