### PR TITLE
Validate df.break() is inside a loop at graph construction time

### DIFF
--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -574,6 +574,10 @@ pub fn start(
     if let Err(e) = durofut.validate_recursive() {
         pgrx::error!("Invalid durable function graph: {}", e);
     }
+    // Validate structural constraints (e.g. df.break() must be inside df.loop())
+    if let Err(e) = durofut.validate_structural(false) {
+        pgrx::error!("Invalid durable function graph: {}", e);
+    }
     let instance_id = short_id();
 
     // Validate that the target database exists (if specified)

--- a/src/types.rs
+++ b/src/types.rs
@@ -538,6 +538,42 @@ impl Durofut {
         Ok(())
     }
 
+    /// Validate structural constraints that depend on nesting context.
+    ///
+    /// Specifically, `df.break()` is only valid inside a `df.loop()` body.
+    /// Call this with `in_loop = false` at the graph root.
+    pub fn validate_structural(&self, in_loop: bool) -> Result<(), String> {
+        match self.node_type.as_str() {
+            "BREAK" if !in_loop => {
+                return Err(
+                    "df.break() used outside of a loop — df.break() is only valid inside a df.loop() body"
+                        .to_string(),
+                );
+            }
+            "LOOP" => {
+                // The loop body (left_node) runs in a loop context.
+                if let Some(ref body) = self.left_node {
+                    body.validate_structural(true)?;
+                }
+                // The while-condition (config condition_node) is not a loop body;
+                // df.break() there doesn't make sense either.
+                self.for_each_config_child(|child| child.validate_structural(false))?;
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        // For all other nodes propagate the current loop context.
+        if let Some(ref left) = self.left_node {
+            left.validate_structural(in_loop)?;
+        }
+        if let Some(ref right) = self.right_node {
+            right.validate_structural(in_loop)?;
+        }
+        self.for_each_config_child(|child| child.validate_structural(in_loop))?;
+        Ok(())
+    }
+
     /// Extract config-embedded Durofut children from the `query` JSON field and apply
     /// a callback to each. This is the single source of truth for walking `condition_node`
     /// (in IF/LOOP nodes) and `extra_nodes` (in JOIN nodes).

--- a/tests/e2e/sql/39_break_outside_loop.sql
+++ b/tests/e2e/sql/39_break_outside_loop.sql
@@ -1,0 +1,67 @@
+-- Test: df.break() outside a loop is rejected at graph construction time (df.start()).
+-- Expected: df.start raises an error when df.break() appears outside df.loop().
+
+DO $body$
+BEGIN
+    -- 1. Bare df.break() at the top level
+    BEGIN
+        PERFORM df.start(df.break());
+        RAISE EXCEPTION 'TEST FAILED: bare df.break() at top level should have been rejected';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Case 1 OK - caught expected error: %', SQLERRM;
+    END;
+
+    -- 2. df.break() inside a sequence, outside any loop
+    BEGIN
+        PERFORM df.start('SELECT 1' ~> df.break() ~> 'SELECT 2');
+        RAISE EXCEPTION 'TEST FAILED: df.break() in sequence without loop should have been rejected';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Case 2 OK - caught expected error: %', SQLERRM;
+    END;
+
+    -- 3. df.break() in the then-branch of a conditional, outside any loop
+    BEGIN
+        PERFORM df.start('SELECT true' ?> df.break() !> 'SELECT 1');
+        RAISE EXCEPTION 'TEST FAILED: df.break() in conditional outside loop should have been rejected';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Case 3 OK - caught expected error: %', SQLERRM;
+    END;
+
+    RAISE NOTICE 'Cases 1-3 passed: df.break() outside loop correctly rejected';
+END $body$;
+
+-- 4. df.break() inside a df.loop() body is valid — should NOT raise.
+--    Must be outside the DO block so df.start() commits and the background
+--    worker can see the instance.
+CREATE TEMP TABLE _test_state (instance_id TEXT);
+INSERT INTO _test_state SELECT df.start(
+    df.loop(
+        'SELECT 1' ~> df.break('{"done": true}')
+    ),
+    'break-in-loop-test'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED: df.break() inside loop did not complete, status = %', status;
+    END IF;
+
+    RAISE NOTICE 'Case 4 OK - df.break() inside loop is valid and completed';
+END $$;
+
+DROP TABLE _test_state;
+
+SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## Problem

`df.break()` used outside a `df.loop()` body silently produced a corrupted result — the raw internal `{"__break__": true, "value": ...}` sentinel was written as the instance output, and the instance was marked `completed`. No error was raised.

## Fix

Reject such graphs immediately at `df.start()` time, before any nodes are inserted into the database.

### Changes

- **`src/types.rs`**: Add `Durofut::validate_structural(in_loop: bool)` which walks the graph, tracking whether execution is inside a loop body. A `BREAK` node encountered with `in_loop = false` returns a clear error. `LOOP` nodes recurse into their body with `in_loop = true` and into their while-condition with `in_loop = false`.

- **`src/dsl.rs`**: Call `validate_structural(false)` in `df.start()` after the existing `validate_recursive()` check, before any nodes are inserted.

- **`tests/e2e/sql/39_break_outside_loop.sql`**: E2E test covering four cases:
  1. Bare `df.break()` at top level → must error
  2. `df.break()` inside `~>` sequence without loop → must error
  3. `df.break()` in conditional branch outside loop → must error
  4. `df.break()` inside `df.loop()` body → must complete successfully

## Behavior table

| Pattern | Before | After |
|---|---|---|
| `df.start(df.break())` | Completed with sentinel result | Error at `df.start()` |
| `df.start('step1' ~> df.break())` | Completed with sentinel result | Error at `df.start()` |
| `df.start(df.loop('step' ~> df.break()))` | Completed correctly | Completed correctly |