### PR TITLE
Update Copilot setup workflow for submodule-based duroxide-pg-opt

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,8 +25,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          submodules: recursive
-          token: ${{ secrets.DUROXIDE_PG_OPT_TOKEN }}
+          submodules: false
+
+      - name: Initialize private submodule duroxide-pg-opt
+        run: |
+          test -n "${{ secrets.DUROXIDE_PG_OPT_TOKEN }}"
+          git -c url."https://x-access-token:${{ secrets.DUROXIDE_PG_OPT_TOKEN }}@github.com/".insteadOf="https://github.com/" \
+            submodule update --init --recursive
 
       - name: Install Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@stable
@@ -55,15 +60,6 @@ jobs:
 
       - name: Verify pgrx installation
         run: cargo pgrx --version
-
-      # Keep Cargo git transport behavior consistent in CI.
-      - name: Configure Cargo to use git CLI
-        run: |
-          mkdir -p ~/.cargo
-          cat >> ~/.cargo/config.toml << 'EOF'
-          [net]
-          git-fetch-with-cli = true
-          EOF
 
       # Warm Cargo caches so later builds/tests are faster and more reliable.
       - name: Prefetch Rust dependencies

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          token: ${{ secrets.DUROXIDE_PG_OPT_TOKEN }}
 
       - name: Install Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@stable
@@ -53,7 +56,7 @@ jobs:
       - name: Verify pgrx installation
         run: cargo pgrx --version
 
-      # Strongly recommended for private git deps + auth in CI-like envs
+      # Keep Cargo git transport behavior consistent in CI.
       - name: Configure Cargo to use git CLI
         run: |
           mkdir -p ~/.cargo
@@ -62,15 +65,10 @@ jobs:
           git-fetch-with-cli = true
           EOF
 
-      # Provide non-interactive auth for *all* https://github.com/* git fetches
-      # using an environment secret in the `copilot` environment.
-      - name: Configure git auth for private GitHub deps (PAT)
-        run: |
-          test -n "${{ secrets.DUROXIDE_PG_OPT_TOKEN }}"
-          git config --global --add url."https://x-access-token:${{ secrets.DUROXIDE_PG_OPT_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --global --add url."https://x-access-token:${{ secrets.DUROXIDE_PG_OPT_TOKEN }}@github.com/".insteadOf "https://api.github.com/"
-
-      # Warm the Cargo git/db caches so later `cargo update/test` is fast and reliable.
-      - name: Prefetch Rust dependencies (including private git deps)
+      # Warm Cargo caches so later builds/tests are faster and more reliable.
+      - name: Prefetch Rust dependencies
         run: |
           cargo fetch
+
+      - name: Verify duroxide migrations match upstream
+        run: ./scripts/verify-duroxide-migrations.sh


### PR DESCRIPTION
## Summary
- check out the main repository with default GitHub Actions credentials
- initialize private submodule duroxide-pg-opt in a dedicated step using DUROXIDE_PG_OPT_TOKEN
- remove the redundant global git URL rewrite auth step
- remove the Cargo git-fetch-with-cli configuration step
- verify duroxide migrations match upstream

## Why
The previous checkout configuration used DUROXIDE_PG_OPT_TOKEN as the primary checkout token, which caused PR checkout failures against microsoft/pg_durable with HTTP 403 in Actions.

This change keeps root checkout auth and private submodule auth separate: default token for the main repo, PAT only for submodule initialization.

## Validation
- reproduced and analyzed the checkout failure mode from the Actions logs
- confirmed Checkout private submodules succeeded after the split-auth update
- verified workflow edits are scoped to .github/workflows/copilot-setup-steps.yml
