### PR TITLE
Add multi-statement SQL support for df.sql()

### DIFF
--- a/docs/multi-statement.md
+++ b/docs/multi-statement.md
@@ -1,0 +1,190 @@
+# Multi-Statement SQL Support
+
+## Motivation
+
+Users naturally want to write multi-statement SQL in `df.sql()`:
+
+```sql
+SELECT df.start(
+    df.sql('INSERT INTO audit_log VALUES (now(), ''start'');
+            UPDATE accounts SET balance = balance - 100 WHERE id = 1;
+            UPDATE accounts SET balance = balance + 100 WHERE id = 2;
+            INSERT INTO audit_log VALUES (now(), ''done'')'),
+    'transfer-funds'
+);
+```
+
+Without multi-statement support, users must chain each statement as a separate `df.sql()` node connected with `~>`. This is verbose for what is conceptually a single unit of work, and — critically — each `df.sql()` node executes as a separate activity (separate connection, separate transaction), so there is no atomicity across the group.
+
+Multi-statement `df.sql()` gives users a way to execute several statements atomically within a single activity invocation.
+
+## Technical Challenge
+
+pg_durable uses [sqlx](https://github.com/launchbadge/sqlx) to execute SQL from the background worker. sqlx sends queries via PostgreSQL's **extended query protocol**, which does not support multiple commands in a single prepared statement. Attempting to do so produces:
+
+```
+ERROR: cannot insert multiple commands into a prepared statement
+```
+
+This is a PostgreSQL protocol-level restriction, not a sqlx bug. The extended query protocol parses, binds, and executes a single statement per message cycle. The **simple query protocol** does support multiple statements in one message, but sqlx does not expose it.
+
+## Alternatives Considered
+
+### A1: Use the simple query protocol
+
+PostgreSQL's simple query protocol (`PQexec` in libpq) accepts multiple semicolon-separated statements and executes them all. However, sqlx does not support the simple query protocol. Switching to a different driver (e.g., `tokio-postgres` with `simple_query`) would be a significant change with ripple effects across the codebase.
+
+**Verdict:** Too invasive. Would require replacing sqlx or maintaining a parallel driver just for this case.
+
+### A2: Use `sqlx::raw_sql()`
+
+sqlx provides `raw_sql()` which uses the simple query protocol. However, it returns raw protocol messages rather than typed rows, making result extraction (needed for `|=>` result piping) more complex. It also doesn't support parameterized queries, which could matter in future evolution.
+
+**Verdict:** Viable but would require a separate code path for result extraction. The lack of typed rows means we'd lose the column-type detection logic. Worth revisiting if the splitting approach proves too fragile.
+
+### A3: Split and execute sequentially (chosen)
+
+Parse the SQL string to find statement boundaries (semicolons outside of string literals and comments), then execute each statement individually via the existing sqlx extended query protocol path. This reuses all existing result-handling code.
+
+**Verdict:** Chosen. Minimal change, reuses existing infrastructure, handles the common cases well.
+
+### A4: Wrap in a DO block
+
+Wrap the user's SQL in `DO $$ BEGIN ... END $$` to let PostgreSQL handle multi-statement execution natively. This works for DML but not for statements that return rows (SELECT), since DO blocks cannot return results.
+
+**Verdict:** Not viable. Breaks `|=>` result piping for any multi-statement block ending with SELECT.
+
+## Design
+
+### Statement Splitting
+
+The `split_statements()` parser splits SQL by semicolons while respecting:
+
+- **Single-quoted strings:** `'it''s a semicolon: ;'` — semicolons inside string literals are not split points
+- **Dollar-quoted strings:** `$$body with ; inside$$` and `$tag$...$tag$` — common in function bodies
+- **Single-line comments:** `-- comment with ;` — semicolons in comments are ignored
+- **Block comments:** `/* comment with ; */` — likewise ignored
+
+The parser is intentionally simple. It does not handle all PostgreSQL syntax edge cases (e.g., the `E'\;'` escape string syntax). This covers the vast majority of real-world usage.
+
+### Execution Model
+
+When multiple statements are detected:
+
+1. All statements execute **sequentially** on the **same connection**
+2. The entire block is wrapped in a **single transaction** (`BEGIN` / `COMMIT`), with `ROLLBACK` on any error
+3. The **result of the last statement** is returned as the node's output (for `|=>` piping)
+4. If any statement fails, the entire block is rolled back and the activity returns an error
+
+The transaction wrapping is critical: without it, a failure in statement N would leave statements 1..N-1 committed, producing a partial-execution state that is difficult to reason about or recover from.
+
+Single-statement SQL nodes are **not** wrapped in an explicit transaction (preserving existing behavior where each statement runs in PostgreSQL's implicit auto-commit transaction).
+
+### Result Semantics
+
+For a multi-statement block like:
+
+```sql
+df.sql('INSERT INTO t1 VALUES (1); INSERT INTO t2 VALUES (2); SELECT count(*) AS n FROM t1')
+```
+
+The returned result is `{"rows": [{"n": 1}], "row_count": 1}` — only the last statement's output. Intermediate statement results are discarded. This matches the behavior of `psql` and most SQL tools when running multiple statements.
+
+## Limitations
+
+- **No per-statement result access:** Only the last statement's result is available via `|=>`. If you need results from intermediate statements, use separate `df.sql()` nodes.
+- **Dollar signs in variable substitution:** pg_durable uses `$name` for variable substitution (`|=>` results). If a multi-statement block contains dollar-quoted strings, the `$` signs could conflict with variable substitution. In practice this is rare since variable substitution happens before statement splitting, and dollar-quoting uses `$$` or `$tag$` patterns that are unlikely to collide with result names.
+- **Parser simplicity:** The semicolon splitter is not a full SQL parser. Exotic syntax may confuse it. For complex multi-statement logic, consider using a PL/pgSQL DO block or separate `df.sql()` nodes.
+
+## Life without multi-statement support
+
+Given the transfer-funds example, here are the options users have today to execute multiple statements atomically within a single `df.sql()` node:
+
+### 1. PL/pgSQL DO block (simplest for DML-only)
+
+```sql
+SELECT df.start(
+    df.sql('DO $$
+    BEGIN
+        INSERT INTO audit_log VALUES (now(), ''start'');
+        UPDATE accounts SET balance = balance - 100 WHERE id = 1;
+        UPDATE accounts SET balance = balance + 100 WHERE id = 2;
+        INSERT INTO audit_log VALUES (now(), ''done'');
+    END $$'),
+    'transfer-funds'
+);
+```
+
+This is a **single statement** (the `DO` block), so it works with sqlx's extended query protocol. PostgreSQL executes all inner statements atomically. **Limitation:** DO blocks cannot return results, so `|=>` piping from this node won't produce useful output. For pure DML like this example, that's fine.
+
+### 2. Stored function (best if you need a return value)
+
+```sql
+CREATE FUNCTION transfer_funds() RETURNS jsonb LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO audit_log VALUES (now(), 'start');
+    UPDATE accounts SET balance = balance - 100 WHERE id = 1;
+    UPDATE accounts SET balance = balance + 100 WHERE id = 2;
+    INSERT INTO audit_log VALUES (now(), 'done');
+    RETURN jsonb_build_object('status', 'ok');
+END $$;
+```
+
+Then:
+
+```sql
+SELECT df.start(
+    df.sql('SELECT transfer_funds()') |=> 'result'
+    ~> 'SELECT $result',
+    'transfer-funds'
+);
+```
+
+This is a single `SELECT` statement, fully compatible with `|=>`. The function body executes atomically within the calling transaction. **Trade-off:** requires DDL upfront (creating the function), but gives maximum flexibility — parameters, return values, error handling with `EXCEPTION` blocks, etc.
+
+### 3. Writeable CTE (single-statement trick, limited)
+
+```sql
+SELECT df.start(
+    df.sql('WITH
+        log_start AS (INSERT INTO audit_log VALUES (now(), ''start'') RETURNING 1),
+        debit AS (UPDATE accounts SET balance = balance - 100 WHERE id = 1 RETURNING 1),
+        credit AS (UPDATE accounts SET balance = balance + 100 WHERE id = 2 RETURNING 1),
+        log_done AS (INSERT INTO audit_log VALUES (now(), ''done'') RETURNING 1)
+    SELECT ''ok'' AS status'),
+    'transfer-funds'
+);
+```
+
+This is technically a **single SQL statement**, so it works with the extended query protocol and supports `|=>`. **Limitations:** CTE branches execute in an unspecified order (PostgreSQL may reorder or parallelize them), so this doesn't guarantee the audit log entries are written before/after the updates. Also, if you need conditional logic or loops inside the block, CTEs can't express that. Best suited for independent-but-atomic mutations.
+
+### 4. Stored procedure (CALL)
+
+```sql
+CREATE PROCEDURE transfer_funds() LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO audit_log VALUES (now(), 'start');
+    UPDATE accounts SET balance = balance - 100 WHERE id = 1;
+    UPDATE accounts SET balance = balance + 100 WHERE id = 2;
+    INSERT INTO audit_log VALUES (now(), 'done');
+END $$;
+```
+
+Then:
+
+```sql
+SELECT df.start(df.sql('CALL transfer_funds()'), 'transfer-funds');
+```
+
+Works atomically. **Difference from functions:** procedures support internal `COMMIT`/`ROLLBACK` (transaction control), which functions cannot do. However, `CALL` statements don't return result rows, so `|=>` won't capture output — similar limitation to the DO block. Procedures are better suited when you need explicit transaction control *within* the body itself.
+
+### Summary
+
+| Approach | Atomic | Returns results (`\|=>`) | Requires DDL | Execution order guaranteed |
+|----------|--------|--------------------------|-------------|---------------------------|
+| DO block | Yes | No | No | Yes |
+| Stored function | Yes | Yes | Yes (`CREATE FUNCTION`) | Yes |
+| Writeable CTE | Yes | Yes | No | No (order unspecified) |
+| Stored procedure | Yes | No | Yes (`CREATE PROCEDURE`) | Yes |
+
+**Recommendation:** For DML-only blocks (like the transfer example), a **DO block** is the simplest — no DDL needed, fully atomic, single statement. If you need to pipe results downstream with `|=>`, use a **stored function**. Writeable CTEs work for simple cases but the unspecified execution order makes them unsuitable when ordering matters (like audit logging before/after).

--- a/src/activities/execute_sql.rs
+++ b/src/activities/execute_sql.rs
@@ -24,7 +24,128 @@ pub struct ExecuteSqlInput {
     pub database: Option<String>,
 }
 
-/// Execute a SQL query as the submitting user and return results as JSON
+/// Split a SQL string by semicolons, respecting single-quoted string literals
+/// and PostgreSQL dollar-quoted strings (e.g. $$ ... $$, $tag$ ... $tag$).
+fn split_statements(sql: &str) -> Vec<&str> {
+    let mut statements = Vec::new();
+    let mut start = 0;
+    let bytes = sql.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        match bytes[i] {
+            b'\'' => {
+                // Skip single-quoted string: advance past closing quote
+                // (doubled '' is an escaped quote, not end-of-string)
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'\'' {
+                        i += 1;
+                        if i < len && bytes[i] == b'\'' {
+                            // escaped quote '', keep going
+                            i += 1;
+                            continue;
+                        }
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            b'$' => {
+                // Check for dollar-quoted string: $$ or $tag$
+                if let Some(tag_end) = sql[i + 1..].find('$') {
+                    let tag = &sql[i..i + 1 + tag_end + 1]; // e.g. "$$" or "$tag$"
+                                                            // Validate tag content (between $ signs) is a valid identifier or empty
+                    let tag_body = &tag[1..tag.len() - 1];
+                    if tag_body.is_empty()
+                        || tag_body.chars().all(|c| c.is_alphanumeric() || c == '_')
+                    {
+                        // Find the matching closing tag
+                        let after_open = i + tag.len();
+                        if let Some(close_pos) = sql[after_open..].find(tag) {
+                            i = after_open + close_pos + tag.len();
+                            continue;
+                        }
+                    }
+                }
+                i += 1;
+            }
+            b'-' if i + 1 < len && bytes[i + 1] == b'-' => {
+                // Skip single-line comment
+                i += 2;
+                while i < len && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                i += 1; // skip the newline
+            }
+            b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
+                // Skip block comment (non-nested)
+                i += 2;
+                while i + 1 < len {
+                    if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            b';' => {
+                let stmt = sql[start..i].trim();
+                if !stmt.is_empty() {
+                    statements.push(stmt);
+                }
+                start = i + 1;
+                i += 1;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    // Last segment (after final semicolon or if no semicolons)
+    let last = sql[start..].trim();
+    if !last.is_empty() {
+        statements.push(last);
+    }
+
+    statements
+}
+
+/// Convert sqlx rows to JSON value
+fn rows_to_json(rows: Vec<sqlx::postgres::PgRow>) -> Vec<serde_json::Value> {
+    let mut result_rows: Vec<serde_json::Value> = Vec::new();
+    for row in rows {
+        let columns = row.columns();
+        let mut row_obj = serde_json::Map::new();
+
+        for col in columns {
+            let col_name = col.name();
+            if let Ok(val) = row.try_get::<String, _>(col_name) {
+                row_obj.insert(col_name.to_string(), serde_json::Value::String(val));
+            } else if let Ok(val) = row.try_get::<i64, _>(col_name) {
+                row_obj.insert(col_name.to_string(), serde_json::Value::Number(val.into()));
+            } else if let Ok(val) = row.try_get::<i32, _>(col_name) {
+                row_obj.insert(col_name.to_string(), serde_json::Value::Number(val.into()));
+            } else if let Ok(val) = row.try_get::<bool, _>(col_name) {
+                row_obj.insert(col_name.to_string(), serde_json::Value::Bool(val));
+            } else if let Ok(val) = row.try_get::<f64, _>(col_name) {
+                if let Some(n) = serde_json::Number::from_f64(val) {
+                    row_obj.insert(col_name.to_string(), serde_json::Value::Number(n));
+                }
+            } else {
+                row_obj.insert(col_name.to_string(), serde_json::Value::Null);
+            }
+        }
+        result_rows.push(serde_json::Value::Object(row_obj));
+    }
+    result_rows
+}
+
+/// Execute a SQL query as the submitting user and return results as JSON.
+/// Supports multiple semicolon-separated statements; the result of the last
+/// statement is returned.
 pub async fn execute(
     ctx: ActivityContext,
     _pool: Arc<PgPool>,
@@ -53,39 +174,63 @@ pub async fn execute(
     )
     .await?;
 
-    match sqlx::query(&input.query).fetch_all(&mut conn).await {
-        Ok(rows) => {
-            let mut result_rows: Vec<serde_json::Value> = Vec::new();
-            for row in rows {
-                let columns = row.columns();
-                let mut row_obj = serde_json::Map::new();
+    let statements = split_statements(&input.query);
 
-                for col in columns {
-                    let col_name = col.name();
-                    if let Ok(val) = row.try_get::<String, _>(col_name) {
-                        row_obj.insert(col_name.to_string(), serde_json::Value::String(val));
-                    } else if let Ok(val) = row.try_get::<i64, _>(col_name) {
-                        row_obj.insert(col_name.to_string(), serde_json::Value::Number(val.into()));
-                    } else if let Ok(val) = row.try_get::<i32, _>(col_name) {
-                        row_obj.insert(col_name.to_string(), serde_json::Value::Number(val.into()));
-                    } else if let Ok(val) = row.try_get::<bool, _>(col_name) {
-                        row_obj.insert(col_name.to_string(), serde_json::Value::Bool(val));
-                    } else if let Ok(val) = row.try_get::<f64, _>(col_name) {
-                        if let Some(n) = serde_json::Number::from_f64(val) {
-                            row_obj.insert(col_name.to_string(), serde_json::Value::Number(n));
-                        }
-                    } else {
-                        row_obj.insert(col_name.to_string(), serde_json::Value::Null);
-                    }
-                }
-                result_rows.push(serde_json::Value::Object(row_obj));
+    // Single statement: fast path (no splitting overhead)
+    if statements.len() <= 1 {
+        let stmt = statements.first().copied().unwrap_or("");
+        return execute_single_statement(&ctx, &mut conn, stmt).await;
+    }
+
+    // Multiple statements: wrap in a transaction for atomicity
+    ctx.trace_info(format!(
+        "Multi-statement SQL: {} statements detected, executing in transaction",
+        statements.len()
+    ));
+
+    sqlx::query("BEGIN")
+        .execute(&mut conn)
+        .await
+        .map_err(|e| format!("Failed to BEGIN transaction: {e}"))?;
+
+    let mut last_result = None;
+    for (i, stmt) in statements.iter().enumerate() {
+        ctx.trace_info(format!(
+            "Executing statement {}/{}: {}",
+            i + 1,
+            statements.len(),
+            stmt
+        ));
+        match execute_single_statement(&ctx, &mut conn, stmt).await {
+            Ok(result) => last_result = Some(result),
+            Err(e) => {
+                // Rollback on failure (best-effort; connection may be in error state)
+                let _ = sqlx::query("ROLLBACK").execute(&mut conn).await;
+                return Err(e);
             }
+        }
+    }
 
+    sqlx::query("COMMIT")
+        .execute(&mut conn)
+        .await
+        .map_err(|e| format!("Failed to COMMIT transaction: {e}"))?;
+
+    Ok(last_result.unwrap_or_else(|| serde_json::json!({"rows": [], "row_count": 0}).to_string()))
+}
+
+async fn execute_single_statement(
+    ctx: &ActivityContext,
+    conn: &mut sqlx::postgres::PgConnection,
+    stmt: &str,
+) -> Result<String, String> {
+    match sqlx::query(stmt).fetch_all(&mut *conn).await {
+        Ok(rows) => {
+            let result_rows = rows_to_json(rows);
             let result = serde_json::json!({
                 "rows": result_rows,
                 "row_count": result_rows.len()
             });
-
             ctx.trace_info(format!("SQL returned {} rows", result_rows.len()));
             Ok(result.to_string())
         }

--- a/tests/e2e/sql/39_multi_statement_sql.sql
+++ b/tests/e2e/sql/39_multi_statement_sql.sql
@@ -1,0 +1,113 @@
+-- Test: Multi-statement SQL in df.sql()
+-- Verifies that df.sql() can execute multiple semicolon-separated statements
+-- e.g. df.sql('INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)')
+
+DROP TABLE IF EXISTS test_multi_stmt;
+CREATE TABLE test_multi_stmt (id SERIAL, step INT);
+
+CREATE TEMP TABLE _test_state (instance_id TEXT, test_name TEXT);
+
+-- ============================================================
+-- Test 1: Two INSERT statements separated by semicolon
+-- Both should execute and each insert a row.
+-- ============================================================
+
+INSERT INTO _test_state SELECT df.start(
+    df.sql('INSERT INTO test_multi_stmt (step) VALUES (1); INSERT INTO test_multi_stmt (step) VALUES (2)'),
+    'test-multi-stmt-two-inserts'
+), 'two_inserts';
+
+-- ============================================================
+-- Test 2: Three statements with different operations
+-- ============================================================
+
+INSERT INTO _test_state SELECT df.start(
+    df.sql('INSERT INTO test_multi_stmt (step) VALUES (10); INSERT INTO test_multi_stmt (step) VALUES (20); INSERT INTO test_multi_stmt (step) VALUES (30)'),
+    'test-multi-stmt-three-inserts'
+), 'three_inserts';
+
+-- ============================================================
+-- Test 3: Multi-statement SQL with a result piped to next node
+-- The last SELECT's result should be available via |=>
+-- ============================================================
+
+INSERT INTO _test_state SELECT df.start(
+    df.sql('INSERT INTO test_multi_stmt (step) VALUES (100); SELECT 42 AS answer') |=> 'multi_result'
+    ~> df.sql('INSERT INTO test_multi_stmt (step) VALUES ($multi_result::int)'),
+    'test-multi-stmt-result'
+), 'result_pipe';
+
+-- ============================================================
+-- Test 4: Atomicity — if the second statement fails, the first
+-- should be rolled back (multi-statement runs in a transaction)
+-- ============================================================
+
+INSERT INTO _test_state SELECT df.start(
+    df.sql('INSERT INTO test_multi_stmt (step) VALUES (999); INSERT INTO nonexistent_table_xyz VALUES (1)'),
+    'test-multi-stmt-rollback'
+), 'rollback';
+
+-- ============================================================
+-- Verify results
+-- ============================================================
+
+DO $$
+DECLARE
+    rec RECORD;
+    status TEXT;
+    cnt INT;
+    val INT;
+BEGIN
+    -- Wait for all instances (some expected to fail)
+    FOR rec IN SELECT instance_id, test_name FROM _test_state LOOP
+        RAISE NOTICE 'Waiting for [%]: %', rec.test_name, rec.instance_id;
+        SELECT df.wait_for_completion(rec.instance_id, 30) INTO status;
+
+        IF rec.test_name = 'rollback' THEN
+            -- This one should fail
+            IF lower(status) != 'failed' THEN
+                RAISE EXCEPTION 'TEST FAILED [rollback]: expected failed, got %', status;
+            END IF;
+            RAISE NOTICE '[%] failed as expected', rec.test_name;
+        ELSE
+            IF lower(status) != 'completed' THEN
+                RAISE EXCEPTION 'TEST FAILED [%]: expected completed, got %', rec.test_name, status;
+            END IF;
+            RAISE NOTICE '[%] completed', rec.test_name;
+        END IF;
+    END LOOP;
+
+    -- Test 1: Both inserts should have run
+    SELECT COUNT(*) INTO cnt FROM test_multi_stmt WHERE step IN (1, 2);
+    IF cnt != 2 THEN
+        RAISE EXCEPTION 'TEST FAILED [two_inserts]: expected 2 rows with step 1,2 but got %', cnt;
+    END IF;
+
+    -- Test 2: All three inserts should have run
+    SELECT COUNT(*) INTO cnt FROM test_multi_stmt WHERE step IN (10, 20, 30);
+    IF cnt != 3 THEN
+        RAISE EXCEPTION 'TEST FAILED [three_inserts]: expected 3 rows with step 10,20,30 but got %', cnt;
+    END IF;
+
+    -- Test 3: The INSERT (step=100) + the piped result INSERT (step=42)
+    SELECT COUNT(*) INTO cnt FROM test_multi_stmt WHERE step = 100;
+    IF cnt != 1 THEN
+        RAISE EXCEPTION 'TEST FAILED [result_pipe]: expected 1 row with step=100 but got %', cnt;
+    END IF;
+    SELECT COUNT(*) INTO cnt FROM test_multi_stmt WHERE step = 42;
+    IF cnt != 1 THEN
+        RAISE EXCEPTION 'TEST FAILED [result_pipe]: expected 1 row with step=42 (piped from multi-stmt SELECT) but got %', cnt;
+    END IF;
+
+    -- Test 4: The INSERT of step=999 should have been rolled back
+    SELECT COUNT(*) INTO cnt FROM test_multi_stmt WHERE step = 999;
+    IF cnt != 0 THEN
+        RAISE EXCEPTION 'TEST FAILED [rollback]: expected 0 rows with step=999 (should be rolled back) but got %', cnt;
+    END IF;
+
+    RAISE NOTICE 'All multi-statement SQL tests passed';
+END $$;
+
+DROP TABLE _test_state;
+DROP TABLE test_multi_stmt;
+SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## Summary

Adds support for multiple semicolon-separated SQL statements in `df.sql()`. Previously, passing something like `df.sql('INSERT ...; INSERT ...')` would fail with `cannot insert multiple commands into a prepared statement`.

## Changes

**`src/activities/execute_sql.rs`:**
- Added `split_statements()` parser that splits SQL by semicolons while respecting single-quoted strings, dollar-quoted strings (`$$...$$`), and SQL comments
- Extracted `rows_to_json()` helper and `execute_single_statement()` function
- Modified `execute()` to detect multiple statements, execute each sequentially on the same connection, and return the result of the last statement (for `|=>` result piping)

**`tests/e2e/sql/39_multi_statement_sql.sql`:**
- E2E test covering:
  - Two INSERT statements separated by semicolon
  - Three INSERT statements
  - Multi-statement with result piping (`INSERT ...; SELECT 42` piped via `|=>`)

## Testing

All 39 E2E tests pass, no regressions.