### PR TITLE
ci: simplify Docker workflow path triggers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,20 +15,13 @@ name: Docker CI
 on:
   pull_request:
     paths:
+      - '.github/workflows/docker.yml'
       - 'Dockerfile'
       - 'docker-compose.yml'
       - 'docker-entrypoint-initdb.d/**'
       - 'scripts/test-e2e-docker.sh'
-      - 'tests/e2e/sql/**'
-      - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-  push:
-    branches: [main]
-    paths:
-      - 'Dockerfile'
-      - 'docker-compose.yml'
-      - 'docker-entrypoint-initdb.d/**'
   schedule:
     - cron: '0 3 * * *'  # Nightly at 3 AM UTC
   workflow_dispatch:


### PR DESCRIPTION
## Changes

- Remove `src/**` and `tests/e2e/sql/**` from `pull_request` path triggers — these are covered by the main CI workflow and running them here is redundant and expensive.
- Remove the `push` trigger entirely — the PR trigger handles pre-merge validation and the nightly schedule covers post-merge drift.
- Add `.github/workflows/docker.yml` to the path triggers so changes to the workflow file itself are validated in PRs.