### PR TITLE
Add Azure Functions example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  azure_example_smoke:
+    name: Azure Example Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run Azure Functions example smoke checks
+        run: ./examples/azure-functions/scripts/smoke_check.sh
+
   format:
     name: Format Check
     runs-on: ubuntu-latest
@@ -66,7 +80,7 @@ jobs:
   test:
     name: Clippy & Tests (PG${{ matrix.pg_version }})
     runs-on: ubuntu-latest
-    needs: [format, prepare]
+    needs: [azure_example_smoke, format, prepare]
     permissions:
       contents: read
     strategy:

--- a/examples/azure-functions/.gitignore
+++ b/examples/azure-functions/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+local.settings.json
+.azure-functions.env

--- a/examples/azure-functions/README.md
+++ b/examples/azure-functions/README.md
@@ -1,0 +1,165 @@
+# Azure Functions + pg_durable Example
+
+Call an HTTP-triggered Azure Function from a pg_durable workflow using `df.http()`, then store the returned chunks in PostgreSQL.
+
+## Scenario
+
+Token-aware text chunking for ingestion.
+
+Flow:
+
+1. Read pending documents from PostgreSQL.
+2. Call Azure Function over HTTPS.
+3. Receive JSON with chunk metadata.
+4. Insert chunks and mark documents processed.
+
+## Azure Functions in one minute
+
+For this example, you deploy a Python HTTP-triggered Azure Function and call it from `df.http()`.
+
+Reference: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview?pivots=programming-language-python
+
+## Authentication
+
+Uses **Function** auth. `df.http()` sends `x-functions-key` from `.azure-functions.env`.
+
+## Directory layout
+
+- `function-app/chunk_text/`: Python function design contract
+- `sql/`: SQL workflow design contract
+- `scripts/`: setup/deploy script design contract
+
+## Request/Response shape
+
+Request body example:
+
+```json
+{
+  "document_id": 123,
+  "text": "<full document text>",
+  "max_tokens": 400,
+  "overlap_tokens": 40,
+  "language": "en"
+}
+```
+
+Response body example:
+```json
+{
+  "document_id": 123,
+  "model_hint": "cl100k_base",
+  "total_tokens": 1842,
+  "chunks": [
+    {
+      "chunk_index": 0,
+      "text": "...",
+      "token_count": 395
+    }
+  ]
+}
+```
+
+SQL handling:
+
+- Parse `df.http()` envelope (`status`, `ok`, `body`).
+- Cast `body` to JSON/JSONB.
+- Insert one row per chunk.
+- Update source document status.
+
+## What is intentionally out of scope
+
+- Multi-function pipelines
+- RAG orchestration
+- idle-time schedulers and advanced runtime patterns
+- provider-specific secret managers
+
+## Prerequisites
+
+- Azure CLI (`az`) installed
+- Azure Functions Core Tools (`func`) installed
+- Azure login completed (`az login`)
+- PostgreSQL client (`psql`) available (or pgrx `psql` path)
+
+## Quickstart
+
+### 1) Provision Azure Function App
+
+From this directory:
+
+```bash
+chmod +x scripts/*.sh
+
+./scripts/create_function_app.sh -l <location>
+```
+
+What this creates:
+
+- Resource group: `pgd_ex_af_<5 random hex>`
+- Function app: derived from the resource group and sanitized for Azure naming rules
+- Storage account: derived from the same base name and sanitized for Azure naming rules
+
+Location defaults to `eastus`.
+
+### 2) Deploy Python function
+
+```bash
+./scripts/deploy_function.sh
+```
+
+`deploy_function.sh` reads app/resource-group from `.azure-functions.env` and updates it with function base URL and key.
+
+### 3) Prepare PostgreSQL demo schema
+
+```bash
+psql -d postgres -f sql/01_schema.sql
+```
+
+### 4) Configure pg_durable variables
+
+```bash
+./scripts/configure_pg.sh \
+  -d postgres \
+  -h localhost \
+  -p 28817 \
+  -U postgres
+```
+
+`configure_pg.sh` reads base URL and function key from `.azure-functions.env`.
+
+### 5) Start workflow
+
+```bash
+psql -d postgres -f sql/03_start_workflow.sql
+```
+
+If there are no `pending` rows in `demo.af_documents`, the workflow completes as a no-op.
+
+### 6) Verify results
+
+```bash
+psql -d postgres -f sql/04_verify.sql
+```
+
+You should see:
+
+- one processed row in `demo.af_documents`
+- one or more rows in `demo.af_document_chunks`
+
+### 7) Cleanup Azure resources when done
+
+```bash
+./scripts/cleanup_azure.sh -y
+```
+
+This reads the resource group from `.azure-functions.env`.
+You can also pass one explicitly:
+
+```bash
+./scripts/cleanup_azure.sh -g <resource-group> -y
+```
+
+## Operational Notes
+
+- This scenario uses Function auth with `x-functions-key`.
+- Keep function keys out of committed files and shell history where possible.
+- `df.http()` response is an envelope; SQL parses `body` JSON only after checking `ok`/`status`.

--- a/examples/azure-functions/function-app/chunk_text/README.md
+++ b/examples/azure-functions/function-app/chunk_text/README.md
@@ -1,0 +1,84 @@
+# Function Design: chunk_text (Python)
+
+This document defines the function behavior contract and matches the implementation in this directory.
+
+## Purpose
+
+Accept one document payload, split text into token-aware chunks, and return chunk metadata in a deterministic JSON format consumable by pg_durable SQL.
+
+## Trigger
+
+- Azure Functions HTTP trigger
+- Method: `POST`
+- Auth level: Function
+
+## Input
+
+```json
+{
+  "document_id": 123,
+  "text": "<string>",
+  "max_tokens": 400,
+  "overlap_tokens": 40,
+  "language": "en"
+}
+```
+
+Validation rules:
+
+- `document_id`: required integer
+- `text`: required non-empty string
+- `max_tokens`: optional positive integer (default to agreed value)
+- `overlap_tokens`: optional integer >= 0 and < `max_tokens`
+- `language`: optional string
+
+## Output
+
+Success (`200`):
+
+```json
+{
+  "document_id": 123,
+  "model_hint": "cl100k_base",
+  "total_tokens": 1842,
+  "chunks": [
+    {
+      "chunk_index": 0,
+      "text": "...",
+      "token_count": 395
+    }
+  ]
+}
+```
+
+Client error (`400`):
+
+```json
+{
+  "error": "validation_error",
+  "message": "overlap_tokens must be less than max_tokens"
+}
+```
+
+Server error (`500`):
+
+```json
+{
+  "error": "internal_error",
+  "message": "unexpected processing failure"
+}
+```
+
+## Behavior expectations
+
+- Preserve chunk ordering via `chunk_index`.
+- Never return overlapping chunk indexes.
+- Return stable JSON keys to simplify SQL parsing.
+- Include token counts for downstream storage/analytics.
+
+## Non-goals
+
+- Embedding generation
+- classification
+- summarization
+- any outbound calls to other AI services

--- a/examples/azure-functions/function-app/chunk_text/__init__.py
+++ b/examples/azure-functions/function-app/chunk_text/__init__.py
@@ -1,0 +1,125 @@
+import json
+from typing import Any
+
+import azure.functions as func
+
+
+def _json_error(status_code: int, code: str, message: str) -> func.HttpResponse:
+    body = {"error": code, "message": message}
+    return func.HttpResponse(
+        json.dumps(body),
+        status_code=status_code,
+        mimetype="application/json",
+    )
+
+
+def _validate_payload(payload: dict[str, Any]) -> tuple[int, str, int, int, str | None] | None:
+    document_id = payload.get("document_id")
+    text = payload.get("text")
+    max_tokens = payload.get("max_tokens", 400)
+    overlap_tokens = payload.get("overlap_tokens", 40)
+    language = payload.get("language")
+
+    if not isinstance(document_id, int):
+        return None
+    if not isinstance(text, str) or not text.strip():
+        return None
+    if not isinstance(max_tokens, int) or max_tokens <= 0:
+        return None
+    if not isinstance(overlap_tokens, int) or overlap_tokens < 0:
+        return None
+    if overlap_tokens >= max_tokens:
+        return None
+    if language is not None and not isinstance(language, str):
+        return None
+
+    return document_id, text, max_tokens, overlap_tokens, language
+
+
+def _token_ops():
+    """
+    Return (encode_fn, decode_fn, model_hint).
+
+    Uses tiktoken when available, otherwise falls back to word-based tokenization.
+    The fallback is approximate but keeps the function usable in minimal environments.
+    """
+    try:
+        import tiktoken  # type: ignore
+
+        enc = tiktoken.get_encoding("cl100k_base")
+        return enc.encode, enc.decode, "cl100k_base"
+    except Exception:
+
+        def encode_fallback(text: str) -> list[str]:
+            return text.split()
+
+        def decode_fallback(tokens: list[str]) -> str:
+            return " ".join(tokens)
+
+        return encode_fallback, decode_fallback, "whitespace_fallback"
+
+
+def _chunk_tokens(tokens: list[Any], max_tokens: int, overlap_tokens: int) -> list[tuple[int, int]]:
+    windows: list[tuple[int, int]] = []
+    step = max_tokens - overlap_tokens
+    start = 0
+
+    while start < len(tokens):
+        end = min(start + max_tokens, len(tokens))
+        windows.append((start, end))
+        if end >= len(tokens):
+            break
+        start += step
+
+    return windows
+
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        payload = req.get_json()
+    except ValueError:
+        return _json_error(400, "validation_error", "request body must be valid JSON")
+
+    if not isinstance(payload, dict):
+        return _json_error(400, "validation_error", "request body must be a JSON object")
+
+    validated = _validate_payload(payload)
+    if validated is None:
+        return _json_error(
+            400,
+            "validation_error",
+            "payload must include valid document_id, text, max_tokens, and overlap_tokens",
+        )
+
+    document_id, text, max_tokens, overlap_tokens, _language = validated
+
+    try:
+        encode, decode, model_hint = _token_ops()
+        tokens = encode(text)
+        windows = _chunk_tokens(tokens, max_tokens, overlap_tokens)
+
+        chunks = []
+        for i, (start, end) in enumerate(windows):
+            chunk_tokens = tokens[start:end]
+            chunks.append(
+                {
+                    "chunk_index": i,
+                    "text": decode(chunk_tokens),
+                    "token_count": len(chunk_tokens),
+                }
+            )
+
+        result = {
+            "document_id": document_id,
+            "model_hint": model_hint,
+            "total_tokens": len(tokens),
+            "chunks": chunks,
+        }
+
+        return func.HttpResponse(
+            json.dumps(result),
+            status_code=200,
+            mimetype="application/json",
+        )
+    except Exception as exc:
+        return _json_error(500, "internal_error", f"unexpected processing failure: {exc}")

--- a/examples/azure-functions/function-app/chunk_text/function.json
+++ b/examples/azure-functions/function-app/chunk_text/function.json
@@ -1,0 +1,18 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "chunk_text"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/examples/azure-functions/function-app/host.json
+++ b/examples/azure-functions/function-app/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/azure-functions/function-app/requirements.txt
+++ b/examples/azure-functions/function-app/requirements.txt
@@ -1,0 +1,3 @@
+azure-functions>=1.20.0
+# Optional but recommended for closer token accounting with OpenAI-style tokenization
+tiktoken>=0.8.0

--- a/examples/azure-functions/scripts/README.md
+++ b/examples/azure-functions/scripts/README.md
@@ -1,0 +1,53 @@
+# Setup Scripts
+
+This directory contains helper scripts to provision and deploy the Azure Function and configure pg_durable variables.
+
+## Included scripts
+
+- `create_function_app.sh`
+- `deploy_function.sh`
+- `configure_pg.sh`
+- `cleanup_azure.sh`
+
+## Script responsibilities
+
+### create_function_app.sh
+
+- Validate required tools (`az`, optionally `func`)
+- Create resource group (or use existing)
+- Create storage account and function app
+- Generate names automatically from `pgd_ex_af_<5 random hex>`
+- Allow changing only location (`-l`, default `eastus`)
+- Derive function app and storage account names with Azure-safe sanitization
+- Output app name and default URL
+- Write app metadata to `.azure-functions.env`
+
+### deploy_function.sh
+
+- Package/deploy Python function code
+- Sync function definitions
+- Read app/resource-group from `.azure-functions.env` (required)
+- Use function name from `.azure-functions.env` when present, else `chunk_text`
+- Return function endpoint and function key retrieval instructions
+- Write function endpoint and key to `.azure-functions.env`
+
+### configure_pg.sh
+
+- Read endpoint + function key from `.azure-functions.env` by default
+- Allow endpoint + key overrides via `-u` / `-k`
+- Run SQL that sets pg_durable variables for current session/demo
+- Optionally print verification queries
+
+### cleanup_azure.sh
+
+- Read resource group from `.azure-functions.env` by default
+- Allow resource group override via `-g`
+- Delete the resource group and all contained resources
+- Prompt for confirmation unless `-y` is supplied
+
+## Usage notes
+
+- Keep scripts non-interactive where possible (flags/env vars)
+- Fail fast with clear error messages
+- Avoid writing secrets to tracked files
+- Print copy/paste-safe outputs for SQL setup

--- a/examples/azure-functions/scripts/README.md
+++ b/examples/azure-functions/scripts/README.md
@@ -8,6 +8,7 @@ This directory contains helper scripts to provision and deploy the Azure Functio
 - `deploy_function.sh`
 - `configure_pg.sh`
 - `cleanup_azure.sh`
+- `smoke_check.sh`
 
 ## Script responsibilities
 
@@ -45,9 +46,17 @@ This directory contains helper scripts to provision and deploy the Azure Functio
 - Delete the resource group and all contained resources
 - Prompt for confirmation unless `-y` is supplied
 
+### smoke_check.sh
+
+- Run fast, non-cloud validation for this example
+- Check shell syntax for all scripts in this directory
+- Check Python syntax for the function code
+- Validate JSON files used by Azure Functions host/runtime
+
 ## Usage notes
 
 - Keep scripts non-interactive where possible (flags/env vars)
 - Fail fast with clear error messages
 - Avoid writing secrets to tracked files
 - Print copy/paste-safe outputs for SQL setup
+- Use `./scripts/smoke_check.sh` locally before opening a PR

--- a/examples/azure-functions/scripts/cleanup_azure.sh
+++ b/examples/azure-functions/scripts/cleanup_azure.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [-g <resource-group>] [-e <env-file>] [-y]"
+  echo "Default env file: .azure-functions.env"
+  echo "Examples:"
+  echo "  $0 -y"
+  echo "  $0 -g my-resource-group -y"
+}
+
+RESOURCE_GROUP=""
+YES="false"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.azure-functions.env}"
+
+while getopts ":g:e:yh" opt; do
+  case "$opt" in
+    g) RESOURCE_GROUP="$OPTARG" ;;
+    e) ENV_FILE="$OPTARG" ;;
+    y) YES="true" ;;
+    h) usage; exit 0 ;;
+    :) echo "Missing argument for -$OPTARG"; usage; exit 1 ;;
+    \?) echo "Unknown option: -$OPTARG"; usage; exit 1 ;;
+  esac
+done
+
+command -v az >/dev/null 2>&1 || { echo "Error: az CLI not found"; exit 1; }
+
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+if [[ -z "$RESOURCE_GROUP" ]]; then
+  RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-}"
+fi
+
+if [[ -z "$RESOURCE_GROUP" ]]; then
+  echo "Error: resource group not provided and not found in env file."
+  echo "Use -g <resource-group> or set AZURE_RESOURCE_GROUP in $ENV_FILE"
+  exit 1
+fi
+
+if [[ "$YES" != "true" ]]; then
+  echo "This will delete Azure resource group '$RESOURCE_GROUP' and all contained resources."
+  read -r -p "Type the resource group name to continue: " CONFIRM
+  if [[ "$CONFIRM" != "$RESOURCE_GROUP" ]]; then
+    echo "Aborted."
+    exit 1
+  fi
+fi
+
+echo "Deleting resource group: $RESOURCE_GROUP"
+az group delete --name "$RESOURCE_GROUP" --yes --no-wait
+
+echo "Delete request submitted. Azure may take several minutes to complete."
+echo "You can check status with: az group show --name $RESOURCE_GROUP"

--- a/examples/azure-functions/scripts/configure_pg.sh
+++ b/examples/azure-functions/scripts/configure_pg.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [-u <base-url>] [-k <function-key>] [-e <env-file>] [-d <database>] [-h <host>] [-p <port>] [-U <user>]"
+  echo "Example (auto-read .env): $0 -d postgres -h localhost -p 28817 -U postgres"
+  echo "Example (manual override): $0 -u https://my-func.azurewebsites.net -k abc123 -d postgres"
+  echo "Optional: set PSQL_BIN to a specific psql path (for example ~/.pgrx/.../bin/psql)"
+}
+
+BASE_URL=""
+FUNCTION_KEY=""
+DB_NAME="postgres"
+PGHOST_VAL="${PGHOST:-localhost}"
+PGPORT_VAL="${PGPORT:-28817}"
+PGUSER_VAL="${PGUSER:-postgres}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.azure-functions.env}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+BASE_URL="${AZURE_FUNCTION_BASE_URL:-$BASE_URL}"
+FUNCTION_KEY="${AZURE_FUNCTION_KEY:-$FUNCTION_KEY}"
+
+while getopts ":u:k:e:d:h:p:U:?" opt; do
+  case "$opt" in
+    u) BASE_URL="$OPTARG" ;;
+    k) FUNCTION_KEY="$OPTARG" ;;
+    e) ENV_FILE="$OPTARG"
+       if [[ -f "$ENV_FILE" ]]; then
+         # shellcheck disable=SC1090
+         source "$ENV_FILE"
+         BASE_URL="${AZURE_FUNCTION_BASE_URL:-$BASE_URL}"
+         FUNCTION_KEY="${AZURE_FUNCTION_KEY:-$FUNCTION_KEY}"
+       else
+         echo "Error: env file not found: $ENV_FILE"
+         exit 1
+       fi
+       ;;
+    d) DB_NAME="$OPTARG" ;;
+    h) PGHOST_VAL="$OPTARG" ;;
+    p) PGPORT_VAL="$OPTARG" ;;
+    U) PGUSER_VAL="$OPTARG" ;;
+    ?) usage; exit 0 ;;
+    :) echo "Missing argument for -$OPTARG"; usage; exit 1 ;;
+    \?) echo "Unknown option: -$OPTARG"; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$BASE_URL" || -z "$FUNCTION_KEY" ]]; then
+  echo "Error: missing base URL or function key."
+  if [[ -f "$ENV_FILE" ]]; then
+    echo "Checked env file: $ENV_FILE"
+  else
+    echo "Env file not found: $ENV_FILE"
+  fi
+  echo "Run deploy_function.sh first, or pass -u and -k explicitly."
+  usage
+  exit 1
+fi
+
+resolve_psql() {
+  if [[ -n "${PSQL_BIN:-}" ]]; then
+    if [[ -x "$PSQL_BIN" ]]; then
+      echo "$PSQL_BIN"
+      return 0
+    fi
+    echo "Error: PSQL_BIN is set but not executable: $PSQL_BIN" >&2
+    return 1
+  fi
+
+  if command -v psql >/dev/null 2>&1; then
+    command -v psql
+    return 0
+  fi
+
+  local pgrx_psql=""
+  pgrx_psql="$(ls -1d "$HOME"/.pgrx/*/pgrx-install/bin/psql 2>/dev/null | head -n 1 || true)"
+  if [[ -n "$pgrx_psql" && -x "$pgrx_psql" ]]; then
+    echo "$pgrx_psql"
+    return 0
+  fi
+
+  echo "Error: psql not found on PATH and no pgrx psql discovered." >&2
+  echo "Set PSQL_BIN=/home/vscode/.pgrx/<version>/pgrx-install/bin/psql and retry." >&2
+  return 1
+}
+
+PSQL_CMD="$(resolve_psql)"
+
+export PGHOST="$PGHOST_VAL"
+export PGPORT="$PGPORT_VAL"
+export PGUSER="$PGUSER_VAL"
+
+export AZURE_FUNCTION_BASE_URL="$BASE_URL"
+export AZURE_FUNCTION_KEY="$FUNCTION_KEY"
+
+"$PSQL_CMD" -d "$DB_NAME" -f "$ROOT_DIR/sql/02_set_vars.sql"
+
+echo "pg_durable variables configured for the current SQL session context (psql: $PSQL_CMD)."

--- a/examples/azure-functions/scripts/create_function_app.sh
+++ b/examples/azure-functions/scripts/create_function_app.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [-l <location>]"
+  echo "  -l (optional):   Azure location (default: eastus)"
+  echo ""
+  echo "Notes:"
+  echo "  - Function App name is derived from resource group and sanitized for Azure"
+  echo "    (lowercase, underscores -> hyphens, invalid chars removed)."
+  echo ""
+  echo "Examples:"
+  echo "  $0"
+  echo "  $0 -l westus2"
+}
+
+LOCATION="eastus"
+
+while getopts ":l:h" opt; do
+  case "$opt" in
+    l) LOCATION="$OPTARG" ;;
+    h) usage; exit 0 ;;
+    :) echo "Missing argument for -$OPTARG"; usage; exit 1 ;;
+    \?) echo "Unknown option: -$OPTARG"; usage; exit 1 ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+if [[ $# -gt 0 ]]; then
+  usage
+  exit 1
+fi
+
+RAND5="$(openssl rand -hex 3 | cut -c1-5)"
+BASE_NAME="pgd_ex_af_${RAND5}"
+
+RG="$BASE_NAME"
+APP_NAME="$(echo "$RG" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/_+/-/g' \
+  | sed -E 's/[^a-z0-9-]//g' \
+  | sed -E 's/^-+//; s/-+$//; s/-{2,}/-/g')"
+
+# Azure Function App names must be globally unique and <= 60 chars.
+if [[ ${#APP_NAME} -gt 60 ]]; then
+  APP_NAME="${APP_NAME:0:60}"
+  APP_NAME="$(echo "$APP_NAME" | sed -E 's/-+$//')"
+fi
+if [[ -z "$APP_NAME" ]]; then
+  echo "Error: derived Function App name is empty after sanitization."
+  echo "Choose a different base name with alphanumeric characters."
+  exit 1
+fi
+
+command -v az >/dev/null 2>&1 || { echo "Error: az CLI not found"; exit 1; }
+
+# Derive storage account name from resource group by stripping non-alnum.
+# Azure Storage names must be lowercase letters/numbers, 3-24 chars.
+STORAGE_NAME="$(echo "$RG" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')"
+if [[ ${#STORAGE_NAME} -lt 3 ]]; then
+  STORAGE_NAME="${STORAGE_NAME}af0"
+fi
+if [[ ${#STORAGE_NAME} -gt 24 ]]; then
+  STORAGE_NAME="${STORAGE_NAME:0:24}"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.azure-functions.env}"
+
+upsert_env_var() {
+  local key="$1"
+  local value="$2"
+  touch "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  if grep -q "^${key}=" "$ENV_FILE"; then
+    sed -i "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+  fi
+}
+
+unset_env_var() {
+  local key="$1"
+  touch "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  if grep -q "^${key}=" "$ENV_FILE"; then
+    sed -i "/^${key}=/d" "$ENV_FILE"
+  fi
+}
+
+run_status() {
+  local status="$1"
+  upsert_env_var "AZURE_LAST_CREATE_STATUS" "$status"
+  upsert_env_var "AZURE_LAST_CREATE_AT" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+
+run_status "started"
+upsert_env_var "AZURE_REQUESTED_BASE_NAME" "$BASE_NAME"
+
+# Clear stale values that should not be reused across create runs.
+unset_env_var "AZURE_RESOURCE_GROUP"
+unset_env_var "AZURE_LOCATION"
+unset_env_var "AZURE_FUNCTION_APP_NAME"
+unset_env_var "AZURE_STORAGE_ACCOUNT_NAME"
+unset_env_var "AZURE_FUNCTION_BASE_URL"
+unset_env_var "AZURE_FUNCTION_NAME"
+unset_env_var "AZURE_FUNCTION_KEY"
+
+# Persist derived names immediately so partial progress is visible on failure.
+upsert_env_var "AZURE_RESOURCE_GROUP" "$RG"
+upsert_env_var "AZURE_LOCATION" "$LOCATION"
+upsert_env_var "AZURE_FUNCTION_APP_NAME" "$APP_NAME"
+upsert_env_var "AZURE_STORAGE_ACCOUNT_NAME" "$STORAGE_NAME"
+
+echo "Creating/ensuring resource group: $RG"
+az group create --name "$RG" --location "$LOCATION" --output table >/dev/null
+upsert_env_var "AZURE_RESOURCE_GROUP_CREATED" "true"
+
+echo "Creating storage account: $STORAGE_NAME"
+az storage account create \
+  --name "$STORAGE_NAME" \
+  --location "$LOCATION" \
+  --resource-group "$RG" \
+  --sku Standard_LRS \
+  --kind StorageV2 \
+  --min-tls-version TLS1_2 \
+  --https-only true \
+  --allow-blob-public-access false \
+  --output table >/dev/null
+upsert_env_var "AZURE_STORAGE_ACCOUNT_CREATED" "true"
+
+echo "Creating Function App: $APP_NAME"
+az functionapp create \
+  --name "$APP_NAME" \
+  --resource-group "$RG" \
+  --storage-account "$STORAGE_NAME" \
+  --consumption-plan-location "$LOCATION" \
+  --runtime python \
+  --runtime-version 3.11 \
+  --functions-version 4 \
+  --os-type Linux \
+  --output table >/dev/null
+upsert_env_var "AZURE_FUNCTION_APP_CREATED" "true"
+
+APP_URL="https://${APP_NAME}.azurewebsites.net"
+
+if [[ "$APP_NAME" != "$RG" ]]; then
+  echo "Note: Function App name was sanitized from resource group name for Azure compatibility."
+fi
+
+upsert_env_var "AZURE_RESOURCE_GROUP" "$RG"
+upsert_env_var "AZURE_LOCATION" "$LOCATION"
+upsert_env_var "AZURE_FUNCTION_APP_NAME" "$APP_NAME"
+upsert_env_var "AZURE_STORAGE_ACCOUNT_NAME" "$STORAGE_NAME"
+upsert_env_var "AZURE_FUNCTION_BASE_URL" "$APP_URL"
+run_status "completed"
+
+echo
+echo "Function App created."
+echo "App URL: $APP_URL"
+echo "Resource group: $RG"
+echo "Function app:   $APP_NAME"
+echo "Storage acct:   $STORAGE_NAME"
+echo "Wrote app settings to: $ENV_FILE"
+echo "Next: run deploy_function.sh to publish code."

--- a/examples/azure-functions/scripts/deploy_function.sh
+++ b/examples/azure-functions/scripts/deploy_function.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0"
+  echo "  app/resource-group are read from .azure-functions.env"
+  echo "  function name defaults to AZURE_FUNCTION_NAME, else chunk_text"
+}
+
+APP_NAME=""
+RESOURCE_GROUP=""
+FUNCTION_NAME="chunk_text"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -gt 0 ]]; then
+  usage
+  exit 1
+fi
+
+command -v func >/dev/null 2>&1 || { echo "Error: Azure Functions Core Tools (func) not found"; exit 1; }
+command -v az >/dev/null 2>&1 || { echo "Error: az CLI not found"; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FUNC_APP_DIR="$ROOT_DIR/function-app"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.azure-functions.env}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+APP_NAME="${AZURE_FUNCTION_APP_NAME:-}"
+RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-}"
+
+if [[ -z "$FUNCTION_NAME" && -n "${AZURE_FUNCTION_NAME:-}" ]]; then
+  FUNCTION_NAME="$AZURE_FUNCTION_NAME"
+fi
+
+if [[ -z "$FUNCTION_NAME" ]]; then
+  FUNCTION_NAME="chunk_text"
+fi
+
+if [[ -z "$APP_NAME" ]]; then
+  echo "Error: AZURE_FUNCTION_APP_NAME not found in .azure-functions.env"
+  usage
+  exit 1
+fi
+
+if [[ -z "$RESOURCE_GROUP" ]]; then
+  echo "Error: AZURE_RESOURCE_GROUP not found in .azure-functions.env"
+  usage
+  exit 1
+fi
+
+upsert_env_var() {
+  local key="$1"
+  local value="$2"
+  touch "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  if grep -q "^${key}=" "$ENV_FILE"; then
+    sed -i "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+  fi
+}
+
+unset_env_var() {
+  local key="$1"
+  touch "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  if grep -q "^${key}=" "$ENV_FILE"; then
+    sed -i "/^${key}=/d" "$ENV_FILE"
+  fi
+}
+
+run_status() {
+  local status="$1"
+  upsert_env_var "AZURE_LAST_DEPLOY_STATUS" "$status"
+  upsert_env_var "AZURE_LAST_DEPLOY_AT" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+
+run_status "started"
+upsert_env_var "AZURE_FUNCTION_NAME" "$FUNCTION_NAME"
+unset_env_var "AZURE_FUNCTION_KEY"
+
+if [[ ! -d "$FUNC_APP_DIR" ]]; then
+  echo "Error: function-app directory not found at $FUNC_APP_DIR"
+  exit 1
+fi
+
+pushd "$FUNC_APP_DIR" >/dev/null
+
+echo "Publishing function app code to: $APP_NAME"
+func azure functionapp publish "$APP_NAME" --python
+upsert_env_var "AZURE_FUNCTION_PUBLISHED" "true"
+
+popd >/dev/null
+
+echo
+echo "Deployment completed."
+echo "Function endpoint: https://${APP_NAME}.azurewebsites.net/api/${FUNCTION_NAME}"
+echo
+echo "Fetching function key..."
+if ! az functionapp function show \
+  --name "$APP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --function-name "$FUNCTION_NAME" \
+  --output none >/dev/null 2>&1; then
+  echo "Error: Function '$FUNCTION_NAME' was not found in app '$APP_NAME' (resource group '$RESOURCE_GROUP')."
+  echo "Tip: wait ~30-60s after publish and retry, or confirm function name."
+  exit 1
+fi
+
+FUNCTION_KEY="$(az functionapp function keys list \
+  --name "$APP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --function-name "$FUNCTION_NAME" \
+  --query default \
+  -o tsv)"
+
+if [[ -z "$FUNCTION_KEY" ]]; then
+  echo "Error: Function key retrieval returned empty for '$FUNCTION_NAME'."
+  echo "Try again in 30-60s; key creation can lag immediately after deployment."
+  exit 1
+fi
+
+BASE_URL="https://${APP_NAME}.azurewebsites.net"
+upsert_env_var "AZURE_RESOURCE_GROUP" "$RESOURCE_GROUP"
+upsert_env_var "AZURE_FUNCTION_APP_NAME" "$APP_NAME"
+upsert_env_var "AZURE_FUNCTION_NAME" "$FUNCTION_NAME"
+upsert_env_var "AZURE_FUNCTION_BASE_URL" "$BASE_URL"
+upsert_env_var "AZURE_FUNCTION_KEY" "$FUNCTION_KEY"
+run_status "completed"
+
+echo "Function key retrieved."
+echo "Use this in SQL vars setup:"
+echo "  resource_group          = ${RESOURCE_GROUP}"
+echo "  azure_function_base_url = ${BASE_URL}"
+echo "  azure_function_key      = ${FUNCTION_KEY}"
+echo
+echo "Saved deployment settings to: $ENV_FILE"

--- a/examples/azure-functions/scripts/smoke_check.sh
+++ b/examples/azure-functions/scripts/smoke_check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$EXAMPLE_DIR"
+
+echo "[smoke] Checking shell script syntax"
+bash -n scripts/*.sh
+
+echo "[smoke] Checking Python syntax"
+python3 -m py_compile function-app/chunk_text/__init__.py
+
+echo "[smoke] Validating JSON files"
+python3 -m json.tool function-app/host.json > /dev/null
+python3 -m json.tool function-app/chunk_text/function.json > /dev/null
+
+echo "[smoke] Azure Functions example smoke checks passed"

--- a/examples/azure-functions/sql/01_schema.sql
+++ b/examples/azure-functions/sql/01_schema.sql
@@ -1,0 +1,36 @@
+-- Phase 2 example schema for Azure Functions + pg_durable
+
+CREATE EXTENSION IF NOT EXISTS pg_durable;
+
+CREATE SCHEMA IF NOT EXISTS demo;
+
+CREATE TABLE IF NOT EXISTS demo.af_documents (
+    id BIGSERIAL PRIMARY KEY,
+    content TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    total_tokens INT,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS demo.af_document_chunks (
+    id BIGSERIAL PRIMARY KEY,
+    document_id BIGINT NOT NULL REFERENCES demo.af_documents(id) ON DELETE CASCADE,
+    chunk_index INT NOT NULL,
+    chunk_text TEXT NOT NULL,
+    token_count INT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (document_id, chunk_index)
+);
+
+TRUNCATE TABLE demo.af_document_chunks, demo.af_documents RESTART IDENTITY;
+
+INSERT INTO demo.af_documents (content)
+VALUES (
+    'pg_durable runs workflows durably inside PostgreSQL. This sample shows how to call an HTTP-triggered Azure Function for token-aware chunking and persist the returned chunks in SQL tables for downstream processing.'
+);
+
+SELECT id, status, left(content, 80) AS preview
+FROM demo.af_documents
+ORDER BY id;

--- a/examples/azure-functions/sql/02_set_vars.sql
+++ b/examples/azure-functions/sql/02_set_vars.sql
@@ -1,0 +1,35 @@
+-- Set per-session variables before running the workflow.
+-- Preferred path: source .azure-functions.env then run this script with psql.
+--
+-- Example:
+--   set -a
+--   source .azure-functions.env
+--   set +a
+--   psql -d postgres -f sql/02_set_vars.sql
+
+\getenv azure_function_base_url AZURE_FUNCTION_BASE_URL
+\getenv azure_function_key AZURE_FUNCTION_KEY
+
+DO $$
+DECLARE
+    v_base_url TEXT := :'azure_function_base_url';
+    v_function_key TEXT := :'azure_function_key';
+BEGIN
+    IF COALESCE(length(trim(v_base_url)), 0) = 0 THEN
+        RAISE EXCEPTION 'AZURE_FUNCTION_BASE_URL is not set. Source .azure-functions.env first.';
+    END IF;
+
+    IF COALESCE(length(trim(v_function_key)), 0) = 0 THEN
+        RAISE EXCEPTION 'AZURE_FUNCTION_KEY is not set. Source .azure-functions.env first.';
+    END IF;
+END $$;
+
+SELECT df.setvar('azure_function_base_url', :'azure_function_base_url');
+SELECT df.setvar('azure_function_key', :'azure_function_key');
+
+SELECT df.getvar('azure_function_base_url') AS azure_function_base_url;
+SELECT CASE
+    WHEN df.getvar('azure_function_key') IS NULL THEN 'missing'
+    WHEN length(df.getvar('azure_function_key')) > 0 THEN 'configured'
+    ELSE 'empty'
+END AS azure_function_key_state;

--- a/examples/azure-functions/sql/03_start_workflow.sql
+++ b/examples/azure-functions/sql/03_start_workflow.sql
@@ -1,0 +1,65 @@
+-- Start one workflow instance that:
+-- 1) Reads one pending document
+-- 2) Calls Azure Function via df.http()
+-- 3) Stores returned chunks
+-- 4) Marks document processed/failed
+
+SELECT df.start(
+    $$SELECT COALESCE(
+          (
+            SELECT jsonb_build_object('id', id, 'content', content)::text
+            FROM demo.af_documents
+            WHERE status = 'pending'
+            ORDER BY id
+            LIMIT 1
+          ),
+          'null'
+      )$$ |=> 'doc'
+    ~> df.if(
+      $$SELECT (($doc)::jsonb) IS NOT NULL$$,
+      (
+        ($$SELECT jsonb_build_object(
+              'document_id', ((($doc)::jsonb->>'id')::bigint),
+              'text', (($doc)::jsonb->>'content'),
+            'max_tokens', 20,
+            'overlap_tokens', 5,
+              'language', 'en'
+          )::text$$ |=> 'requestbody')
+        ~> (df.http(
+            '{azure_function_base_url}/api/chunk_text',
+            'POST',
+            '$requestbody',
+            ('{"Content-Type":"application/json","x-functions-key":"{azure_function_key}"}')::jsonb,
+            60
+        ) |=> 'chunkresponse')
+        ~> df.if(
+            $$SELECT ($chunkresponse::jsonb->>'ok')::boolean$$,
+            (
+                $$WITH payload AS (
+                      SELECT (($chunkresponse::jsonb->>'body')::jsonb) AS body_json
+                  )
+                  INSERT INTO demo.af_document_chunks (document_id, chunk_index, chunk_text, token_count)
+                  SELECT
+                      (payload.body_json->>'document_id')::bigint,
+                      (c->>'chunk_index')::int,
+                      c->>'text',
+                      (c->>'token_count')::int
+                  FROM payload, jsonb_array_elements(payload.body_json->'chunks') AS c$$
+                ~> $$UPDATE demo.af_documents
+                    SET status = 'processed',
+                        processed_at = now(),
+                        total_tokens = ((($chunkresponse::jsonb->>'body')::jsonb->>'total_tokens')::int),
+                        last_error = NULL
+                    WHERE id = ((($doc)::jsonb->>'id')::bigint)$$
+            ),
+            $$UPDATE demo.af_documents
+              SET status = 'failed',
+                  processed_at = now(),
+                  last_error = 'HTTP ' || ($chunkresponse::jsonb->>'status') || ': ' || coalesce(($chunkresponse::jsonb->>'body'), '')
+              WHERE id = ((($doc)::jsonb->>'id')::bigint)$$
+        )
+      ),
+      $$SELECT 'no pending documents'$$
+    ),
+    'azure-functions-chunk-text'
+) AS instance_id;

--- a/examples/azure-functions/sql/04_verify.sql
+++ b/examples/azure-functions/sql/04_verify.sql
@@ -1,0 +1,34 @@
+-- Poll for completion (up to ~30 seconds)
+DO $$
+DECLARE
+    inst_id TEXT;
+    st TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT id INTO inst_id
+    FROM df.instances
+    WHERE label = 'azure-functions-chunk-text'
+    ORDER BY created_at DESC
+    LIMIT 1;
+
+    IF inst_id IS NULL THEN
+        RAISE EXCEPTION 'No instance found with label azure-functions-chunk-text';
+    END IF;
+
+    LOOP
+        SELECT s INTO st FROM df.status(inst_id) AS s;
+        EXIT WHEN lower(st) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    RAISE NOTICE 'Instance % status: % (attempts=%)', inst_id, st, attempts;
+END $$;
+
+SELECT id, status, total_tokens, processed_at, left(coalesce(last_error, ''), 160) AS last_error
+FROM demo.af_documents
+ORDER BY id;
+
+SELECT document_id, chunk_index, token_count, left(chunk_text, 100) AS preview
+FROM demo.af_document_chunks
+ORDER BY document_id, chunk_index;

--- a/examples/azure-functions/sql/README.md
+++ b/examples/azure-functions/sql/README.md
@@ -1,0 +1,43 @@
+# SQL Files for Azure Functions Scenario
+
+This directory contains runnable SQL scripts for calling Azure Functions from pg_durable.
+
+## Tables used
+
+- `demo.af_documents`: source rows waiting to be chunked
+- `demo.af_document_chunks`: output rows, one per chunk
+
+## Workflow shape
+
+1. Select pending document rows.
+2. Build JSON request payload for one document.
+3. Call Azure Function via `df.http()`.
+4. Validate HTTP envelope (`ok`, `status`).
+5. Parse response body JSON and insert chunk rows.
+6. Mark source document as processed.
+
+## Variable usage
+
+Set before `df.start()`:
+
+- `azure_function_base_url`
+- `azure_function_key`
+
+Use variable substitution in workflow SQL where applicable.
+
+## Error handling
+
+- Handle 4xx in SQL branch logic (bad payload, auth issues).
+- Allow 5xx/network failures to fail activity and rely on durable retry behavior.
+- Persist concise diagnostics in an audit/log table if needed.
+
+## SQL files
+
+- `01_schema.sql`: demo schema and test data
+- `02_set_vars.sql`: endpoint and key setup
+- `03_start_workflow.sql`: workflow definition and kickoff
+- `04_verify.sql`: result inspection queries
+
+## Notes
+
+The implementation should explicitly parse `df.http()` response envelope fields before reading response body content.


### PR DESCRIPTION
## Summary
Add a complete Azure Functions example under examples/azure-functions, including function app code, SQL workflow scripts, and setup/deploy helpers.

Add a fast, non-cloud smoke-check layer for the Azure Functions example and wire it into CI.

## Testing
- Verified scripts and SQL flow locally during development
- Ran ./examples/azure-functions/scripts/smoke_check.sh locally
- Added Azure Example Smoke CI job in .github/workflows/ci.yml