### PR TITLE
Harden CI: disk cleanup, cache split, and actions/cache v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
@@ -95,6 +96,15 @@ jobs:
           submodules: true
           token: ${{ secrets.GH_PAT }}
 
+      - name: Free disk space and show usage
+        run: |
+          echo "Disk usage before cleanup"
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup
+          docker system prune -af || true
+          echo "Disk usage after cleanup"
+          df -h
+
       - name: Install Rust nightly
         run: |
           rustup toolchain install nightly --profile minimal --component clippy
@@ -116,20 +126,26 @@ jobs:
               libxslt1-dev \
               libicu-dev
 
-      - name: Cache cargo dependencies
-        uses: actions/cache@v4
+      - name: Cache cargo-pgrx tool
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin/cargo-pgrx
+          key: ${{ runner.os }}-cargo-pgrx-0.16.1-v1
+
+      - name: Cache Cargo dependency sources
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.cargo/bin/cargo-pgrx
-            target
-          key: ${{ runner.os }}-cargo-pg${{ matrix.pg_version }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-deps-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-pg${{ matrix.pg_version }}-
+            ${{ runner.os }}-cargo-deps-
 
       - name: Cache PostgreSQL build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pgrx/config.toml

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -53,7 +53,7 @@ jobs:
               libicu-dev
 
       - name: Cache cargo-pgrx tool
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/.crates2.json
@@ -61,7 +61,7 @@ jobs:
           key: ${{ runner.os }}-copilot-setup-cargo-pgrx-0.16.1-v1
 
       - name: Cache Cargo dependency sources
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -71,7 +71,7 @@ jobs:
             ${{ runner.os }}-copilot-setup-cargo-deps-rust-stable-
 
       - name: Cache pgrx PostgreSQL downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pgrx/config.toml


### PR DESCRIPTION
## Summary
- Opt into Node 24 for JavaScript actions via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.
- Split Cargo caching into a `cargo-pgrx` tool cache and a Cargo source cache.
- Add an early disk cleanup step in the test job to reduce runner `No space left on device` failures.
- Upgrade `actions/cache` from v4 to v5 across both CI and copilot-setup-steps workflows, fixing Node.js deprecation warnings (`punycode`, `url.parse()`).

## Why
Recent scheduled and PR CI runs intermittently failed with runner-level `No space left on device` errors. These changes reduce disk pressure and cache footprint while proactively handling the Node 20 deprecation path. The `actions/cache@v4` action emits deprecation warnings on Node 20+ runners.

## Scope
- `.github/workflows/ci.yml` — disk cleanup, cache restructuring, `actions/cache` v5, Node 24 opt-in.
- `.github/workflows/copilot-setup-steps.yml` — `actions/cache` v5.
- No extension runtime behavior changes.