### PR TITLE
feat: Named Results v2 — dot-notation, null-safe, row-set expansion, df.if_rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Pre-1.0 note: while `pg_durable` is in major version `0`, minor releases may inc
 - Fix: `is_truthy` now correctly treats "false", "no", and "f" as falsy (#57)
 - Docs: add "Debugging Failed Workflows" section to User Guide (#71)
 - New: Azure Functions integration example (#69)
+- Named result substitution now supports dot-notation for column access (`$name.col`), null-safe variants (`$name?`, `$name.col?`), and row-set expansion (`$name.*`). Referencing a named result that returned no rows or a NULL value now fails the orchestration by default; append `?` to substitute an empty string instead.
+- New DSL function `df.if_rows()`: branches on whether a named result returned any rows, without executing a SQL condition query.
 
 ## v0.1.1 (Released)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,6 +2336,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ pg_test = []
 [dependencies]
 pgrx = "=0.16.1"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 
 # duroxide integration

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -238,6 +238,49 @@ SELECT df.start(
 );
 ```
 
+#### Dot-Notation (`$name.column`)
+
+Access specific columns by name instead of just the first column:
+
+```sql
+SELECT df.start(
+    $$SELECT 42 AS id, 'Alice' AS name$$ |=> 'user'
+    ~> $$SELECT $user.id, $user.name$$          -- access specific columns
+);
+```
+
+#### Null-Safe Accessor (`$name?`, `$name.column?`)
+
+By default, referencing a result with no rows or a NULL value **fails** the instance with a clear error. Use the `?` suffix to substitute `NULL` instead:
+
+```sql
+SELECT df.start(
+    $$SELECT NULL::text AS val$$ |=> 'x'
+    ~> $$SELECT COALESCE($x.val?, 'fallback')$$   -- NULL → 'fallback'
+);
+```
+
+| Pattern | No rows | NULL value |
+|---------|---------|------------|
+| `$name` | **Fails** | **Fails** |
+| `$name.col` | **Fails** | **Fails** |
+| `$name?` | → `NULL` | → `NULL` |
+| `$name.col?` | → `NULL` | → `NULL` |
+
+#### Row-Set Expansion (`$name.*`)
+
+Expand a multi-row result into an inline `VALUES` subquery:
+
+```sql
+SELECT df.start(
+    $$SELECT id, name FROM users WHERE active$$ |=> 'batch'
+    ~> $$SELECT count(*) FROM $batch.*$$                   -- FROM expansion
+);
+```
+
+This is useful for passing row sets between steps. The expansion generates SQL like `(VALUES (1,'Alice'), (2,'Bob')) AS batch(id, name)`.
+
+
 ### Cron Expression Format
 
 ```
@@ -461,6 +504,22 @@ SELECT df.start(
         'INSERT INTO playground.logs (msg) VALUES (''Queue normal'')'
     ),
     'check-task-load-func'
+);
+```
+
+#### Branching on Row Count with `df.if_rows`
+
+Use `df.if_rows()` to branch based on whether a named result has rows — without executing an extra SQL query:
+
+```sql
+SELECT df.start(
+    $$SELECT id FROM orders WHERE status = 'pending'$$ |=> 'pending'
+    ~> df.if_rows(
+        'pending',                                               -- result name
+        $$UPDATE orders SET status = 'processing' WHERE id = $pending.id$$,  -- then
+        $$INSERT INTO logs (msg) VALUES ('No pending orders')$$               -- else
+    ),
+    'check-pending'
 );
 ```
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -67,6 +67,16 @@ df.as('SELECT id FROM users LIMIT 1', 'user_id')
 'SELECT id FROM users LIMIT 1' |=> 'user_id'  -- operator form
 ```
 
+**Substitution patterns** available on named results:
+
+| Pattern | Behavior | On no rows | On NULL |
+|---------|----------|------------|---------|
+| `$name` | First column of first row | Error | Error |
+| `$name.column` | Specific column of first row | Error | Error |
+| `$name?` | Null-safe scalar | → `NULL` | → `NULL` |
+| `$name.column?` | Null-safe column | → `NULL` | → `NULL` |
+| `$name.*` | Row-set expansion (inline VALUES) | Empty relation | N/A |
+
 ---
 
 ### df.join(a, b) / `&` operator
@@ -130,6 +140,22 @@ Conditional execution.
 ```sql
 df.if('SELECT count(*) > 0 FROM q', 'SELECT ''yes''', 'SELECT ''no''')
 'SELECT true' ?> 'SELECT ''yes''' !> 'SELECT ''no'''  -- operator form
+```
+
+---
+
+### df.if_rows(result_name, then, else)
+
+Branches based on whether a named result has any rows. Unlike `df.if()`, no SQL query is executed — the check is done in-memory on the stored result.
+
+| Parameter | Type | Auto-wrap | Description |
+|-----------|------|-----------|-------------|
+| `result_name` | TEXT | ❌ Literal | Name of a previously stored result (no `$` prefix) |
+| `then` | TEXT | ✅ Auto-wrap | Execute if result has rows |
+| `else` | TEXT | ✅ Auto-wrap | Execute if result has zero rows |
+
+```sql
+df.if_rows('data', 'SELECT $data.id', 'SELECT ''no data''')
 ```
 
 ---

--- a/docs/named-results-v2.md
+++ b/docs/named-results-v2.md
@@ -1,0 +1,383 @@
+# Named Result Improvements — Dot-Notation, Row Sets, Null Safety
+
+## Summary
+
+Named results (`|=>`) previously only exposed the first column of the first row via `$name` substitution. This made multi-column results awkward, null handling error-prone, and small row sets impossible to pass between nodes without extra SQL gymnastics.
+
+Four features were introduced to address these problems:
+
+| Feature | Syntax | Purpose |
+|---------|--------|---------|
+| **Dot-notation** | `$name.column` | Access any column from the first row |
+| **Row-set expansion** | `$name.*` | Expand all rows as an inline `VALUES` subquery |
+| **`df.if_rows`** | `df.if_rows('name', then, else)` | Branch on whether a named result has rows |
+| **Null-safe accessor** | `$name?`, `$name.col?` | Return SQL `NULL` instead of failing the instance |
+
+All four are backward compatible. Bare `$name` retains its existing first-col-first-row behavior.
+
+Additionally, two bugs were fixed: no-rows substitution previously produced raw JSON garbage, and NULL columns silently injected unquoted `null` text (see [Bug Fixes](#bug-fixes)).
+
+---
+
+## Dot-Notation (`$name.column`)
+
+### Problem: multi-column results required manual jsonb packing
+
+Previously, to use multiple columns from a query result, users had to manually serialize into jsonb and deserialize with cast operators:
+
+```sql
+-- Node 1: must manually pack columns into jsonb to access more than one
+$$SELECT jsonb_build_object('id', id, 'content', content)::text
+  FROM documents WHERE status = 'pending' LIMIT 1
+$$ |=> 'doc'
+
+-- Node 2: must extract each column with jsonb operators + casts
+~> $$UPDATE documents
+    SET status = 'processing',
+        summary = 'Processing: ' || ($doc::jsonb->>'content')
+    WHERE id = ($doc::jsonb->>'id')::bigint$$
+```
+
+The user had to enumerate columns twice (once in the SELECT, once in `jsonb_build_object`), and every downstream reference required `($doc::jsonb->>'field')` with explicit type casts.
+
+On top of that, bare `$name` on multi-column results picked a non-deterministic column — `serde_json::Map::iter().next()` does not guarantee insertion order, so `SELECT id, content FROM ...` could substitute `content` instead of `id`.
+
+### Solution
+
+`$name.column` accesses any named column from the first row of a named result:
+
+```sql
+$$SELECT id, content FROM documents
+    WHERE status = 'pending' LIMIT 1
+$$ |=> 'doc'
+
+~> $$UPDATE documents
+    SET status = 'processing',
+        summary = 'Processing: ' || $doc.content
+    WHERE id = $doc.id$$
+```
+
+### Semantics
+
+- `$doc.id` looks up the column named `id` in the first row of result `doc`
+- String values are SQL-quoted: `$doc.name` → `'Alice'`
+- Numeric/boolean values are unquoted: `$doc.id` → `42`
+- Works in both SQL (quoted) and raw contexts (HTTP bodies/headers — unquoted)
+- **Strict by default**: fails the instance if column is NULL or result has no rows (see [Null-Safe Accessor](#null-safe-accessor--suffix) for opt-out)
+- Non-existent column name: left as-is in the query, so PostgreSQL reports a clear SQL error
+- **Deterministic**: `$doc.id` always looks up by name, not iteration order — fixing the non-deterministic column problem with bare `$doc`
+
+### Implementation
+
+In `substitute_all_with_options`, before processing bare `$name` patterns, scan for `$name.column` patterns. For each named result, parse the stored JSON, extract the first row, and look up the column by name.
+
+**Substitution order** is longest-match-first: `$name.*` → `$name.column` → `$name`.
+
+---
+
+## Row-Set Expansion (`$name.*`)
+
+### Problem: passing row sets between nodes required JSON gymnastics
+
+Each node in the function graph gets a separate sqlx connection and transaction. Previously, to pass a batch of rows from one node to the next, users had to serialize the batch into a JSON array and deserialize it with `jsonb_array_elements` — the DSL had no native way to express this:
+
+```sql
+-- Node 1: pack rows into a JSON array
+$$SELECT jsonb_agg(jsonb_build_object('id', id, 'content', content))::text
+  FROM documents WHERE status = 'pending' LIMIT 10
+$$ |=> 'batch'
+
+-- Node 2: unpack with jsonb_array_elements + extraction
+~> $$UPDATE documents SET status = 'processing'
+    WHERE id IN (
+        SELECT (elem->>'id')::bigint
+        FROM jsonb_array_elements($batch::jsonb) AS elem
+    )$$
+```
+
+This worked, but was verbose, error-prone, and required the user to handle JSON serialization in both directions.
+
+### Solution
+
+`$name.*` expands a named result's full row set as an inline `VALUES` subquery, usable in any SQL `FROM` clause, subquery, or `IN (SELECT ... FROM ...)`:
+
+```sql
+-- Node 1: fetch batch
+$$SELECT id, content FROM documents
+    WHERE status = 'pending' LIMIT 10
+$$ |=> 'batch'
+
+-- Node 2: use the row set directly
+~> $$UPDATE documents SET status = 'processing'
+    WHERE id IN (SELECT id FROM $batch.*)$$
+
+-- Node 3: also works in FROM clauses
+~> $$INSERT INTO results SELECT id, upper(content) FROM $batch.*$$
+```
+
+### Expansion
+
+`$batch.*` expands to a self-contained inline relation:
+
+```sql
+(VALUES (1,'hello'::text), (2,'world'::text), (3,'foo'::text)) AS batch(id, content)
+```
+
+### Semantics
+
+- All rows and all columns from the stored result are included
+- Column names come from the original query's column names (as stored in the JSON)
+- Values are type-cast where possible (text, numeric, boolean)
+- In raw contexts (HTTP body), `$batch.*` expands to a JSON array: `[{"id":1,"content":"hello"}, ...]`
+- Empty results (no rows): expands to an empty relation — `(VALUES (NULL::text, NULL::text) LIMIT 0) AS batch(id, content)` or similar
+
+### Practical limits
+
+Designed for small-to-medium row sets. PostgreSQL handles inline `VALUES` well up to a few thousand rows. For large result sets (10K+), users should build a **table pipeline** — use ordinary tables to hold intermediate results between stages, with each node reading from and writing to those tables directly. The DSL should not try to shuttle huge result sets through the substitution layer.
+
+---
+
+## `df.if_rows` — Branch on Row Existence
+
+### Problem: no-rows substitution produced garbage
+
+Previously, when a query returned zero rows, `$name` substituted the **raw JSON string** `{"rows": [], "row_count": 0}` into the SQL. This produced invalid SQL that failed with a confusing parse error rather than a clear "no rows" message:
+
+```sql
+SELECT df.start(
+    $$SELECT id FROM test_docs WHERE status = 'nonexistent' LIMIT 1$$ |=> 'doc'
+    ~> $$SELECT 'doc value is: ' || $doc$$,
+    'test-no-rows'
+);
+-- Instance failed. Worker log showed:
+-- Executing SQL: SELECT 'doc value is: ' || {"row_count":0,"rows":[]}
+-- ERROR:  syntax error at or near "{"
+```
+
+The error message gave zero indication that the problem was a named result with no rows. The instance failed, and `df.result()` returned empty — the user had to dig through server logs to understand what happened.
+
+There was no clean way to branch on whether a result had rows — attempting to check `$doc IS NOT NULL` would itself fail because `$doc` was already garbage.
+
+### Solution
+
+`df.if_rows` branches based on whether a named result contains any rows, providing a clean, zero-cost way to handle the common "query returned nothing" case:
+
+```sql
+$$SELECT id, content FROM documents
+    WHERE status = 'pending' LIMIT 1
+$$ |=> 'doc'
+
+~> df.if_rows('doc',
+    -- has rows: proceed
+    $$UPDATE documents SET status = 'processing' WHERE id = $doc.id$$,
+    -- no rows: alternative path
+    $$SELECT 'nothing to process'$$
+)
+```
+
+### Semantics
+
+- The condition is evaluated by checking `row_count > 0` from the stored result JSON
+- **No SQL execution** for the condition — zero-cost check against the in-memory results HashMap
+- Entering the then-branch guarantees at least one row exists, so `$doc.id` is safe (assuming the column is not NULL)
+- The argument is the result name as a string (without `$` prefix)
+
+### Implementation
+
+- DSL function `df.if_rows` in `src/dsl.rs` with `#[pg_extern(schema = "df")]`
+- Creates an IF node with a special condition marker (e.g., `condition_type: "result_has_rows"`, `condition_ref: "doc"`)
+- The orchestration handles this without scheduling a SQL activity — purely an in-memory check
+
+---
+
+## Null-Safe Accessor (`?` suffix)
+
+### Problem: NULL columns silently injected `null` text
+
+Previously, when a column value was NULL, `$name` substituted the literal text `null` (no quotes). This had two failure modes:
+
+**String concatenation → silent NULL propagation:**
+```sql
+SELECT 'the value is: ' || null
+-- Result: NULL (entire expression becomes NULL)
+```
+The instance completed "successfully" with a null result. No error, no warning.
+
+**WHERE clause → silent no-op (the worst case):**
+```sql
+UPDATE test_docs SET status = 'processed' WHERE content = null
+-- Result: 0 rows updated (NULL comparisons are always false in SQL)
+```
+
+An instance could complete with status `completed` but update zero rows — there was no way to distinguish "did work" from "silently did nothing because of a null substitution."
+
+### Solution
+
+`$name` and `$name.column` now **fail the instance** when the value would be NULL (either because the result has no rows or the column is NULL). The `?` suffix opts into returning SQL `NULL` instead:
+
+```
+$name?         — first col, first row; NULL if no rows or column is NULL
+$name.column?  — named col, first row; NULL if no rows or column is NULL
+```
+
+### Behavior Matrix
+
+| Syntax | On value exists | On NULL column | On no rows |
+|--------|----------------|----------------|------------|
+| `$doc` | Value | **Fail instance** | **Fail instance** |
+| `$doc?` | Value | `NULL` | `NULL` |
+| `$doc.id` | Value | **Fail instance** | **Fail instance** |
+| `$doc.id?` | Value | `NULL` | `NULL` |
+
+### Rationale
+
+**Why strict by default?** If a user writes `$doc.id`, they expect a value. A NULL result usually indicates a bug (unexpected data, wrong query). Failing fast with a clear error message is better than silently injecting NULL, which causes:
+- `WHERE id = NULL` → silent no-op (NULL comparisons are always false)
+- `'prefix_' || NULL` → entire expression becomes NULL
+- Downstream nodes consuming garbage data
+
+**Why offer `?` at all?** Sometimes columns are intentionally nullable and the user wants to branch on them:
+
+```sql
+$$SELECT id, manager_id FROM employees WHERE id = 1$$ |=> 'emp'
+
+~> df.if_rows('emp',
+    df.if(
+        $$SELECT $emp.manager_id? IS NOT NULL$$,
+        $$SELECT 'has manager: ' || $emp.manager_id$$,
+        $$SELECT 'no manager'$$
+    ),
+    $$SELECT 'employee not found'$$
+)
+```
+
+Without `?`, `$emp.manager_id` would fail before the `IS NOT NULL` check could run. With `?`, it substitutes to `NULL`, the condition evaluates to false, and the else branch runs. In the then-branch, bare `$emp.manager_id` (no `?`) is safe — the condition already confirmed it's not NULL.
+
+### Guidance for users
+
+If a column may be NULL, handle it at the source with `COALESCE`:
+
+```sql
+$$SELECT id, COALESCE(content, '') as content FROM documents LIMIT 1$$ |=> 'doc'
+-- $doc.content is never NULL — no need for ?
+```
+
+Use `?` when you specifically need to test for NULL in a conditional.
+
+---
+
+## Bug Fixes
+
+### Fix: No-rows substitution produced raw JSON
+
+**Previous behavior:** `$name` on a zero-row result substituted to `{"rows": [], "row_count": 0}` — raw JSON injected into SQL, causing parse errors.
+
+**New behavior:** `$name` on a zero-row result **fails the instance** with:
+```
+Variable substitution failed: $doc has no rows
+  Hint: The query for result 'doc' returned 0 rows.
+  Use df.if_rows('doc', ...) to branch on empty results,
+  or $doc? for NULL-safe substitution.
+```
+
+### Fix: NULL column substituted unquoted `null`
+
+**Previous behavior:** `$name` when the first column is JSON null substituted the literal text `null` (unquoted).
+
+**New behavior:** `$name` when the value is NULL **fails the instance** with:
+```
+Variable substitution failed: $doc is NULL
+  Hint: The first column of result 'doc' is NULL.
+  Use $doc? for NULL-safe substitution,
+  or COALESCE in the original query.
+```
+
+---
+
+## Implementation Notes
+
+### Substitution ordering
+
+Resolution proceeds longest-match-first to avoid partial matches:
+
+1. `$name.*` — row-set expansion
+2. `$name.column?` — null-safe dot-notation
+3. `$name.column` — strict dot-notation
+4. `$name?` — null-safe scalar
+5. `$name` — strict scalar (with fail-fast behavior)
+
+### No schema changes required
+
+All features are implemented in the substitution layer (`src/types.rs`) and orchestration (`src/orchestrations/execute_function_graph.rs`). No new tables, no upgrade scripts, no duroxide changes.
+
+Exception: `df.if_rows` required a new DSL function in `src/dsl.rs` and a new condition evaluation path in the orchestration.
+
+### Backward compatibility
+
+- Bare `$name` behavior changed from "substitute garbage/null" to "fail on no-rows/NULL". This is technically a breaking change but the previous behavior produced invalid SQL, so any existing usage was already broken.
+- `$name` with valid non-NULL single-row results: unchanged behavior.
+
+---
+
+## Out of Scope
+
+- **FROM-able syntax** (`FROM $batch` expanding to a CTE): not planned; for large result sets, users should build a table pipeline instead of passing data through the substitution layer
+- **Large result set management**: the DSL is not the right place to shuttle 10K+ rows between nodes. Users should use ordinary tables as staging areas between pipeline stages — each node writes to and reads from those tables directly
+- **`$name.row_count` metadata accessor**: potential future convenience; users can use `df.if_rows` for now
+
+## Issue Tracker - Items left for later
+
+| # | Item | Severity | Status |
+|---|------|----------|--------|
+| 1 | Audit backslash escaping or document assumption | Defense-in-depth | Not started |
+| 2 | Validate `df.if_rows` result name at graph-build time | UX | Deferred |
+| 3 | Fail substitution on missing columns | UX | Deferred |
+| 4 | Add non-ASCII column edge case unit test | Testing | Not started |
+| 5 | Fix changelog wording: "NULL" not "empty string" | Documentation | Not started |
+
+---
+
+### 1. String Escaping: Single-Quote-Only May Be Insufficient
+
+The `format_value` function escapes strings by doubling single quotes (`'` → `''`), which is correct for PostgreSQL's standard string syntax. However, if the server has `standard_conforming_strings = off` (rare but possible), backslash sequences become significant and `\' ` could escape the closing quote.
+
+This is a pre-existing concern (not introduced by this PR), but since the substitution engine was rewritten, it's worth noting. PostgreSQL's `E'...'` escape syntax and the `$$..$$` dollar-quoting used elsewhere in the codebase avoid this issue. For defense-in-depth, consider also replacing `\` with `\\` in string values, or document the `standard_conforming_strings = on` assumption.
+
+**Status:** Not started.
+
+### 2. `df.if_rows` Result Name Validation
+
+`df.if_rows('name', ...)` stores the name as-is in the `condition_type: "result_has_rows"` config JSON. The orchestration looks it up in the results HashMap at runtime. If the name is misspelled, the error is:
+
+```
+df.if_rows: result 'naem' not found
+```
+
+This is a reasonable runtime error. But since the result name is known at graph-build time (in the DSL), it could theoretically be validated earlier — when `df.start()` walks the graph. This would be a future improvement, not a blocker.
+
+**Status:** Deferred — future improvement.
+
+### 3. Missing Column Behavior Inconsistency
+
+When `$doc.nonexistent` is used and the column doesn't exist in the result JSON, the substitution leaves the pattern as-is in the SQL string. The spec says this is so "PostgreSQL reports a clear SQL error." This is a pragmatic choice, but may produce confusing error messages — PostgreSQL will see a literal `$doc` in the query and report a syntax error about `$` rather than about a missing column.
+
+Consider instead failing the substitution with:
+```
+$doc.nonexistent: column 'nonexistent' not found in result 'doc'. Available columns: id, name
+```
+
+**Status:** Deferred — future improvement.
+
+### 4. Non-ASCII Column Edge Case
+
+The `parse_identifier` function stops at non-ASCII bytes, so `$doc.café` would parse as `$doc.caf` and leave `é` in the query. This is an edge case but worth a unit test to document the behavior.
+
+**Status:** Not started.
+
+### 5. Changelog Wording
+
+The USER_GUIDE.md documents `$name?` as substituting `NULL` but the changelog says "append `?` to substitute an empty string instead". These should be made consistent — the code substitutes `NULL` (the SQL keyword), not an empty string.
+
+**Status:** Not started.
+
+---

--- a/docs/upgrade-testing.md
+++ b/docs/upgrade-testing.md
@@ -222,3 +222,9 @@ what the upgrade script handles, and any backward compatibility considerations.
 - **Scenario B1 considerations:** The BGW uses `MigrationPolicy::ApplyAll`. A database that has only migrations 0001–0005 is handled gracefully: the BGW detects the gap and applies 0006–0010 at startup. No manual intervention is needed.
 - **Scenario B2 considerations:** All five new migrations are additive (new tables and columns with defaults or nullable). Existing `df.vars`, `df.nodes`, `df.instances`, and `df.graphs` data is untouched.
 - **Current status:** Implemented — submodule at `4a6bf6b`, `Cargo.toml` pinned to `duroxide = "=0.1.26"`.
+
+#### Named Results v2 — df.if_rows
+- **DDL change:** Upgrade script adds `CREATE FUNCTION df.if_rows(result_name text, then_branch text, else_branch text)` — a new C-language function backed by the pgrx `#[pg_extern]` `if_rows_fn_wrapper` symbol.
+- **Scenario A considerations:** Fresh install picks up `df.if_rows` automatically from pgrx-generated SQL. The upgrade path required an explicit `CREATE FUNCTION` in the upgrade script to match.
+- **Scenario B1 considerations:** No backward compatibility concern. `df.if_rows` is a new function that doesn't exist in v0.1.1 schemas — it simply won't be callable until the customer runs `ALTER EXTENSION UPDATE`. The `.so` symbol exists but is never invoked from old schemas. All other changes (substitution engine rewrite, `Result` return type) are internal to orchestration code and don't touch any SQL queries or table schemas.
+- **Scenario B2 considerations:** No data migration needed. The change is purely additive (new function) with no table or column changes.

--- a/sql/pg_durable--0.1.1--0.2.0.sql
+++ b/sql/pg_durable--0.1.1--0.2.0.sql
@@ -108,3 +108,16 @@ $$ LANGUAGE plpgsql IMMUTABLE SET search_path = pg_catalog, df, pg_temp;
 CREATE OR REPLACE FUNCTION df.loop_prefix_op(body text) RETURNS text AS $$
     SELECT df.loop(body);
 $$ LANGUAGE SQL IMMUTABLE SET search_path = pg_catalog, df, pg_temp;
+
+-- ============================================================================
+-- 4. Add df.if_rows() — branches on whether a named result has rows
+-- ============================================================================
+
+CREATE FUNCTION df."if_rows"(
+    "result_name" TEXT,
+    "then_branch" TEXT,
+    "else_branch" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'if_rows_fn_wrapper';

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -10,7 +10,7 @@ use std::cell::RefCell;
 use std::time::Instant;
 
 use crate::client::start_durable_function;
-use crate::types::{short_id, Durofut, FunctionInput};
+use crate::types::{short_id, validate_result_name, Durofut, FunctionInput};
 
 /// Check if we're running inside a workflow context (background worker connection).
 /// The background worker sets df.in_workflow='true' on all its connections.
@@ -220,6 +220,9 @@ pub fn then_fn(a: &str, b: &str) -> String {
 /// Note: Parameter order matches the |=> operator: fut |=> name -> df.as(fut, name)
 #[pg_extern(name = "as", schema = "df")]
 pub fn as_named(fut: &str, name: &str) -> String {
+    if let Err(msg) = validate_result_name(name) {
+        pgrx::error!("df.as: {msg}");
+    }
     let mut durofut = Durofut::ensure(fut);
     durofut.result_name = Some(name.to_string());
 
@@ -349,6 +352,29 @@ pub fn if_fn(condition: &str, then_branch: &str, else_branch: &str) -> String {
 
     let config = serde_json::json!({
         "condition_node": condition_fut
+    });
+
+    Durofut {
+        node_type: "IF".to_string(),
+        left_node: Some(Box::new(then_fut)),
+        right_node: Some(Box::new(else_fut)),
+        query: Some(config.to_string()),
+        ..Default::default()
+    }
+    .to_json()
+}
+
+/// Branches based on whether a named result has any rows.
+/// Unlike df.if(), the condition is not a SQL query — it checks the
+/// in-memory result JSON for row_count > 0. Zero-cost, no activity scheduled.
+#[pg_extern(name = "if_rows", schema = "df")]
+pub fn if_rows_fn(result_name: &str, then_branch: &str, else_branch: &str) -> String {
+    let then_fut = Durofut::ensure(then_branch);
+    let else_fut = Durofut::ensure(else_branch);
+
+    let config = serde_json::json!({
+        "condition_type": "result_has_rows",
+        "result_name": result_name
     });
 
     Durofut {

--- a/src/orchestrations/execute_function_graph.rs
+++ b/src/orchestrations/execute_function_graph.rs
@@ -262,7 +262,7 @@ async fn execute_sql_node(
         .as_ref()
         .ok_or_else(|| format!("SQL node {node_id} has no query"))?;
 
-    let final_query = substitute_all(query, results, &exec_ctx.vars, sys_vars);
+    let final_query = substitute_all(query, results, &exec_ctx.vars, sys_vars)?;
     ctx.trace_info(format!("Executing SQL: {final_query}"));
 
     let input = serde_json::json!({
@@ -508,10 +508,6 @@ async fn execute_if_node(
     let config: serde_json::Value =
         serde_json::from_str(config_str).map_err(|e| format!("Invalid IF config: {e}"))?;
 
-    let condition_node_id = config["condition_node"]
-        .as_str()
-        .ok_or_else(|| "IF node missing condition_node".to_string())?;
-
     let then_id = node
         .left_node
         .as_ref()
@@ -521,17 +517,46 @@ async fn execute_if_node(
         .as_ref()
         .ok_or_else(|| format!("IF node {node_id} has no else branch"))?;
 
-    ctx.trace_info("Evaluating IF condition");
-    let condition_result = Box::pin(execute_function_node_with_vars(
-        ctx,
-        graph,
-        condition_node_id,
-        results,
-        exec_ctx,
-    ))
-    .await?;
+    let is_true =
+        if config.get("condition_type").and_then(|ct| ct.as_str()) == Some("result_has_rows") {
+            // df.if_rows: check row_count from in-memory results — no activity needed
+            let result_name = config["result_name"]
+                .as_str()
+                .ok_or_else(|| "df.if_rows: missing result_name".to_string())?;
+            let result_json = results
+                .get(result_name)
+                .ok_or_else(|| format!("df.if_rows: result '{result_name}' not found"))?;
+            let parsed: serde_json::Value = serde_json::from_str(result_json)
+                .map_err(|e| format!("df.if_rows: invalid result JSON: {e}"))?;
+            let row_count = parsed
+                .get("row_count")
+                .and_then(|rc| rc.as_u64())
+                .ok_or_else(|| {
+                    format!(
+                    "df.if_rows: result '{result_name}' is not a SQL result (missing row_count)"
+                )
+                })?;
+            ctx.trace_info(format!("if_rows '{result_name}': {row_count} rows"));
+            row_count > 0
+        } else {
+            // df.if: execute condition node as SQL
+            let condition_node_id = config["condition_node"]
+                .as_str()
+                .ok_or_else(|| "IF node missing condition_node".to_string())?;
 
-    let is_true = evaluate_condition(&condition_result)?;
+            ctx.trace_info("Evaluating IF condition");
+            let condition_result = Box::pin(execute_function_node_with_vars(
+                ctx,
+                graph,
+                condition_node_id,
+                results,
+                exec_ctx,
+            ))
+            .await?;
+
+            evaluate_condition(&condition_result)?
+        };
+
     ctx.trace_info(format!("Condition evaluated to: {is_true}"));
 
     if is_true {
@@ -727,13 +752,13 @@ async fn execute_http_node(
 
     // Substitute variables in body if present
     if let Some(body) = config.get("body").and_then(|b| b.as_str()) {
-        let substituted_body = substitute_all_raw(body, results, &exec_ctx.vars, sys_vars);
+        let substituted_body = substitute_all_raw(body, results, &exec_ctx.vars, sys_vars)?;
         config["body"] = serde_json::Value::String(substituted_body);
     }
 
     // Substitute variables in URL if present
     if let Some(url) = config.get("url").and_then(|u| u.as_str()) {
-        let substituted_url = substitute_all_raw(url, results, &exec_ctx.vars, sys_vars);
+        let substituted_url = substitute_all_raw(url, results, &exec_ctx.vars, sys_vars)?;
         config["url"] = serde_json::Value::String(substituted_url);
     }
 
@@ -746,7 +771,7 @@ async fn execute_http_node(
         for key in sorted_keys {
             if let Some(value) = headers.get(key) {
                 if let Some(v) = value.as_str() {
-                    let substituted = substitute_all_raw(v, results, &exec_ctx.vars, sys_vars);
+                    let substituted = substitute_all_raw(v, results, &exec_ctx.vars, sys_vars)?;
                     new_headers.insert(key.clone(), serde_json::Value::String(substituted));
                 } else {
                     new_headers.insert(key.clone(), value.clone());

--- a/src/types.rs
+++ b/src/types.rs
@@ -176,7 +176,10 @@ pub fn calculate_cron_wait(cron_expr: &str) -> Result<Duration, String> {
     Ok(duration)
 }
 
-/// Evaluate a condition result to determine if it's truthy
+/// Evaluate a condition result to determine if it's truthy.
+/// Uses iter().next() for first-column extraction — picks an arbitrary first
+/// column, which is acceptable here because conditions are single-value
+/// queries (SELECT <bool_expr>).
 pub fn evaluate_condition(result: &str) -> Result<bool, String> {
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(result) {
         if let Some(rows) = json.get("rows").and_then(|r| r.as_array()) {
@@ -233,20 +236,354 @@ pub struct SystemVars {
     pub label: Option<String>,
 }
 
+// ============================================================================
+// Result Substitution Helpers
+// ============================================================================
+
+fn is_ident_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+fn is_ident_continue(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Parse an identifier at the start of `s`: [a-zA-Z_][a-zA-Z0-9_]*
+fn parse_identifier(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() || !is_ident_start(bytes[0]) {
+        return "";
+    }
+    let len = bytes.iter().take_while(|&&b| is_ident_continue(b)).count();
+    &s[..len]
+}
+
+/// Validate that a result name is a safe SQL identifier: [a-zA-Z_][a-zA-Z0-9_]*
+/// Returns Ok(()) if valid, Err with message if not.
+pub fn validate_result_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("result name cannot be empty".to_string());
+    }
+    let parsed = parse_identifier(name);
+    if parsed.len() != name.len() {
+        return Err(format!(
+            "result name '{}' is not a valid identifier — must match [a-zA-Z_][a-zA-Z0-9_]*",
+            name
+        ));
+    }
+    Ok(())
+}
+
+/// Double-quote a SQL identifier, escaping any internal double-quotes.
+fn quote_identifier(name: &str) -> String {
+    let escaped = name.replace('"', "\"\"");
+    format!("\"{escaped}\"")
+}
+
+/// Format a JSON value for use in a SQL or raw context.
+fn format_value(val: &serde_json::Value, for_sql: bool) -> String {
+    match val {
+        serde_json::Value::String(s) => {
+            if for_sql {
+                let escaped = s.replace('\'', "''");
+                format!("'{escaped}'")
+            } else {
+                s.clone()
+            }
+        }
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        _ => {
+            if for_sql {
+                let s = val.to_string();
+                let escaped = s.replace('\'', "''");
+                format!("'{escaped}'")
+            } else {
+                val.to_string()
+            }
+        }
+    }
+}
+
+/// Extract first-column-first-row (bare `$name` / `$name?`).
+fn extract_first_column_value(
+    name: &str,
+    json_str: &str,
+    null_safe: bool,
+    for_sql: bool,
+) -> Result<String, String> {
+    let json: serde_json::Value = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(_) => {
+            // Not JSON — return raw value (backward compat for HTTP responses etc.)
+            return Ok(if for_sql {
+                let escaped = json_str.replace('\'', "''");
+                format!("'{escaped}'")
+            } else {
+                json_str.to_string()
+            });
+        }
+    };
+
+    if let Some(rows) = json.get("rows").and_then(|r| r.as_array()) {
+        if rows.is_empty() {
+            return if null_safe {
+                Ok("NULL".to_string())
+            } else {
+                Err(format!("${name} has no rows — query returned zero results"))
+            };
+        }
+
+        let first_row = rows[0]
+            .as_object()
+            .ok_or_else(|| format!("${name}: first row is not an object"))?;
+        let (_, val) = first_row
+            .iter()
+            .next()
+            .ok_or_else(|| format!("${name}: first row has no columns"))?;
+
+        if val.is_null() {
+            return if null_safe {
+                Ok("NULL".to_string())
+            } else {
+                Err(format!(
+                    "${name} is NULL — first column of first row is NULL"
+                ))
+            };
+        }
+
+        Ok(format_value(val, for_sql))
+    } else if for_sql {
+        let escaped = json_str.replace('\'', "''");
+        Ok(format!("'{escaped}'"))
+    } else {
+        Ok(json_str.to_string())
+    }
+}
+
+/// Extract a specific column from the first row (`$name.col` / `$name.col?`).
+/// Returns the original pattern when the column does not exist in the result.
+fn extract_column_value(
+    name: &str,
+    json_str: &str,
+    col: &str,
+    null_safe: bool,
+    for_sql: bool,
+) -> Result<String, String> {
+    let json: serde_json::Value = serde_json::from_str(json_str)
+        .map_err(|_| format!("${name}.{col}: result is not valid JSON"))?;
+
+    let rows = json
+        .get("rows")
+        .and_then(|r| r.as_array())
+        .ok_or_else(|| format!("${name}.{col}: result has no rows array"))?;
+
+    if rows.is_empty() {
+        return if null_safe {
+            Ok("NULL".to_string())
+        } else {
+            Err(format!("${name} has no rows — query returned zero results"))
+        };
+    }
+
+    let first_row = rows[0]
+        .as_object()
+        .ok_or_else(|| format!("${name}.{col}: first row is not an object"))?;
+
+    let val = match first_row.get(col) {
+        Some(v) => v,
+        None => {
+            // Missing column — leave the pattern as-is so PostgreSQL reports the error
+            let suffix = if null_safe { "?" } else { "" };
+            return Ok(format!("${name}.{col}{suffix}"));
+        }
+    };
+
+    if val.is_null() {
+        return if null_safe {
+            Ok("NULL".to_string())
+        } else {
+            Err(format!("${name}.{col} is NULL"))
+        };
+    }
+
+    Ok(format_value(val, for_sql))
+}
+
+/// Expand `$name.*` into an inline `VALUES` subquery (SQL) or JSON array (raw).
+fn expand_row_set(name: &str, json_str: &str, for_sql: bool) -> Result<String, String> {
+    let json: serde_json::Value = serde_json::from_str(json_str)
+        .map_err(|e| format!("${name}.* — invalid result JSON: {e}"))?;
+
+    let rows = json
+        .get("rows")
+        .and_then(|r| r.as_array())
+        .ok_or_else(|| format!("${name}.* — invalid result format"))?;
+
+    if !for_sql {
+        return Ok(serde_json::to_string(rows).unwrap());
+    }
+
+    let quoted_name = quote_identifier(name);
+
+    if rows.is_empty() {
+        return Ok(format!("(SELECT NULL WHERE false) AS {quoted_name}"));
+    }
+
+    let first_obj = rows[0]
+        .as_object()
+        .ok_or_else(|| format!("${name}.* — row is not an object"))?;
+    let col_names: Vec<&str> = first_obj.keys().map(|k| k.as_str()).collect();
+
+    let mut value_rows = Vec::with_capacity(rows.len());
+    for row in rows {
+        let obj = row
+            .as_object()
+            .ok_or_else(|| format!("${name}.* — row is not an object"))?;
+        let vals: Vec<String> = col_names
+            .iter()
+            .map(|&col| match obj.get(col) {
+                Some(serde_json::Value::String(s)) => {
+                    let escaped = s.replace('\'', "''");
+                    format!("'{escaped}'::text")
+                }
+                Some(serde_json::Value::Number(n)) => n.to_string(),
+                Some(serde_json::Value::Bool(b)) => b.to_string(),
+                Some(serde_json::Value::Null) | None => "NULL".to_string(),
+                Some(other) => {
+                    let escaped = other.to_string().replace('\'', "''");
+                    format!("'{escaped}'::text")
+                }
+            })
+            .collect();
+        value_rows.push(format!("({})", vals.join(",")));
+    }
+
+    let col_list = col_names
+        .iter()
+        .map(|c| quote_identifier(c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Ok(format!(
+        "(VALUES {}) AS {quoted_name}({col_list})",
+        value_rows.join(", ")
+    ))
+}
+
+/// Scan-based result substitution supporting:
+///   `$name.*`    — row-set expansion
+///   `$name.col?` — null-safe dot-notation
+///   `$name.col`  — strict dot-notation
+///   `$name?`     — null-safe scalar
+///   `$name`      — strict scalar
+fn substitute_results(
+    input: &str,
+    results: &std::collections::HashMap<String, String>,
+    for_sql: bool,
+) -> Result<String, String> {
+    if results.is_empty() {
+        return Ok(input.to_string());
+    }
+
+    // Sort names longest-first to avoid partial matches
+    let mut names: Vec<&str> = results.keys().map(|s| s.as_str()).collect();
+    names.sort_by_key(|name| std::cmp::Reverse(name.len()));
+
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    let input_bytes = input.as_bytes();
+
+    while i < input.len() {
+        if input_bytes[i] != b'$' {
+            let ch = input[i..].chars().next().unwrap();
+            out.push(ch);
+            i += ch.len_utf8();
+            continue;
+        }
+
+        let after_dollar = &input[i + 1..];
+        let mut matched = false;
+
+        for name in &names {
+            if !after_dollar.starts_with(name) {
+                continue;
+            }
+
+            let after_name = &after_dollar[name.len()..];
+            let json_str = &results[*name];
+
+            // 1. $name.* — row-set expansion
+            if after_name.starts_with(".*") {
+                let replacement = expand_row_set(name, json_str, for_sql)?;
+                out.push_str(&replacement);
+                i += 1 + name.len() + 2; // $ + name + .*
+                matched = true;
+                break;
+            }
+
+            // 2/3. $name.col? or $name.col — dot-notation
+            if let Some(after_dot) = after_name.strip_prefix('.') {
+                let col = parse_identifier(after_dot);
+                if !col.is_empty() {
+                    let after_col = &after_dot[col.len()..];
+                    let null_safe = after_col.starts_with('?');
+                    let replacement =
+                        extract_column_value(name, json_str, col, null_safe, for_sql)?;
+                    out.push_str(&replacement);
+                    i += 1 + name.len() + 1 + col.len() + if null_safe { 1 } else { 0 };
+                    matched = true;
+                    break;
+                }
+                // No valid column name after dot — fall through to bare $name
+            }
+
+            // 4. $name? — null-safe scalar
+            if after_name.starts_with('?') {
+                let replacement = extract_first_column_value(name, json_str, true, for_sql)?;
+                out.push_str(&replacement);
+                i += 1 + name.len() + 1; // $ + name + ?
+                matched = true;
+                break;
+            }
+
+            // 5. $name — strict scalar (with word-boundary check)
+            if after_name.is_empty() || !is_ident_continue(after_name.as_bytes()[0]) {
+                let replacement = extract_first_column_value(name, json_str, false, for_sql)?;
+                out.push_str(&replacement);
+                i += 1 + name.len();
+                matched = true;
+                break;
+            }
+
+            // Next char is an identifier continuation — try shorter names
+        }
+
+        if !matched {
+            out.push('$');
+            i += 1;
+        }
+    }
+
+    Ok(out)
+}
+
 /// Substitute all variable types in a query:
 /// - {name} for user vars (from FunctionInput.vars) - values are inserted as-is
 /// - {sys_instance_id}, {sys_label} for system vars - inserted as-is
-/// - $name for result naming (from |=>) - may be quoted for JSON values
+/// - $name, $name.col, $name?, $name.col?, $name.* for named results (from |=>)
 ///
 /// User vars and system vars are substituted without quoting - the user should
 /// handle SQL escaping in the original query if needed.
+///
+/// Returns `Err` if a strict (non-`?`) pattern references a result with no rows
+/// or a NULL value.
 pub fn substitute_all_with_options(
     query: &str,
     results: &std::collections::HashMap<String, String>,
     vars: &std::collections::HashMap<String, String>,
     sys_vars: &SystemVars,
     quote_results_for_sql: bool,
-) -> String {
+) -> Result<String, String> {
     let mut result = query.to_string();
 
     // 1. Substitute system vars: {sys_*} (inserted as-is)
@@ -261,55 +598,8 @@ pub fn substitute_all_with_options(
         }
     }
 
-    // 3. Substitute results: $name
-    for (name, value) in results {
-        let pattern = format!("${name}");
-        if result.contains(&pattern) {
-            let replacement = if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
-                // Check if this is a SQL result format with rows
-                if let Some(rows) = json.get("rows").and_then(|r| r.as_array()) {
-                    if let Some(first_row) = rows.first() {
-                        if let Some(obj) = first_row.as_object() {
-                            if let Some((_, val)) = obj.iter().next() {
-                                match val {
-                                    serde_json::Value::String(s) => {
-                                        if quote_results_for_sql {
-                                            let escaped = s.replace('\'', "''");
-                                            format!("'{escaped}'")
-                                        } else {
-                                            s.clone()
-                                        }
-                                    }
-                                    serde_json::Value::Number(n) => n.to_string(),
-                                    serde_json::Value::Bool(b) => b.to_string(),
-                                    _ => val.to_string(),
-                                }
-                            } else {
-                                value.clone()
-                            }
-                        } else {
-                            value.clone()
-                        }
-                    } else {
-                        value.clone()
-                    }
-                } else if quote_results_for_sql {
-                    // This is a JSON object/array (like HTTP response) - quote it for SQL
-                    // so it can be cast to jsonb: '{"key": "value"}'::jsonb
-                    let escaped = value.replace('\'', "''");
-                    format!("'{escaped}'")
-                } else {
-                    // Raw mode - no quoting for non-SQL contexts
-                    value.clone()
-                }
-            } else {
-                value.clone()
-            };
-            result = result.replace(&pattern, &replacement);
-        }
-    }
-
-    result
+    // 3. Substitute results: $name with dot-notation, null-safe, and row-set support
+    substitute_results(&result, results, quote_results_for_sql)
 }
 
 /// Substitute all variables with SQL quoting (default for SQL contexts)
@@ -318,7 +608,7 @@ pub fn substitute_all(
     results: &std::collections::HashMap<String, String>,
     vars: &std::collections::HashMap<String, String>,
     sys_vars: &SystemVars,
-) -> String {
+) -> Result<String, String> {
     substitute_all_with_options(query, results, vars, sys_vars, true)
 }
 
@@ -328,7 +618,7 @@ pub fn substitute_all_raw(
     results: &std::collections::HashMap<String, String>,
     vars: &std::collections::HashMap<String, String>,
     sys_vars: &SystemVars,
-) -> String {
+) -> Result<String, String> {
     substitute_all_with_options(query, results, vars, sys_vars, false)
 }
 
@@ -336,7 +626,7 @@ pub fn substitute_all_raw(
 pub fn substitute_variables(
     query: &str,
     results: &std::collections::HashMap<String, String>,
-) -> String {
+) -> Result<String, String> {
     substitute_all(
         query,
         results,
@@ -749,5 +1039,225 @@ mod tests {
                 "evaluate_condition raw fallback failed for: {input}"
             );
         }
+    }
+
+    // ============================================================================
+    // Substitution Engine Tests
+    // ============================================================================
+
+    fn make_results(entries: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn empty_vars() -> std::collections::HashMap<String, String> {
+        std::collections::HashMap::new()
+    }
+
+    fn sys_vars() -> SystemVars {
+        SystemVars {
+            instance_id: "test-id".to_string(),
+            label: None,
+        }
+    }
+
+    #[test]
+    fn test_dot_notation_string() {
+        let results =
+            make_results(&[("doc", r#"{"rows":[{"id":1,"name":"Alice"}],"row_count":1}"#)]);
+        let out = substitute_all("SELECT $doc.name", &results, &empty_vars(), &sys_vars()).unwrap();
+        assert_eq!(out, "SELECT 'Alice'");
+    }
+
+    #[test]
+    fn test_dot_notation_number() {
+        let results = make_results(&[(
+            "doc",
+            r#"{"rows":[{"id":42,"name":"Alice"}],"row_count":1}"#,
+        )]);
+        let out = substitute_all("SELECT $doc.id", &results, &empty_vars(), &sys_vars()).unwrap();
+        assert_eq!(out, "SELECT 42");
+    }
+
+    #[test]
+    fn test_dot_notation_bool() {
+        let results = make_results(&[("doc", r#"{"rows":[{"active":true}],"row_count":1}"#)]);
+        let out =
+            substitute_all("SELECT $doc.active", &results, &empty_vars(), &sys_vars()).unwrap();
+        assert_eq!(out, "SELECT true");
+    }
+
+    #[test]
+    fn test_bare_name_backward_compat() {
+        let results = make_results(&[("x", r#"{"rows":[{"num":100}],"row_count":1}"#)]);
+        let out = substitute_all("SELECT $x::text", &results, &empty_vars(), &sys_vars()).unwrap();
+        assert_eq!(out, "SELECT 100::text");
+    }
+
+    #[test]
+    fn test_no_rows_strict_fail() {
+        let results = make_results(&[("doc", r#"{"rows":[],"row_count":0}"#)]);
+        let out = substitute_all("SELECT $doc", &results, &empty_vars(), &sys_vars());
+        assert!(out.is_err());
+        assert!(out.unwrap_err().contains("has no rows"));
+    }
+
+    #[test]
+    fn test_null_strict_fail() {
+        let results = make_results(&[("doc", r#"{"rows":[{"val":null}],"row_count":1}"#)]);
+        let out = substitute_all("SELECT $doc", &results, &empty_vars(), &sys_vars());
+        assert!(out.is_err());
+        assert!(out.unwrap_err().contains("is NULL"));
+    }
+
+    #[test]
+    fn test_null_safe_no_rows() {
+        let results = make_results(&[("doc", r#"{"rows":[],"row_count":0}"#)]);
+        let out = substitute_all("SELECT $doc?", &results, &empty_vars(), &sys_vars()).unwrap();
+        assert_eq!(out, "SELECT NULL");
+    }
+
+    #[test]
+    fn test_null_safe_null_col() {
+        let results = make_results(&[("doc", r#"{"rows":[{"name":null}],"row_count":1}"#)]);
+        let out =
+            substitute_all("SELECT $doc.name?", &results, &empty_vars(), &sys_vars()).unwrap();
+        assert_eq!(out, "SELECT NULL");
+    }
+
+    #[test]
+    fn test_null_safe_has_value() {
+        let results = make_results(&[("x", r#"{"rows":[{"num":42}],"row_count":1}"#)]);
+        let out = substitute_all("SELECT $x?", &results, &empty_vars(), &sys_vars()).unwrap();
+        assert_eq!(out, "SELECT 42");
+    }
+
+    #[test]
+    fn test_dot_notation_missing_col() {
+        let results = make_results(&[("doc", r#"{"rows":[{"id":1}],"row_count":1}"#)]);
+        let out = substitute_all(
+            "SELECT $doc.nonexistent",
+            &results,
+            &empty_vars(),
+            &sys_vars(),
+        )
+        .unwrap();
+        // Missing column is left as-is
+        assert_eq!(out, "SELECT $doc.nonexistent");
+    }
+
+    #[test]
+    fn test_multiple_refs() {
+        let results = make_results(&[
+            ("a", r#"{"rows":[{"id":1}],"row_count":1}"#),
+            ("b", r#"{"rows":[{"name":"Bob"}],"row_count":1}"#),
+        ]);
+        let out = substitute_all(
+            "SELECT $a.id, $b.name",
+            &results,
+            &empty_vars(),
+            &sys_vars(),
+        )
+        .unwrap();
+        assert_eq!(out, "SELECT 1, 'Bob'");
+    }
+
+    #[test]
+    fn test_substitution_order() {
+        // Ensure $doc.id doesn't partially match as $doc first
+        let results = make_results(&[("doc", r#"{"rows":[{"id":7,"name":"X"}],"row_count":1}"#)]);
+        let out = substitute_all("SELECT $doc.id", &results, &empty_vars(), &sys_vars()).unwrap();
+        assert_eq!(out, "SELECT 7");
+    }
+
+    #[test]
+    fn test_row_set_expansion_sql() {
+        let results = make_results(&[(
+            "batch",
+            r#"{"rows":[{"id":1,"val":"a"},{"id":2,"val":"b"}],"row_count":2}"#,
+        )]);
+        let out = substitute_all(
+            "SELECT * FROM $batch.*",
+            &results,
+            &empty_vars(),
+            &sys_vars(),
+        )
+        .unwrap();
+        assert!(out.contains("VALUES"));
+        assert!(out.contains(r#"AS "batch"("#));
+    }
+
+    #[test]
+    fn test_row_set_expansion_empty() {
+        let results = make_results(&[("batch", r#"{"rows":[],"row_count":0}"#)]);
+        let out = substitute_all(
+            "SELECT * FROM $batch.*",
+            &results,
+            &empty_vars(),
+            &sys_vars(),
+        )
+        .unwrap();
+        assert!(out.contains("SELECT NULL WHERE false"));
+    }
+
+    #[test]
+    fn test_validate_result_name_valid() {
+        assert!(validate_result_name("batch").is_ok());
+        assert!(validate_result_name("my_result").is_ok());
+        assert!(validate_result_name("_private").is_ok());
+        assert!(validate_result_name("A123").is_ok());
+    }
+
+    #[test]
+    fn test_validate_result_name_invalid() {
+        assert!(validate_result_name("").is_err());
+        assert!(validate_result_name("123abc").is_err());
+        assert!(validate_result_name("x) UNION SELECT version()--").is_err());
+        assert!(validate_result_name("name with spaces").is_err());
+        assert!(validate_result_name("a-b").is_err());
+        assert!(validate_result_name("drop;--").is_err());
+    }
+
+    #[test]
+    fn test_expand_row_set_quoted_columns() {
+        // Column names from PostgreSQL can contain special characters
+        let json = r#"{"rows":[{"normal":1,"has space":2}],"row_count":1}"#;
+        let result = expand_row_set("tbl", json, true).unwrap();
+        assert!(result.contains(r#""normal""#));
+        assert!(result.contains(r#""has space""#));
+        assert!(result.contains(r#"AS "tbl"("#));
+    }
+
+    #[test]
+    fn test_expand_row_set_empty_quoted_name() {
+        let json = r#"{"rows":[],"row_count":0}"#;
+        let result = expand_row_set("batch", json, true).unwrap();
+        assert_eq!(result, r#"(SELECT NULL WHERE false) AS "batch""#);
+    }
+    #[test]
+    fn test_row_set_expansion_raw() {
+        let results = make_results(&[("batch", r#"{"rows":[{"id":1}],"row_count":1}"#)]);
+        let out =
+            substitute_all_raw("data: $batch.*", &results, &empty_vars(), &sys_vars()).unwrap();
+        assert_eq!(out, r#"data: [{"id":1}]"#);
+    }
+
+    #[test]
+    fn test_no_partial_match_longer_name() {
+        // $doc should not match inside $document
+        let results = make_results(&[("doc", r#"{"rows":[{"id":1}],"row_count":1}"#)]);
+        let out = substitute_all("SELECT $document", &results, &empty_vars(), &sys_vars()).unwrap();
+        // $document is not a known result — left as-is
+        assert_eq!(out, "SELECT $document");
+    }
+
+    #[test]
+    fn test_dot_notation_no_sql_quoting() {
+        let results = make_results(&[("doc", r#"{"rows":[{"name":"Alice"}],"row_count":1}"#)]);
+        let out =
+            substitute_all_raw("Hello $doc.name", &results, &empty_vars(), &sys_vars()).unwrap();
+        assert_eq!(out, "Hello Alice");
     }
 }

--- a/tests/e2e/sql/39_named_results_dot.sql
+++ b/tests/e2e/sql/39_named_results_dot.sql
@@ -1,0 +1,121 @@
+-- Test: Named result dot-notation, null-safe accessor, strict fail
+-- Tests $name.column, $name.column?, $name?, and fail-fast on no-rows/NULL
+
+-- ============================================================================
+-- Test 1: Dot-notation — access specific columns
+-- ============================================================================
+
+DROP TABLE IF EXISTS test_dot_results;
+CREATE TABLE test_dot_results (id SERIAL, got_id INT, got_content TEXT);
+
+CREATE TEMP TABLE _test_state (instance_id TEXT, variant TEXT);
+
+INSERT INTO _test_state SELECT df.start(
+    $$SELECT 42 AS id, 'hello' AS content$$ |=> 'doc'
+    ~> $$INSERT INTO test_dot_results (got_id, got_content) VALUES ($doc.id, $doc.content)$$,
+    'test-dot-notation'
+), 'dot';
+
+DO $$
+DECLARE
+    rec RECORD;
+    status TEXT;
+    r_id INT;
+    r_content TEXT;
+BEGIN
+    SELECT instance_id INTO rec FROM _test_state WHERE variant = 'dot';
+
+    SELECT df.wait_for_completion(rec.instance_id) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [dot-notation]: status = %', status;
+    END IF;
+
+    SELECT got_id, got_content INTO r_id, r_content FROM test_dot_results ORDER BY id DESC LIMIT 1;
+
+    IF r_id != 42 THEN
+        RAISE EXCEPTION 'TEST FAILED [dot-notation]: expected id=42, got %', r_id;
+    END IF;
+
+    IF r_content != 'hello' THEN
+        RAISE EXCEPTION 'TEST FAILED [dot-notation]: expected content=hello, got %', r_content;
+    END IF;
+
+    RAISE NOTICE 'PASSED: dot-notation';
+END $$;
+
+DROP TABLE _test_state;
+DROP TABLE test_dot_results;
+
+-- ============================================================================
+-- Test 2: Null-safe accessor — $name.col? substitutes NULL
+-- ============================================================================
+
+DROP TABLE IF EXISTS test_nullsafe_results;
+CREATE TABLE test_nullsafe_results (id SERIAL, val TEXT);
+
+CREATE TEMP TABLE _test_state2 (instance_id TEXT);
+
+INSERT INTO _test_state2 SELECT df.start(
+    $$SELECT NULL::text AS val$$ |=> 'x'
+    ~> $$INSERT INTO test_nullsafe_results (val) VALUES (COALESCE($x.val?, 'fallback'))$$,
+    'test-null-safe'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    val_result TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state2;
+
+    SELECT df.wait_for_completion(inst_id) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [null-safe]: status = %', status;
+    END IF;
+
+    SELECT val INTO val_result FROM test_nullsafe_results ORDER BY id DESC LIMIT 1;
+
+    IF val_result != 'fallback' THEN
+        RAISE EXCEPTION 'TEST FAILED [null-safe]: expected fallback, got %', val_result;
+    END IF;
+
+    RAISE NOTICE 'PASSED: null-safe accessor';
+END $$;
+
+DROP TABLE _test_state2;
+DROP TABLE test_nullsafe_results;
+
+-- ============================================================================
+-- Test 3: Strict fail — $name on empty result fails the instance
+-- ============================================================================
+
+CREATE TEMP TABLE _test_state3 (instance_id TEXT);
+
+INSERT INTO _test_state3 SELECT df.start(
+    $$SELECT 1 WHERE false$$ |=> 'empty'
+    ~> $$SELECT $empty$$,
+    'test-strict-fail'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state3;
+
+    SELECT df.wait_for_completion(inst_id) INTO status;
+
+    IF status != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [strict-fail]: expected failed, got %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED: strict fail on no-rows';
+END $$;
+
+DROP TABLE _test_state3;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/40_if_rows.sql
+++ b/tests/e2e/sql/40_if_rows.sql
@@ -1,0 +1,119 @@
+-- Test: df.if_rows — branch on whether a named result has rows
+-- Tests df.if_rows() with rows present (then branch) and zero rows (else branch)
+
+-- ============================================================================
+-- Test 1: if_rows with rows present → then branch executes
+-- ============================================================================
+
+DROP TABLE IF EXISTS test_if_rows_log;
+CREATE TABLE test_if_rows_log (id SERIAL, branch TEXT, variant TEXT);
+
+CREATE TEMP TABLE _test_state (instance_id TEXT, variant TEXT);
+
+INSERT INTO _test_state SELECT df.start(
+    $$SELECT 1 AS val$$ |=> 'data'
+    ~> df.if_rows(
+        'data',
+        $$INSERT INTO test_if_rows_log (branch, variant) VALUES ('then', 'has_rows')$$,
+        $$INSERT INTO test_if_rows_log (branch, variant) VALUES ('else', 'has_rows')$$
+    ),
+    'test-if-rows-has-rows'
+), 'has_rows';
+
+-- Test 2: if_rows with zero rows → else branch executes
+INSERT INTO _test_state SELECT df.start(
+    $$SELECT 1 WHERE false$$ |=> 'empty'
+    ~> df.if_rows(
+        'empty',
+        $$INSERT INTO test_if_rows_log (branch, variant) VALUES ('then', 'no_rows')$$,
+        $$INSERT INTO test_if_rows_log (branch, variant) VALUES ('else', 'no_rows')$$
+    ),
+    'test-if-rows-no-rows'
+), 'no_rows';
+
+DO $$
+DECLARE
+    rec RECORD;
+    status TEXT;
+    branch_val TEXT;
+    expected_branch TEXT;
+BEGIN
+    FOR rec IN SELECT instance_id, variant FROM _test_state LOOP
+        RAISE NOTICE 'Testing % variant: %', rec.variant, rec.instance_id;
+
+        SELECT df.wait_for_completion(rec.instance_id) INTO status;
+
+        IF status != 'completed' THEN
+            RAISE EXCEPTION 'TEST FAILED [%]: status = %', rec.variant, status;
+        END IF;
+
+        IF rec.variant = 'has_rows' THEN
+            expected_branch := 'then';
+        ELSE
+            expected_branch := 'else';
+        END IF;
+
+        SELECT branch INTO branch_val
+        FROM test_if_rows_log
+        WHERE variant = rec.variant
+        ORDER BY id DESC LIMIT 1;
+
+        IF branch_val != expected_branch THEN
+            RAISE EXCEPTION 'TEST FAILED [%]: expected % branch, got %', rec.variant, expected_branch, branch_val;
+        END IF;
+
+        RAISE NOTICE 'PASSED: if_rows [%]', rec.variant;
+    END LOOP;
+
+    RAISE NOTICE 'TEST PASSED: if_rows (both variants)';
+END $$;
+
+DROP TABLE _test_state;
+DROP TABLE test_if_rows_log;
+
+-- ============================================================================
+-- Test 3: if_rows combined with dot-notation in then branch
+-- ============================================================================
+
+DROP TABLE IF EXISTS test_if_rows_dot;
+CREATE TABLE test_if_rows_dot (id SERIAL, val INT);
+
+CREATE TEMP TABLE _test_state2 (instance_id TEXT);
+
+INSERT INTO _test_state2 SELECT df.start(
+    $$SELECT 99 AS num$$ |=> 'result'
+    ~> df.if_rows(
+        'result',
+        $$INSERT INTO test_if_rows_dot (val) VALUES ($result.num)$$,
+        $$INSERT INTO test_if_rows_dot (val) VALUES (-1)$$
+    ),
+    'test-if-rows-dot'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    val_result INT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state2;
+
+    SELECT df.wait_for_completion(inst_id) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [if_rows+dot]: status = %', status;
+    END IF;
+
+    SELECT val INTO val_result FROM test_if_rows_dot ORDER BY id DESC LIMIT 1;
+
+    IF val_result != 99 THEN
+        RAISE EXCEPTION 'TEST FAILED [if_rows+dot]: expected 99, got %', val_result;
+    END IF;
+
+    RAISE NOTICE 'PASSED: if_rows combined with dot-notation';
+END $$;
+
+DROP TABLE _test_state2;
+DROP TABLE test_if_rows_dot;
+
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/41_row_set_expansion.sql
+++ b/tests/e2e/sql/41_row_set_expansion.sql
@@ -1,0 +1,93 @@
+-- Test: Row-set expansion ($name.*)
+-- Tests $name.* in FROM clause and WHERE IN subquery, plus empty result handling
+
+-- ============================================================================
+-- Test 1: $batch.* in FROM clause — multi-row expansion
+-- ============================================================================
+
+DROP TABLE IF EXISTS test_rowset_results;
+CREATE TABLE test_rowset_results (id SERIAL, total_rows INT);
+
+CREATE TEMP TABLE _test_state (instance_id TEXT, variant TEXT);
+
+INSERT INTO _test_state SELECT df.start(
+    $$SELECT id, val FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, val)$$ |=> 'batch'
+    ~> $$INSERT INTO test_rowset_results (total_rows) SELECT count(*) FROM $batch.*$$,
+    'test-rowset-from'
+), 'from_clause';
+
+-- ============================================================================
+-- Test 2: $batch.* in WHERE IN subquery
+-- ============================================================================
+
+DROP TABLE IF EXISTS test_rowset_source;
+CREATE TABLE test_rowset_source (id INT, name TEXT);
+INSERT INTO test_rowset_source VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Carol'), (4, 'Dave');
+
+DROP TABLE IF EXISTS test_rowset_filtered;
+CREATE TABLE test_rowset_filtered (id SERIAL, cnt INT);
+
+INSERT INTO _test_state SELECT df.start(
+    $$SELECT id FROM test_rowset_source WHERE id <= 2$$ |=> 'ids'
+    ~> $$INSERT INTO test_rowset_filtered (cnt) SELECT count(*) FROM test_rowset_source WHERE id IN (SELECT id FROM $ids.*)$$,
+    'test-rowset-where-in'
+), 'where_in';
+
+-- ============================================================================
+-- Test 3: Empty result set expansion — should not error
+-- ============================================================================
+
+INSERT INTO _test_state SELECT df.start(
+    $$SELECT id FROM test_rowset_source WHERE false$$ |=> 'none'
+    ~> $$INSERT INTO test_rowset_results (total_rows) SELECT count(*) FROM $none.*$$,
+    'test-rowset-empty'
+), 'empty';
+
+DO $$
+DECLARE
+    rec RECORD;
+    status TEXT;
+    int_val INT;
+BEGIN
+    FOR rec IN SELECT instance_id, variant FROM _test_state ORDER BY variant LOOP
+        RAISE NOTICE 'Testing % variant: %', rec.variant, rec.instance_id;
+
+        SELECT df.wait_for_completion(rec.instance_id) INTO status;
+
+        IF status != 'completed' THEN
+            RAISE EXCEPTION 'TEST FAILED [%]: status = %', rec.variant, status;
+        END IF;
+
+        IF rec.variant = 'empty' THEN
+            -- Empty expansion: count(*) from empty subquery = 0
+            SELECT total_rows INTO int_val FROM test_rowset_results ORDER BY id DESC LIMIT 1;
+            IF int_val != 0 THEN
+                RAISE EXCEPTION 'TEST FAILED [empty]: expected 0 rows, got %', int_val;
+            END IF;
+
+        ELSIF rec.variant = 'from_clause' THEN
+            -- FROM expansion: 3 rows from VALUES
+            SELECT total_rows INTO int_val FROM test_rowset_results ORDER BY id ASC LIMIT 1;
+            IF int_val != 3 THEN
+                RAISE EXCEPTION 'TEST FAILED [from_clause]: expected 3 rows, got %', int_val;
+            END IF;
+
+        ELSIF rec.variant = 'where_in' THEN
+            -- WHERE IN expansion: only ids 1,2 matched
+            SELECT cnt INTO int_val FROM test_rowset_filtered ORDER BY id DESC LIMIT 1;
+            IF int_val != 2 THEN
+                RAISE EXCEPTION 'TEST FAILED [where_in]: expected 2 rows, got %', int_val;
+            END IF;
+        END IF;
+
+        RAISE NOTICE 'PASSED: row-set expansion [%]', rec.variant;
+    END LOOP;
+
+    RAISE NOTICE 'TEST PASSED: row-set expansion (all variants)';
+END $$;
+
+DROP TABLE _test_state;
+DROP TABLE test_rowset_results;
+DROP TABLE test_rowset_filtered;
+DROP TABLE test_rowset_source;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/42_result_name_validation.sql
+++ b/tests/e2e/sql/42_result_name_validation.sql
@@ -1,0 +1,92 @@
+-- Test: Result name validation rejects unsafe identifiers
+-- Ensures df.as() / |=> reject names that aren't valid SQL identifiers
+
+-- ============================================================================
+-- Test 1: Valid names should work
+-- ============================================================================
+
+DROP TABLE IF EXISTS test_name_valid_results;
+CREATE TABLE test_name_valid_results (id SERIAL, val INT);
+
+CREATE TEMP TABLE _test_state (instance_id TEXT, variant TEXT);
+
+INSERT INTO _test_state SELECT df.start(
+    $$SELECT 42 AS num$$ |=> 'my_result'
+    ~> $$INSERT INTO test_name_valid_results (val) VALUES ($my_result)$$,
+    'test-name-valid'
+), 'valid_name';
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state WHERE variant = 'valid_name';
+    SELECT df.wait_for_completion(inst_id) INTO status;
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [valid_name]: status = %', status;
+    END IF;
+
+    RAISE NOTICE 'PASSED: valid result name accepted';
+END $$;
+
+-- ============================================================================
+-- Test 2: SQL injection attempt should be rejected at DSL time
+-- ============================================================================
+
+DO $$
+BEGIN
+    PERFORM df.start(
+        df.as(df.sql('SELECT 1'), 'x) UNION SELECT version()--')
+        ~> df.sql('SELECT 1'),
+        'test-injection'
+    );
+    RAISE EXCEPTION 'TEST FAILED: injection name was not rejected';
+EXCEPTION
+    WHEN OTHERS THEN
+        IF SQLERRM LIKE '%not a valid identifier%' THEN
+            RAISE NOTICE 'PASSED: injection name correctly rejected: %', SQLERRM;
+        ELSE
+            RAISE EXCEPTION 'TEST FAILED: unexpected error: %', SQLERRM;
+        END IF;
+END $$;
+
+-- ============================================================================
+-- Test 3: Name with spaces should be rejected
+-- ============================================================================
+
+DO $$
+BEGIN
+    PERFORM df.sql('SELECT 1') |=> 'has space';
+    RAISE EXCEPTION 'TEST FAILED: spaced name was not rejected';
+EXCEPTION
+    WHEN OTHERS THEN
+        IF SQLERRM LIKE '%not a valid identifier%' THEN
+            RAISE NOTICE 'PASSED: spaced name correctly rejected: %', SQLERRM;
+        ELSE
+            RAISE EXCEPTION 'TEST FAILED: unexpected error: %', SQLERRM;
+        END IF;
+END $$;
+
+-- ============================================================================
+-- Test 4: Name starting with digit should be rejected
+-- ============================================================================
+
+DO $$
+BEGIN
+    PERFORM df.sql('SELECT 1') |=> '123abc';
+    RAISE EXCEPTION 'TEST FAILED: digit-start name was not rejected';
+EXCEPTION
+    WHEN OTHERS THEN
+        IF SQLERRM LIKE '%not a valid identifier%' THEN
+            RAISE NOTICE 'PASSED: digit-start name correctly rejected: %', SQLERRM;
+        ELSE
+            RAISE EXCEPTION 'TEST FAILED: unexpected error: %', SQLERRM;
+        END IF;
+END $$;
+
+-- Cleanup
+DROP TABLE _test_state;
+DROP TABLE test_name_valid_results;
+SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## Summary

Implements the [Named Results v2 spec](docs/named-results-v2.md) — four features that make named results (`|=>`) practical for multi-column queries, null handling, and row-set passing between nodes.

| Feature | Syntax | Purpose |
|---------|--------|---------|
| **Dot-notation** | `$name.column` | Access any column from the first row |
| **Null-safe accessor** | `$name?`, `$name.col?` | Return SQL `NULL` instead of failing on no-rows/NULL |
| **`df.if_rows`** | `df.if_rows(name, then, else)` | Branch on whether a named result has rows (in-memory, zero-cost) |
| **Row-set expansion** | `$name.*` | Expand all rows as an inline `VALUES` subquery |

### Bug fixes

- `$name` on a zero-row result previously substituted raw JSON (`{"rows":[],"row_count":0}`) into SQL, causing parse errors. Now **fails the instance** with a clear message and hint.
- `$name` on a NULL column previously substituted unquoted `null` text, causing silent no-ops in `WHERE` clauses. Now **fails the instance** by default; use `$name?` to opt into `NULL`.

### Substitution engine rewrite

The old `String::contains` loop is replaced by a single-pass scan-based engine with longest-match-first resolution:

1. `$name.*` — row-set expansion
2. `$name.column?` — null-safe dot-notation
3. `$name.column` — strict dot-notation
4. `$name?` — null-safe scalar
5. `$name` — strict scalar (fail-fast on no-rows/NULL)

### No DDL changes (except `df.if_rows`)

All substitution changes are in Rust code — no schema changes, no upgrade scripts, no B1 backward-compatibility concerns. `df.if_rows` is the only new SQL function, added via the upgrade script.

### Tests

- 15 new unit tests for the substitution engine
- 4 new E2E tests: `39_named_results_dot`, `40_if_rows`, `41_row_set_expansion`, `42_result_name_validation`

### Changed files

| File | Changes |
|------|---------|
| `src/types.rs` | Rewritten substitution engine, extraction helpers, `Result` return type |
| `src/dsl.rs` | Added `df.if_rows`, result name validation |
| `src/orchestrations/execute_function_graph.rs` | Propagate `Result` from substitution; `if_rows` condition path |
| `tests/e2e/sql/39_named_results_dot.sql` | Dot-notation, null-safe, strict-fail tests |
| `tests/e2e/sql/40_if_rows.sql` | `df.if_rows` branch tests |
| `tests/e2e/sql/41_row_set_expansion.sql` | `$name.*` expansion tests |
| `tests/e2e/sql/42_result_name_validation.sql` | Name validation / injection rejection tests |
| `sql/pg_durable--0.1.1--0.2.0.sql` | Upgrade script: `CREATE FUNCTION df.if_rows` |
| `USER_GUIDE.md` | New syntax docs |
| `docs/api-reference.md` | New `df.if_rows` entry, updated substitution pattern table |
| `docs/named-results-v2.md` | Design spec |
