### PR TITLE
Upgrade to duroxide 0.1.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,9 +489,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "duroxide"
-version = "0.1.20"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f59a981b0ededdac3dbcb89643795ceb3ef82cb92a9aefe4faa514c118886e5"
+checksum = "b1610ef81e6c9a3587188c882da16c5cbc462f1f86cf364d8e9a16074340db1e"
 dependencies = [
  "async-trait",
  "futures",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "duroxide-pg-opt"
-version = "0.1.18"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 
 # duroxide integration
-duroxide = "=0.1.20"
+duroxide = "=0.1.26"
 duroxide-pg-opt = { path = "duroxide-pg-opt", package = "duroxide-pg-opt" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 

--- a/docs/upgrade-testing.md
+++ b/docs/upgrade-testing.md
@@ -209,3 +209,16 @@ what the upgrade script handles, and any backward compatibility considerations.
 - **Scenario B1 considerations:** Readiness checking is internal to the Rust binary — no SQL function needs to be registered. The new `.so` continues to work against v0.1.1 schemas that have not run `ALTER EXTENSION UPDATE`.
 - **Scenario B2 considerations:** The BGW readiness check (`wait_for_ready()`) is called in both B1 and B2 scenarios to ensure the BGW has applied all pending duroxide migrations before exercising the extension.
 - **Current status on this branch:** Implemented. BGW now uses `MigrationPolicy::ApplyAll`, verifies duroxide schema extension ownership before applying, and writes `duroxide._worker_ready` after initialization completes.
+
+#### Bump to duroxide 0.1.26 + duroxide-pg-opt 4a6bf6b (migrations 0006–0010)
+- **DDL change (df schema):** None. All new schema objects are in the `duroxide` schema and are applied at runtime by the BGW.
+- **DDL change (duroxide schema):** Five new migrations applied by BGW at startup:
+  - 0006: `worker_queue.tag TEXT` column + index; updated `enqueue_worker_work` and `fetch_work_item` SPs
+  - 0007: `fetch_orchestration_item` SP body change only (no schema change)
+  - 0008: new `kv_store` table; updated `fetch_orchestration_item`, `ack_orchestration_item`, deletion/pruning SPs
+  - 0009: `kv_store.last_updated_at_ms BIGINT` column; updated KV materialization SPs
+  - 0010: new `kv_delta` table; two-table KV write model; delta→store merge on terminal transition
+- **Scenario A considerations:** The `df` schema equivalence contract is unchanged. The `duroxide` schema is excluded from snapshot diffs — fresh installs start with an empty `duroxide` schema (BGW fills it in at runtime) while upgrades carry forward the fully-populated schema from v0.1.1. This is expected and acceptable.
+- **Scenario B1 considerations:** The BGW uses `MigrationPolicy::ApplyAll`. A database that has only migrations 0001–0005 is handled gracefully: the BGW detects the gap and applies 0006–0010 at startup. No manual intervention is needed.
+- **Scenario B2 considerations:** All five new migrations are additive (new tables and columns with defaults or nullable). Existing `df.vars`, `df.nodes`, `df.instances`, and `df.graphs` data is untouched.
+- **Current status:** Implemented — submodule at `4a6bf6b`, `Cargo.toml` pinned to `duroxide = "=0.1.26"`.


### PR DESCRIPTION
- Bump duroxide crate from 0.1.20 to 0.1.26 (activity tags, KV store, KV delta table — none used by pg_durable yet, but required by duroxide-pg-opt)
- Advance duroxide-pg-opt submodule to 4a6bf6b (post-v0.1.23, includes MigrationPolicy support already in use)
- Five new duroxide migrations (0006–0010) applied automatically by BGW at startup via ApplyAll — no extension SQL or manual steps needed
- Zero Rust source changes: all provider-level breaking changes absorbed by duroxide-pg-opt
- Document upgrade impact in docs/upgrade-testing.md (Scenario A/B1/B2 analysis for migrations 0006–0010)