### PR TITLE
Harden metadata tables under RLS

### DIFF
--- a/docs/upgrade-testing.md
+++ b/docs/upgrade-testing.md
@@ -202,6 +202,12 @@ what the upgrade script handles, and any backward compatibility considerations.
 - **Scenario B2 considerations:** The upgrade script assigns all pre-existing `df.vars` rows to the role running `ALTER EXTENSION` via the `DEFAULT current_user::regrole` backfill. Upgrade tests verify that existing vars remain readable after upgrade for the role that performed the upgrade, that the migrated row is re-homed to that upgrade-running role, and that new post-upgrade writes/executions use owner-scoped semantics. This migration does not preserve per-user ownership for legacy rows; it intentionally re-homes them to the upgrade runner.
 - **Current status on this branch:** `scripts/test-upgrade.sh` now passes all Scenario A, B1, and B2 checks for this change.
 
+#### Metadata table hardening for direct INSERT + RLS
+- **DDL change:** `df.instances` and `df.nodes` add structural `CHECK` constraints, same-instance foreign keys, and supporting unique constraints. Table-wide `INSERT` grants are narrowed to column-level `INSERT` grants that match the columns `df.start()` writes, while preserving direct user `INSERT` under RLS.
+- **Scenario A considerations:** Schema comparison must include the new constraints, foreign keys, and narrowed grants on `df.instances` and `df.nodes`.
+- **Scenario B1 considerations:** The `.so` remains backward compatible with older schemas because the hardening is schema-only and does not introduce new columns or change Rust query shapes.
+- **Scenario B2 considerations:** The upgrade script adds the new `CHECK` and foreign-key constraints as `NOT VALID` so malformed legacy metadata rows do not block `ALTER EXTENSION UPDATE`, while all new writes are still enforced immediately after the upgrade.
+
 #### BGW applies duroxide migrations (replaces extension-SQL approach)
 - **DDL change (df schema):** No new SQL functions added for readiness. The internal Rust `is_worker_ready()` check (not SQL-callable) gates `df.*` functions until the BGW writes a row to `duroxide._worker_ready`.
 - **DDL change (duroxide schema):** None required in the upgrade script. Fresh v0.2.0 installs create `CREATE SCHEMA duroxide` via extension SQL (extension-owned). The BGW's `ApplyAll` policy applies duroxide table DDL at runtime. For customers upgrading from v0.1.1, the duroxide schema and its objects already exist (extension-owned from the earlier SQL-hand-over approach); the BGW will verify they are up-to-date and continue normally.

--- a/sql/pg_durable--0.1.1--0.2.0.sql
+++ b/sql/pg_durable--0.1.1--0.2.0.sql
@@ -26,6 +26,90 @@ ALTER TABLE df.vars ADD COLUMN owner REGROLE NOT NULL DEFAULT current_user::regr
 ALTER TABLE df.vars DROP CONSTRAINT vars_pkey;
 ALTER TABLE df.vars ADD PRIMARY KEY (owner, name);
 
+-- Keep direct INSERT on df.instances/df.nodes, but limit it to the columns
+-- df.start() writes. Runtime-owned columns remain protected from direct INSERT.
+REVOKE INSERT ON df.instances FROM PUBLIC;
+REVOKE INSERT ON df.nodes FROM PUBLIC;
+GRANT INSERT (id, label, root_node, submitted_by, login_role, database) ON df.instances TO PUBLIC;
+GRANT INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, login_role, database) ON df.nodes TO PUBLIC;
+
+-- Enforce a df.start-shaped graph for new direct writes without blocking
+-- upgrades on legacy malformed rows that may already exist.
+ALTER TABLE df.instances
+    ADD CONSTRAINT instances_id_format_chk
+        CHECK (id ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT instances_root_node_format_chk
+        CHECK (root_node ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT instances_status_chk
+        CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')) NOT VALID,
+    -- Supports the composite FK from df.nodes that ties node identity to the instance row.
+    ADD CONSTRAINT instances_identity_key
+        UNIQUE (id, submitted_by, login_role);
+
+ALTER TABLE df.nodes
+    ADD CONSTRAINT nodes_instance_id_present_chk
+        CHECK (instance_id IS NOT NULL) NOT VALID,
+    ADD CONSTRAINT nodes_submitted_by_present_chk
+        CHECK (submitted_by IS NOT NULL) NOT VALID,
+    ADD CONSTRAINT nodes_login_role_present_chk
+        CHECK (login_role IS NOT NULL) NOT VALID,
+    ADD CONSTRAINT nodes_id_format_chk
+        CHECK (id ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT nodes_instance_id_format_chk
+        CHECK (instance_id ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT nodes_left_node_format_chk
+        CHECK (left_node IS NULL OR left_node ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT nodes_right_node_format_chk
+        CHECK (right_node IS NULL OR right_node ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT nodes_node_type_chk
+        CHECK (node_type IN ('SQL', 'THEN', 'IF', 'JOIN', 'LOOP', 'BREAK', 'RACE', 'SLEEP', 'WAIT_SCHEDULE', 'HTTP', 'SIGNAL')) NOT VALID,
+    ADD CONSTRAINT nodes_result_name_chk
+        CHECK (result_name IS NULL OR result_name ~ '^[A-Za-z_][A-Za-z0-9_]*$') NOT VALID,
+    ADD CONSTRAINT nodes_status_chk
+        CHECK (status IN ('pending', 'running', 'completed', 'failed')) NOT VALID,
+    ADD CONSTRAINT nodes_result_status_chk
+        CHECK (result IS NULL OR status IN ('completed', 'failed')) NOT VALID,
+    ADD CONSTRAINT nodes_structure_chk
+        CHECK (
+            CASE
+                WHEN node_type IN ('SQL', 'SLEEP', 'WAIT_SCHEDULE', 'BREAK', 'HTTP', 'SIGNAL')
+                    THEN left_node IS NULL AND right_node IS NULL AND query IS NOT NULL
+                WHEN node_type = 'THEN'
+                    THEN left_node IS NOT NULL AND right_node IS NOT NULL AND query IS NULL
+                WHEN node_type = 'IF'
+                    THEN left_node IS NOT NULL AND right_node IS NOT NULL AND query IS NOT NULL
+                WHEN node_type = 'LOOP'
+                    THEN left_node IS NOT NULL AND right_node IS NULL
+                WHEN node_type = 'JOIN'
+                    THEN left_node IS NOT NULL AND right_node IS NOT NULL
+                WHEN node_type = 'RACE'
+                    THEN left_node IS NOT NULL AND right_node IS NOT NULL AND query IS NULL
+                ELSE FALSE
+            END
+        ) NOT VALID,
+    ADD CONSTRAINT nodes_instance_node_key
+        UNIQUE (instance_id, id);
+
+ALTER TABLE df.nodes
+    ADD CONSTRAINT nodes_instance_identity_fkey
+        FOREIGN KEY (instance_id, submitted_by, login_role)
+        REFERENCES df.instances (id, submitted_by, login_role)
+        DEFERRABLE INITIALLY DEFERRED NOT VALID,
+    ADD CONSTRAINT nodes_left_node_same_instance_fkey
+        FOREIGN KEY (instance_id, left_node)
+        REFERENCES df.nodes (instance_id, id)
+        DEFERRABLE INITIALLY DEFERRED NOT VALID,
+    ADD CONSTRAINT nodes_right_node_same_instance_fkey
+        FOREIGN KEY (instance_id, right_node)
+        REFERENCES df.nodes (instance_id, id)
+        DEFERRABLE INITIALLY DEFERRED NOT VALID;
+
+ALTER TABLE df.instances
+    ADD CONSTRAINT instances_root_node_same_instance_fkey
+        FOREIGN KEY (id, root_node)
+        REFERENCES df.nodes (instance_id, id)
+        DEFERRABLE INITIALLY DEFERRED NOT VALID;
+
 -- ============================================================================
 -- 2. Enable RLS on df.vars
 -- ============================================================================
@@ -36,6 +120,24 @@ CREATE POLICY vars_user_isolation ON df.vars
     FOR ALL
     USING (owner = current_user::regrole)
     WITH CHECK (owner = current_user::regrole);
+
+DROP POLICY instances_user_isolation ON df.instances;
+CREATE POLICY instances_user_isolation ON df.instances
+    FOR ALL
+    USING (submitted_by = current_user::regrole)
+    WITH CHECK (
+        submitted_by = current_user::regrole
+        AND login_role = session_user::regrole
+    );
+
+DROP POLICY nodes_user_isolation ON df.nodes;
+CREATE POLICY nodes_user_isolation ON df.nodes
+    FOR ALL
+    USING (submitted_by = current_user::regrole)
+    WITH CHECK (
+        submitted_by = current_user::regrole
+        AND login_role = session_user::regrole
+    );
 
 -- ============================================================================
 -- 3. Harden PL/pgSQL and SQL helper functions with SET search_path

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -721,7 +721,7 @@ pub fn start(
 
     // Create instance record with root node ID
     if let Err(e) = Spi::run_with_args(
-        "INSERT INTO df.instances (id, label, root_node, status, submitted_by, login_role, database) VALUES ($1, $2, $3, 'pending', $4::oid::regrole, $5::oid::regrole, $6)",
+        "INSERT INTO df.instances (id, label, root_node, submitted_by, login_role, database) VALUES ($1, $2, $3, $4::oid::regrole, $5::oid::regrole, $6)",
         &[
             instance_id.as_str().into(),
             label_arg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,81 @@ CREATE TABLE IF NOT EXISTS df._worker_epoch (
     started_at TIMESTAMPTZ DEFAULT now(),
     last_seen_at TIMESTAMPTZ DEFAULT now()
 );
+
+ALTER TABLE df.instances
+    ADD CONSTRAINT instances_id_format_chk
+        CHECK (id ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT instances_root_node_format_chk
+        CHECK (root_node ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT instances_status_chk
+        CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')) NOT VALID,
+    -- Supports the composite FK from df.nodes that ties node identity to the instance row.
+    ADD CONSTRAINT instances_identity_key
+        UNIQUE (id, submitted_by, login_role);
+
+ALTER TABLE df.nodes
+    ADD CONSTRAINT nodes_instance_id_present_chk
+        CHECK (instance_id IS NOT NULL) NOT VALID,
+    ADD CONSTRAINT nodes_submitted_by_present_chk
+        CHECK (submitted_by IS NOT NULL) NOT VALID,
+    ADD CONSTRAINT nodes_login_role_present_chk
+        CHECK (login_role IS NOT NULL) NOT VALID,
+    ADD CONSTRAINT nodes_id_format_chk
+        CHECK (id ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT nodes_instance_id_format_chk
+        CHECK (instance_id ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT nodes_left_node_format_chk
+        CHECK (left_node IS NULL OR left_node ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT nodes_right_node_format_chk
+        CHECK (right_node IS NULL OR right_node ~ '^[0-9a-f]{8}$') NOT VALID,
+    ADD CONSTRAINT nodes_node_type_chk
+        CHECK (node_type IN ('SQL', 'THEN', 'IF', 'JOIN', 'LOOP', 'BREAK', 'RACE', 'SLEEP', 'WAIT_SCHEDULE', 'HTTP', 'SIGNAL')) NOT VALID,
+    ADD CONSTRAINT nodes_result_name_chk
+        CHECK (result_name IS NULL OR result_name ~ '^[A-Za-z_][A-Za-z0-9_]*$') NOT VALID,
+    ADD CONSTRAINT nodes_status_chk
+        CHECK (status IN ('pending', 'running', 'completed', 'failed')) NOT VALID,
+    ADD CONSTRAINT nodes_result_status_chk
+        CHECK (result IS NULL OR status IN ('completed', 'failed')) NOT VALID,
+    ADD CONSTRAINT nodes_structure_chk
+        CHECK (
+            CASE
+                WHEN node_type IN ('SQL', 'SLEEP', 'WAIT_SCHEDULE', 'BREAK', 'HTTP', 'SIGNAL')
+                    THEN left_node IS NULL AND right_node IS NULL AND query IS NOT NULL
+                WHEN node_type = 'THEN'
+                    THEN left_node IS NOT NULL AND right_node IS NOT NULL AND query IS NULL
+                WHEN node_type = 'IF'
+                    THEN left_node IS NOT NULL AND right_node IS NOT NULL AND query IS NOT NULL
+                WHEN node_type = 'LOOP'
+                    THEN left_node IS NOT NULL AND right_node IS NULL
+                WHEN node_type = 'JOIN'
+                    THEN left_node IS NOT NULL AND right_node IS NOT NULL
+                WHEN node_type = 'RACE'
+                    THEN left_node IS NOT NULL AND right_node IS NOT NULL AND query IS NULL
+                ELSE FALSE
+            END
+        ) NOT VALID,
+    ADD CONSTRAINT nodes_instance_node_key
+        UNIQUE (instance_id, id);
+
+ALTER TABLE df.nodes
+    ADD CONSTRAINT nodes_instance_identity_fkey
+        FOREIGN KEY (instance_id, submitted_by, login_role)
+        REFERENCES df.instances (id, submitted_by, login_role)
+        DEFERRABLE INITIALLY DEFERRED NOT VALID,
+    ADD CONSTRAINT nodes_left_node_same_instance_fkey
+        FOREIGN KEY (instance_id, left_node)
+        REFERENCES df.nodes (instance_id, id)
+        DEFERRABLE INITIALLY DEFERRED NOT VALID,
+    ADD CONSTRAINT nodes_right_node_same_instance_fkey
+        FOREIGN KEY (instance_id, right_node)
+        REFERENCES df.nodes (instance_id, id)
+        DEFERRABLE INITIALLY DEFERRED NOT VALID;
+
+ALTER TABLE df.instances
+    ADD CONSTRAINT instances_root_node_same_instance_fkey
+        FOREIGN KEY (id, root_node)
+        REFERENCES df.nodes (instance_id, id)
+        DEFERRABLE INITIALLY DEFERRED NOT VALID;
 "#,
     name = "create_tables",
     requires = [df]
@@ -220,7 +295,10 @@ ALTER TABLE df.instances ENABLE ROW LEVEL SECURITY;
 CREATE POLICY instances_user_isolation ON df.instances
     FOR ALL
     USING (submitted_by = current_user::regrole)
-    WITH CHECK (submitted_by = current_user::regrole);
+    WITH CHECK (
+        submitted_by = current_user::regrole
+        AND login_role = session_user::regrole
+    );
 
 -- Enable RLS on df.nodes
 ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
@@ -228,7 +306,10 @@ ALTER TABLE df.nodes ENABLE ROW LEVEL SECURITY;
 CREATE POLICY nodes_user_isolation ON df.nodes
     FOR ALL
     USING (submitted_by = current_user::regrole)
-    WITH CHECK (submitted_by = current_user::regrole);
+    WITH CHECK (
+        submitted_by = current_user::regrole
+        AND login_role = session_user::regrole
+    );
 
 -- Enable RLS on df.vars (per-user variable isolation)
 ALTER TABLE df.vars ENABLE ROW LEVEL SECURITY;
@@ -245,9 +326,11 @@ GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df TO PUBLIC;
 -- Column-level UPDATE on instances: only status + updated_at (for df.cancel())
 -- No UPDATE on identity columns (submitted_by, login_role) or structural columns (root_node)
 -- No DELETE — instance/node deletion should happen via admin API or TTL
-GRANT SELECT, INSERT ON df.instances TO PUBLIC;
+GRANT SELECT ON df.instances TO PUBLIC;
 GRANT UPDATE (status, updated_at) ON df.instances TO PUBLIC;
-GRANT SELECT, INSERT ON df.nodes TO PUBLIC;
+GRANT SELECT ON df.nodes TO PUBLIC;
+GRANT INSERT (id, label, root_node, submitted_by, login_role, database) ON df.instances TO PUBLIC;
+GRANT INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, login_role, database) ON df.nodes TO PUBLIC;
 GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO PUBLIC;
 
 -- Validate that the worker role is a superuser.

--- a/tests/e2e/sql/37_rls.sql
+++ b/tests/e2e/sql/37_rls.sql
@@ -381,6 +381,75 @@ BEGIN
 END $$;
 
 -- ============================================================================
+-- Test 10: User cannot INSERT runtime-owned columns directly
+-- ============================================================================
+DO $$
+BEGIN
+    SET SESSION AUTHORIZATION rls_alice;
+
+    BEGIN
+        INSERT INTO df.instances (id, root_node, status, submitted_by, login_role)
+        VALUES ('deadbeef', 'cafebabe', 'completed', current_user::regrole, session_user::regrole);
+        RAISE EXCEPTION 'TEST 10 FAILED: Alice was able to INSERT status into df.instances';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            NULL; -- expected
+    END;
+
+    BEGIN
+        INSERT INTO df.nodes (id, instance_id, node_type, query, status, submitted_by, login_role)
+        VALUES ('deadbeef', 'cafebabe', 'SQL', 'SELECT 1', 'completed', current_user::regrole, session_user::regrole);
+        RAISE EXCEPTION 'TEST 10 FAILED: Alice was able to INSERT status into df.nodes';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            NULL; -- expected
+    END;
+
+    BEGIN
+        INSERT INTO df.instances (id, root_node, submitted_by, login_role)
+        VALUES ('deadbeef', 'cafebabe', current_user::regrole, 'postgres'::regrole);
+        RAISE EXCEPTION 'TEST 10 FAILED: Alice was able to spoof login_role on df.instances';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            NULL; -- expected
+    END;
+
+    RESET SESSION AUTHORIZATION;
+
+    RAISE NOTICE 'Test 10 PASSED: INSERT is limited to df.start()-shaped columns';
+END $$;
+
+-- ============================================================================
+-- Test 11: Direct INSERT still respects shape constraints
+-- ============================================================================
+DO $$
+BEGIN
+    SET SESSION AUTHORIZATION rls_alice;
+
+    BEGIN
+        INSERT INTO df.instances (id, root_node, submitted_by, login_role)
+        VALUES ('not_hex!', 'cafebabe', current_user::regrole, session_user::regrole);
+        RAISE EXCEPTION 'TEST 11 FAILED: Alice was able to INSERT malformed instance metadata';
+    EXCEPTION
+        WHEN check_violation THEN
+            NULL; -- expected
+    END;
+
+    BEGIN
+        INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, submitted_by, login_role)
+        VALUES ('deadbeef', 'cafebabe', 'SQL', 'SELECT 1', 'bad-name', current_user::regrole, session_user::regrole);
+        RAISE EXCEPTION 'TEST 11 FAILED: Alice was able to INSERT malformed node metadata';
+    EXCEPTION
+        WHEN check_violation THEN
+            NULL; -- expected
+    END;
+
+    RESET SESSION AUTHORIZATION;
+
+    RAISE NOTICE 'Test 11 PASSED: Direct INSERT must satisfy metadata shape constraints';
+END $$;
+
+-- ============================================================================
 -- Cleanup
 -- ============================================================================
 DROP TABLE IF EXISTS _rls_alice_state;


### PR DESCRIPTION
## Summary
Add schema hardening for direct metadata inserts under RLS.

- narrow INSERT grants on df.instances and df.nodes to df.start-shaped columns
- add structural checks and same-instance foreign keys for metadata rows
- tighten RLS write checks so login_role must match session_user
- update df.start to rely on the instance status default
- document the upgrade impact and add RLS coverage

## Validation
- cargo build --features pg17
- ./scripts/test-e2e-local.sh --verbose 37_rls
- ./scripts/test-upgrade.sh