### PR TITLE
Parameterize worker status updates

### DIFF
--- a/src/activities/update_instance_status.rs
+++ b/src/activities/update_instance_status.rs
@@ -23,17 +23,25 @@ pub async fn execute(
         "Updating instance {instance_id} status to {status}"
     ));
 
-    let update_query = if status == "completed" {
-        format!(
-            "UPDATE df.instances SET status = 'completed', completed_at = now(), updated_at = now() WHERE id = '{instance_id}'"
+    let query = if status == "completed" {
+        sqlx::query(
+            "UPDATE df.instances
+             SET status = $1, completed_at = now(), updated_at = now()
+             WHERE id = $2",
         )
+        .bind(status)
+        .bind(instance_id)
     } else {
-        format!(
-            "UPDATE df.instances SET status = '{status}', updated_at = now() WHERE id = '{instance_id}'"
+        sqlx::query(
+            "UPDATE df.instances
+             SET status = $1, updated_at = now()
+             WHERE id = $2",
         )
+        .bind(status)
+        .bind(instance_id)
     };
 
-    match sqlx::query(&update_query).execute(pool.as_ref()).await {
+    match query.execute(pool.as_ref()).await {
         Ok(_) => {
             ctx.trace_info(format!("Instance {instance_id} status updated to {status}"));
             Ok(format!("Status updated to {status}"))

--- a/src/activities/update_node_status.rs
+++ b/src/activities/update_node_status.rs
@@ -20,27 +20,31 @@ pub async fn execute(
     let status = input["status"].as_str().ok_or("Missing status")?;
     let result = input.get("result").and_then(|r| r.as_str());
 
-    let update_query = if let Some(res) = result {
-        // The result column is JSONB, so we need valid JSON.
-        // If the result is already valid JSON, use it directly.
-        // If not (e.g., error strings), wrap it as a JSON string.
-        let json_result = if serde_json::from_str::<serde_json::Value>(res).is_ok() {
-            res.to_string()
-        } else {
-            // Wrap as JSON string - serde_json::to_string handles escaping
-            serde_json::to_string(res).unwrap_or_else(|_| "null".to_string())
-        };
-        // Use dollar-quoting to avoid SQL escaping issues with JSON
-        format!(
-            "UPDATE df.nodes SET status = '{status}', result = $json${json_result}$json$::jsonb, updated_at = now() WHERE id = '{node_id}'"
+    let query = if let Some(res) = result {
+        // The result column is JSONB, so normalize invalid JSON payloads into
+        // a JSON string before binding.
+        let json_result = serde_json::from_str::<serde_json::Value>(res)
+            .unwrap_or_else(|_| serde_json::Value::String(res.to_string()));
+
+        sqlx::query(
+            "UPDATE df.nodes
+             SET status = $1, result = $2::jsonb, updated_at = now()
+             WHERE id = $3",
         )
+        .bind(status)
+        .bind(json_result)
+        .bind(node_id)
     } else {
-        format!(
-            "UPDATE df.nodes SET status = '{status}', updated_at = now() WHERE id = '{node_id}'"
+        sqlx::query(
+            "UPDATE df.nodes
+             SET status = $1, updated_at = now()
+             WHERE id = $2",
         )
+        .bind(status)
+        .bind(node_id)
     };
 
-    match sqlx::query(&update_query).execute(pool.as_ref()).await {
+    match query.execute(pool.as_ref()).await {
         Ok(_) => Ok("Node status updated".to_string()),
         Err(e) => {
             let err_msg = format!("Failed to update node status: {e}");


### PR DESCRIPTION
## Summary
Parameterize the worker-side status update queries to remove SQL injection sinks.

- replace interpolated SQL in update_instance_status with bound parameters
- replace interpolated SQL in update_node_status with bound parameters
- keep JSONB result handling by binding normalized JSON values instead of splicing them into SQL text

## Validation
- cargo build --features pg17