### PR TITLE
Add Codespaces read permission for duroxide-pg-opt submodule

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,15 @@
         "rust-analyzer.check.command": "clippy",
         "rust-analyzer.check.extraArgs": ["--features", "pg17"]
       }
+    },
+    "codespaces": {
+      "repositories": {
+        "microsoft/duroxide-pg-opt": {
+          "permissions": {
+            "contents": "read"
+          }
+        }
+      }
     }
   },
 


### PR DESCRIPTION
Grant Codespaces read access to the `microsoft/duroxide-pg-opt` repository so the submodule can be cloned when opening this repo in a codespace.