### PR TITLE
Harden grant/revoke helpers and fix test runner error handling

### DIFF
--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -339,8 +339,10 @@ for run in $(seq 1 $REPEAT_COUNT); do
         # In verbose mode, show output as it happens
         if [ "$VERBOSE" = true ]; then
             echo ""  # Newline before verbose output
-            "$PSQL" -h localhost -p $PG_PORT -U "$PSQL_USER" -d $PG_DB -v ON_ERROR_STOP=1 -v client_min_messages=notice -f "$test_file" || true
-            exit_code=${PIPESTATUS[0]:-$?}
+            set +e
+            "$PSQL" -h localhost -p $PG_PORT -U "$PSQL_USER" -d $PG_DB -v ON_ERROR_STOP=1 -v client_min_messages=notice -f "$test_file"
+            exit_code=$?
+            set -e
 
             if [ $exit_code -eq 0 ]; then
                 echo -e "  ${GREEN}PASS${NC}"
@@ -351,8 +353,10 @@ for run in $(seq 1 $REPEAT_COUNT); do
             fi
         else
             # Non-verbose mode: capture output and show summary
-            output=$( "$PSQL" -h localhost -p $PG_PORT -U "$PSQL_USER" -d $PG_DB -v ON_ERROR_STOP=1 -f "$test_file" 2>&1 ) || true
-            exit_code=${PIPESTATUS[0]:-$?}
+            set +e
+            output=$( "$PSQL" -h localhost -p $PG_PORT -U "$PSQL_USER" -d $PG_DB -v ON_ERROR_STOP=1 -f "$test_file" 2>&1 )
+            exit_code=$?
+            set -e
             
             if [ $exit_code -eq 0 ]; then
                 if echo "$output" | grep -q "TEST PASSED"; then

--- a/sql/pg_durable--0.1.1--0.2.0.sql
+++ b/sql/pg_durable--0.1.1--0.2.0.sql
@@ -242,6 +242,10 @@ LANGUAGE plpgsql
 SET search_path = pg_catalog, df, pg_temp
 AS $fn$
 BEGIN
+    IF NOT current_setting('is_superuser')::bool THEN
+        RAISE EXCEPTION 'df.grant_usage() requires superuser';
+    END IF;
+
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = p_role) THEN
         RAISE EXCEPTION 'role "%" does not exist', p_role;
     END IF;
@@ -268,6 +272,10 @@ LANGUAGE plpgsql
 SET search_path = pg_catalog, df, pg_temp
 AS $fn$
 BEGIN
+    IF NOT current_setting('is_superuser')::bool THEN
+        RAISE EXCEPTION 'df.revoke_usage() requires superuser';
+    END IF;
+
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = p_role) THEN
         RAISE EXCEPTION 'role "%" does not exist', p_role;
     END IF;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,10 @@ LANGUAGE plpgsql
 SET search_path = pg_catalog, df, pg_temp
 AS $fn$
 BEGIN
+    IF NOT current_setting('is_superuser')::bool THEN
+        RAISE EXCEPTION 'df.grant_usage() requires superuser';
+    END IF;
+
     -- Validate the role exists
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = p_role) THEN
         RAISE EXCEPTION 'role "%" does not exist', p_role;
@@ -352,6 +356,10 @@ LANGUAGE plpgsql
 SET search_path = pg_catalog, df, pg_temp
 AS $fn$
 BEGIN
+    IF NOT current_setting('is_superuser')::bool THEN
+        RAISE EXCEPTION 'df.revoke_usage() requires superuser';
+    END IF;
+
     -- Validate the role exists
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = p_role) THEN
         RAISE EXCEPTION 'role "%" does not exist', p_role;

--- a/tests/e2e/sql/00_setup_playground.sql
+++ b/tests/e2e/sql/00_setup_playground.sql
@@ -88,20 +88,6 @@ BEGIN
     END LOOP;
 END $$;
 
--- ---------------------------------------------------------------------------
--- Reusable helper: grant df schema/table/function privileges to a role.
---
--- After removing default PUBLIC grants from CREATE EXTENSION, every test
--- role that needs to call df.* functions must be granted explicitly.
--- Wraps df.grant_usage() so tests stay DRY and use the canonical helper.
--- ---------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION public._e2e_grant_df_privileges(p_role TEXT)
-RETURNS void
-LANGUAGE plpgsql AS $$
-BEGIN
-    PERFORM df.grant_usage(p_role);
-END $$;
-
 -- Install extensions needed by tests (requires superuser)
 CREATE EXTENSION IF NOT EXISTS dblink;
 
@@ -111,7 +97,7 @@ GRANT USAGE, CREATE ON SCHEMA public TO df_e2e_user;
 
 -- Grant df privileges to the default E2E user. CREATE EXTENSION no longer
 -- grants to PUBLIC, so every non-superuser role needs explicit privileges.
-SELECT public._e2e_grant_df_privileges('df_e2e_user');
+SELECT df.grant_usage('df_e2e_user');
 
 -- Create playground schema
 CREATE SCHEMA IF NOT EXISTS playground;

--- a/tests/e2e/sql/25_extension_creation_security.sql
+++ b/tests/e2e/sql/25_extension_creation_security.sql
@@ -116,7 +116,44 @@ END $$;
 RESET ROLE;
 
 -- Re-grant df privileges to the E2E user (no longer auto-granted to PUBLIC)
-SELECT public._e2e_grant_df_privileges('df_e2e_user');
+SELECT df.grant_usage('df_e2e_user');
+
+-- ============================================================================
+-- Test 4: Non-superuser cannot call df.grant_usage() or df.revoke_usage()
+-- ============================================================================
+
+SET ROLE df_e2e_user;
+
+DO $$
+BEGIN
+    -- df.grant_usage() should be blocked for non-superuser
+    BEGIN
+        PERFORM df.grant_usage('df_e2e_user');
+        RAISE EXCEPTION 'SECURITY FAILURE: non-superuser was able to call df.grant_usage()';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLERRM LIKE '%requires superuser%' THEN
+                RAISE NOTICE 'TEST 4a PASSED: df.grant_usage() blocked for non-superuser';
+            ELSE
+                RAISE EXCEPTION 'TEST 4a UNEXPECTED ERROR: %', SQLERRM;
+            END IF;
+    END;
+
+    -- df.revoke_usage() should be blocked for non-superuser
+    BEGIN
+        PERFORM df.revoke_usage('df_e2e_user');
+        RAISE EXCEPTION 'SECURITY FAILURE: non-superuser was able to call df.revoke_usage()';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLERRM LIKE '%requires superuser%' THEN
+                RAISE NOTICE 'TEST 4b PASSED: df.revoke_usage() blocked for non-superuser';
+            ELSE
+                RAISE EXCEPTION 'TEST 4b UNEXPECTED ERROR: %', SQLERRM;
+            END IF;
+    END;
+END $$;
+
+RESET ROLE;
 
 -- Wait for the background worker to fully reinitialize after the drop/recreate.
 SELECT public._e2e_wait_for_worker_ready();

--- a/tests/e2e/sql/27_user_isolation.sql
+++ b/tests/e2e/sql/27_user_isolation.sql
@@ -27,8 +27,8 @@ CREATE ROLE iso_alice LOGIN;
 CREATE ROLE iso_bob   LOGIN;
 
 -- Grant df privileges explicitly (no longer auto-granted to PUBLIC)
-SELECT public._e2e_grant_df_privileges('iso_alice');
-SELECT public._e2e_grant_df_privileges('iso_bob');
+SELECT df.grant_usage('iso_alice');
+SELECT df.grant_usage('iso_bob');
 
 -- Grant non-auto privileges needed by these tests.
 GRANT TEMPORARY ON DATABASE postgres TO iso_alice, iso_bob;
@@ -183,7 +183,7 @@ INSERT INTO iso_analyst_data (value) VALUES ('analyst report') ON CONFLICT DO NO
 -- Grant iso_analysts to alice and grant df permissions to the group role
 GRANT iso_analysts TO iso_alice;
 -- Grant df privileges explicitly (no longer auto-granted to PUBLIC)
-SELECT public._e2e_grant_df_privileges('iso_analysts');
+SELECT df.grant_usage('iso_analysts');
 GRANT TEMPORARY ON DATABASE postgres TO iso_analysts;
 
 -- Test 5a: SET ROLE to NOLOGIN role → df.start() should error
@@ -357,7 +357,7 @@ END $test7_setup$;
 
 CREATE ROLE iso_ephemeral LOGIN;
 -- Grant df privileges explicitly (no longer auto-granted to PUBLIC)
-SELECT public._e2e_grant_df_privileges('iso_ephemeral');
+SELECT df.grant_usage('iso_ephemeral');
 GRANT TEMPORARY ON DATABASE postgres TO iso_ephemeral;
 
 -- Submit a sequence: df.sleep(3) followed by df.sql('SELECT 1')

--- a/tests/e2e/sql/28_bgw_lifecycle.sql
+++ b/tests/e2e/sql/28_bgw_lifecycle.sql
@@ -35,7 +35,7 @@ END $$;
 CREATE EXTENSION pg_durable;
 
 -- Re-grant df privileges to the E2E user (no longer auto-granted to PUBLIC)
-SELECT public._e2e_grant_df_privileges('df_e2e_user');
+SELECT df.grant_usage('df_e2e_user');
 
 -- Wait for the background worker to initialize
 SELECT public._e2e_wait_for_worker_ready();
@@ -88,7 +88,7 @@ END $$;
 CREATE EXTENSION pg_durable;
 
 -- Re-grant df privileges to the E2E user (no longer auto-granted to PUBLIC)
-SELECT public._e2e_grant_df_privileges('df_e2e_user');
+SELECT df.grant_usage('df_e2e_user');
 
 -- Wait for the background worker to fully reinitialize
 SELECT public._e2e_wait_for_worker_ready();

--- a/tests/e2e/sql/29_database_validation.sql
+++ b/tests/e2e/sql/29_database_validation.sql
@@ -42,7 +42,7 @@ SELECT public._e2e_drop_extension_safe();
 CREATE EXTENSION pg_durable;
 
 -- Re-grant df privileges to the E2E user (no longer auto-granted to PUBLIC)
-SELECT public._e2e_grant_df_privileges('df_e2e_user');
+SELECT df.grant_usage('df_e2e_user');
 
 -- Wait for the background worker to fully reinitialize
 SELECT public._e2e_wait_for_worker_ready();

--- a/tests/e2e/sql/37_rls.sql
+++ b/tests/e2e/sql/37_rls.sql
@@ -31,8 +31,8 @@ CREATE ROLE rls_alice LOGIN;
 CREATE ROLE rls_bob   LOGIN;
 
 -- Grant df privileges explicitly (no longer auto-granted to PUBLIC)
-SELECT public._e2e_grant_df_privileges('rls_alice');
-SELECT public._e2e_grant_df_privileges('rls_bob');
+SELECT df.grant_usage('rls_alice');
+SELECT df.grant_usage('rls_bob');
 
 -- Grant TEMPORARY for temp tables
 GRANT TEMPORARY ON DATABASE postgres TO rls_alice, rls_bob;

--- a/tests/e2e/sql/38_rls_vars.sql
+++ b/tests/e2e/sql/38_rls_vars.sql
@@ -30,8 +30,8 @@ CREATE ROLE vars_alice LOGIN;
 CREATE ROLE vars_bob   LOGIN;
 
 -- Grant df privileges explicitly (no longer auto-granted to PUBLIC)
-SELECT public._e2e_grant_df_privileges('vars_alice');
-SELECT public._e2e_grant_df_privileges('vars_bob');
+SELECT df.grant_usage('vars_alice');
+SELECT df.grant_usage('vars_bob');
 
 GRANT TEMPORARY ON DATABASE postgres TO vars_alice, vars_bob;
 


### PR DESCRIPTION
Follow-up fixes from the review of #85 (remove default PUBLIC grants).

## Changes

### 1. Add superuser guard to `df.grant_usage()` / `df.revoke_usage()`

Both functions now check `current_setting('is_superuser')::bool` at the top and raise an exception if the caller is not a superuser. Applied to both the fresh-install SQL (`src/lib.rs`) and the upgrade script (`sql/pg_durable--0.1.1--0.2.0.sql`).

An E2E test (Test 4 in `25_extension_creation_security.sql`) verifies that a non-superuser is blocked from calling either function.

### 2. Remove `_e2e_grant_df_privileges()` test wrapper

The thin wrapper just called `df.grant_usage()`. All 11 call sites across 7 test files now invoke `df.grant_usage()` directly.

### 3. Fix test runner swallowing exit codes

The `|| true` pattern in `test-e2e-local.sh` caused both `$?` and `PIPESTATUS[0]` to always return 0, so failing tests were silently reported as passing. Replaced with `set +e` / `set -e` around the psql invocation to properly capture exit codes.