### PR TITLE
Simplify test-e2e-local options

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Complex local integration tests with pgrx PostgreSQL:
 ```bash
 ./scripts/test-e2e-local.sh                                                  # All local SQL E2E tests, including special restart/config phases
 ./scripts/test-e2e-local.sh 04_parallel                                      # Specific test
-./scripts/test-e2e-local.sh --connlimit-backpressure --connlimit-timeout      # Only the selected connection-limit phases
+./scripts/test-e2e-local.sh --default-build-phases                            # Only the default-build phase group
 ```
 
 See [tests/e2e/](tests/e2e/) for details.

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -43,7 +43,7 @@ The test suite is organized into 23 files. Files `01`–`09` open with `SET SESS
 | File | Description |
 |------|-------------|
 | `00_setup_playground.sql` | Shared test infrastructure — creates `playground.*` tables and helper functions (not a test) |
-| `00_requires_shared_preload.sql` | Verifies that the extension requires `shared_preload_libraries`; runs in `--no-preload` phase only |
+| `00_requires_shared_preload.sql` | Verifies that the extension requires `shared_preload_libraries`; runs in the `no-preload` phase when selected by filename |
 
 ### Non-Privileged Tests (runs as `df_e2e_user`)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -102,11 +102,8 @@ Fast iteration using local pgrx PostgreSQL. Best for development.
 # Run specific test
 ./scripts/test-e2e-local.sh 04_parallel
 
-# Run only the standard preload-enabled suite
-./scripts/test-e2e-local.sh --standard
-
-# Run only specific special phases
-./scripts/test-e2e-local.sh --connlimit-backpressure --connlimit-timeout
+# Run only the phases that share the standard build artifact
+./scripts/test-e2e-local.sh --default-build-phases
 
 # Run test multiple times (stability check)
 ./scripts/test-e2e-local.sh 04_parallel 5

--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -10,12 +10,6 @@
 #   --verbose, -v             Show NOTICE messages and full test output
 #   --pg-version VER          PostgreSQL major version to use (default: 17)
 #   --default-build-phases    Run all phases that share the standard build artifact
-#   --no-preload              Run only the shared_preload_libraries enforcement phase
-#   --standard                Run only the standard preload-enabled phase
-#   --superuser-guc-off       Run only the superuser GUC off phase
-#   --connlimit-backpressure  Run only the connection limit backpressure phase
-#   --connlimit-timeout       Run only the connection limit timeout phase
-#   --connlimit-startup       Run only the connection limit startup-validation phase
 #   --http-disabled           Run only the HTTP-disabled (no http Cargo feature) phase
 #   --http-allow-all          Run only the http-allow-all Cargo feature phase
 #   --help, -h                Show this help
@@ -27,9 +21,9 @@
 #   ./scripts/test-e2e-local.sh --keep
 #   ./scripts/test-e2e-local.sh --clean --pg-version 18
 #   ./scripts/test-e2e-local.sh --default-build-phases
-#   ./scripts/test-e2e-local.sh --no-preload
-#   ./scripts/test-e2e-local.sh --connlimit-backpressure --connlimit-timeout
-#   ./scripts/test-e2e-local.sh --http-disabled
+#   ./scripts/test-e2e-local.sh 00_requires_shared_preload
+#   ./scripts/test-e2e-local.sh 45_connection_limit_timeout
+#   ./scripts/test-e2e-local.sh --http-disabled 47_http_dsl_disabled
 #   ./scripts/test-e2e-local.sh --http-allow-all
 # END_USAGE
 
@@ -210,36 +204,6 @@ while [[ $# -gt 0 ]]; do
         --default-build-phases)
             EXPLICIT_PHASES=true
             add_requested_phases "${DEFAULT_BUILD_PHASES[@]}"
-            shift
-            ;;
-        --no-preload)
-            EXPLICIT_PHASES=true
-            add_requested_phase "no-preload"
-            shift
-            ;;
-        --standard)
-            EXPLICIT_PHASES=true
-            add_requested_phase "standard"
-            shift
-            ;;
-        --superuser-guc-off)
-            EXPLICIT_PHASES=true
-            add_requested_phase "superuser-guc-off"
-            shift
-            ;;
-        --connlimit-backpressure)
-            EXPLICIT_PHASES=true
-            add_requested_phase "connlimit-backpressure"
-            shift
-            ;;
-        --connlimit-timeout)
-            EXPLICIT_PHASES=true
-            add_requested_phase "connlimit-timeout"
-            shift
-            ;;
-        --connlimit-startup)
-            EXPLICIT_PHASES=true
-            add_requested_phase "connlimit-startup"
             shift
             ;;
         --http-disabled)

--- a/tests/e2e/sql/00_requires_shared_preload.sql
+++ b/tests/e2e/sql/00_requires_shared_preload.sql
@@ -4,7 +4,7 @@
 -- via shared_preload_libraries. It must be run against a PostgreSQL instance
 -- that does NOT have pg_durable in shared_preload_libraries.
 --
--- Usage: ./scripts/test-e2e-local.sh --no-preload
+-- Usage: ./scripts/test-e2e-local.sh 00_requires_shared_preload
 
 DO $$
 BEGIN


### PR DESCRIPTION
## Summary
- remove unused phase-specific CLI options from `scripts/test-e2e-local.sh`
- keep the remaining build-scoped options used by current workflows
- update docs and examples to use filename filtering or `--default-build-phases`

## Why
The removed flags were not used by other scripts or workflows, and users can target a specific test file by name when they need to focus on a phase-scoped case.

## Testing
- not run locally in this session