### PR TITLE
Run pg_regress tests as non-superuser role

### DIFF
--- a/expected/00_init.out
+++ b/expected/00_init.out
@@ -48,3 +48,19 @@ BEGIN
     RAISE NOTICE 'Background worker ready';
 END $$;
 NOTICE:  Background worker ready
+-- Create a non-superuser role for testing so that pg_regress passes
+-- without pg_durable.enable_superuser_instances = on.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'df_regress_user') THEN
+        CREATE ROLE df_regress_user LOGIN;
+    END IF;
+END $$;
+SELECT df.grant_usage('df_regress_user');
+NOTICE:  pg_durable: granted df usage privileges to "df_regress_user"
+ grant_usage 
+-------------
+ 
+(1 row)
+
+GRANT CREATE ON SCHEMA public TO df_regress_user;

--- a/expected/conditional.out
+++ b/expected/conditional.out
@@ -1,4 +1,5 @@
 -- Test: Conditional execution using df.if() and ?> !> operators
+SET ROLE df_regress_user;
 DROP TABLE IF EXISTS test_cond_log;
 NOTICE:  table "test_cond_log" does not exist, skipping
 CREATE TABLE test_cond_log (id SERIAL, branch TEXT, variant TEXT);

--- a/expected/parallel.out
+++ b/expected/parallel.out
@@ -1,4 +1,5 @@
 -- Test: Parallel execution with df.join() and & operator
+SET ROLE df_regress_user;
 DROP TABLE IF EXISTS test_parallel_log;
 NOTICE:  table "test_parallel_log" does not exist, skipping
 CREATE TABLE test_parallel_log (id SERIAL, branch TEXT, variant TEXT);

--- a/expected/sequence.out
+++ b/expected/sequence.out
@@ -1,4 +1,5 @@
 -- Test: Sequential execution using ~> operator and df.seq() function
+SET ROLE df_regress_user;
 DROP TABLE IF EXISTS test_sequence_log;
 NOTICE:  table "test_sequence_log" does not exist, skipping
 CREATE TABLE test_sequence_log (id SERIAL, step INT, variant TEXT);

--- a/expected/simple.out
+++ b/expected/simple.out
@@ -1,5 +1,6 @@
 -- Test: Simple SQL execution
 -- Tests both auto-wrapped SQL and explicit df.sql() function
+SET ROLE df_regress_user;
 -- Test A: Auto-wrapped SQL (plain string)
 SELECT df.start('SELECT 42 as answer', 'test-simple-auto') AS instance_id \gset
 SELECT df.wait_for_completion(:'instance_id') AS status;

--- a/expected/variables.out
+++ b/expected/variables.out
@@ -1,4 +1,5 @@
 -- Test: Variable substitution using |=> operator and df.as() function
+SET ROLE df_regress_user;
 DROP TABLE IF EXISTS test_vars_log;
 NOTICE:  table "test_vars_log" does not exist, skipping
 CREATE TABLE test_vars_log (id SERIAL, val TEXT, variant TEXT);

--- a/sql/00_init.sql
+++ b/sql/00_init.sql
@@ -40,3 +40,14 @@ BEGIN
     END IF;
     RAISE NOTICE 'Background worker ready';
 END $$;
+
+-- Create a non-superuser role for testing so that pg_regress passes
+-- without pg_durable.enable_superuser_instances = on.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'df_regress_user') THEN
+        CREATE ROLE df_regress_user LOGIN;
+    END IF;
+END $$;
+SELECT df.grant_usage('df_regress_user');
+GRANT CREATE ON SCHEMA public TO df_regress_user;

--- a/sql/conditional.sql
+++ b/sql/conditional.sql
@@ -1,4 +1,5 @@
 -- Test: Conditional execution using df.if() and ?> !> operators
+SET ROLE df_regress_user;
 DROP TABLE IF EXISTS test_cond_log;
 CREATE TABLE test_cond_log (id SERIAL, branch TEXT, variant TEXT);
 

--- a/sql/parallel.sql
+++ b/sql/parallel.sql
@@ -1,4 +1,5 @@
 -- Test: Parallel execution with df.join() and & operator
+SET ROLE df_regress_user;
 DROP TABLE IF EXISTS test_parallel_log;
 CREATE TABLE test_parallel_log (id SERIAL, branch TEXT, variant TEXT);
 

--- a/sql/sequence.sql
+++ b/sql/sequence.sql
@@ -1,4 +1,5 @@
 -- Test: Sequential execution using ~> operator and df.seq() function
+SET ROLE df_regress_user;
 DROP TABLE IF EXISTS test_sequence_log;
 CREATE TABLE test_sequence_log (id SERIAL, step INT, variant TEXT);
 

--- a/sql/simple.sql
+++ b/sql/simple.sql
@@ -1,5 +1,6 @@
 -- Test: Simple SQL execution
 -- Tests both auto-wrapped SQL and explicit df.sql() function
+SET ROLE df_regress_user;
 
 -- Test A: Auto-wrapped SQL (plain string)
 SELECT df.start('SELECT 42 as answer', 'test-simple-auto') AS instance_id \gset

--- a/sql/variables.sql
+++ b/sql/variables.sql
@@ -1,4 +1,5 @@
 -- Test: Variable substitution using |=> operator and df.as() function
+SET ROLE df_regress_user;
 DROP TABLE IF EXISTS test_vars_log;
 CREATE TABLE test_vars_log (id SERIAL, val TEXT, variant TEXT);
 


### PR DESCRIPTION
The pg_regress tests previously ran as the `postgres` superuser, which required `pg_durable.enable_superuser_instances = on`. This caused failures in downstream CI environments that leave GUCs at their default values.

### Changes

- Create a `df_regress_user` non-superuser LOGIN role in `00_init.sql` and grant it df usage via `df.grant_usage()`
- `SET ROLE df_regress_user` in each test file so `df.start()` runs as a regular user
- Update expected output files to match

### Result

pg_regress tests now pass regardless of the `enable_superuser_instances` GUC setting.