### PR TITLE
Add security annotations for raw variable substitution

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -809,6 +809,8 @@ These read-only variables are automatically available during durable function ex
 
 ### Variable Substitution
 
+> **Security note**: All `{...}` substitutions — including `{varname}`, `{sys_label}`, and `{sys_instance_id}` — perform **raw text substitution**. The value is inserted directly into the SQL string without escaping or parameterization. This is by design so that variables can hold SQL fragments like table names or expressions. Since you control both the variable value and the query template, and SQL executes under your own role, this is safe for configuration values you set yourself. Do **not** store untrusted external input in variables that get substituted into SQL. For passing query *results* between steps, use `$name` (via `|=>`), which applies proper SQL escaping.
+
 Use `{varname}` in SQL queries to substitute variable values:
 
 ```sql

--- a/src/activities/execute_sql.rs
+++ b/src/activities/execute_sql.rs
@@ -80,6 +80,10 @@ pub async fn execute(
 
     let mut conn = connect_as_user(&input.submitted_by, input.database.as_deref()).await?;
 
+    // SECURITY: Dynamic SQL is intentional. The query is authored by the submitting
+    // user via df.sql() and executes under their own role via connect_as_user().
+    // This is equivalent to the user running SQL directly.
+    // See docs/spec-security-model.md §4 for the full threat model.
     match sqlx::query(&input.query).fetch_all(&mut conn).await {
         Ok(rows) => {
             let mut result_rows: Vec<serde_json::Value> = Vec::new();

--- a/src/types.rs
+++ b/src/types.rs
@@ -678,6 +678,11 @@ pub fn substitute_all_with_options(
     result = result.replace("{sys_instance_id}", &sys_vars.instance_id);
     result = result.replace("{sys_label}", sys_vars.label.as_deref().unwrap_or(""));
 
+    // SECURITY: Raw substitution of user vars is by design — variables are
+    // intended for SQL fragments (table names, expressions), not just values.
+    // The user controls both the variable content and the query template, and
+    // SQL executes under their own role via connect_as_user().
+    // See docs/spec-security-model.md §4.3, T10.
     // 2. Substitute user vars: {name} (inserted as-is, no quoting)
     for (name, value) in vars {
         let pattern = format!("{{{name}}}");


### PR DESCRIPTION
Add inline `// SECURITY:` comments and a user-facing documentation note to
make the design intent behind raw `{var}` substitution explicit, preventing
future security reviews from re-raising this as a finding.

### Changes

- **src/types.rs**: `// SECURITY:` comment on the `{var}` substitution loop
  explaining raw substitution is by design (user controls both variable and
  query, SQL runs under their own role). Points to spec-security-model.md §4.3.
- **src/activities/execute_sql.rs**: `// SECURITY:` comment on `sqlx::query()`
  explaining dynamic SQL is intentional and equivalent to the user running SQL
  directly.
- **USER_GUIDE.md**: Security note in the Variable Substitution section covering
  all `{...}` patterns (`{varname}`, `{sys_label}`, `{sys_instance_id}`),
  advising against storing untrusted input in variables and recommending `$name`
  for result passing.

### Why

A security analysis flagged the raw `{var}` substitution as a potential SQL
injection vector. While technically correct that substitution is unescaped, this
is self-injection: the user controls both the variable value and the query
template, and SQL executes under their own role via `connect_as_user()`. The
user can already execute arbitrary SQL via `df.sql()` directly. These
annotations document the design rationale so reviewers can immediately see
the threat was considered and mitigated by privilege scoping.