### PR TITLE
Fix Docker CI: enable superuser instances GUC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN mkdir -p /docker-entrypoint-initdb.d && \
 RUN echo "shared_preload_libraries = 'pg_durable'" >> /usr/share/postgresql/postgresql.conf.sample && \
     echo "pg_durable.database = 'postgres'" >> /usr/share/postgresql/postgresql.conf.sample && \
     echo "pg_durable.worker_role = 'postgres'" >> /usr/share/postgresql/postgresql.conf.sample && \
+    echo "pg_durable.enable_superuser_instances = on" >> /usr/share/postgresql/postgresql.conf.sample && \
     echo "logging_collector = on" >> /usr/share/postgresql/postgresql.conf.sample && \
     echo "log_directory = 'log'" >> /usr/share/postgresql/postgresql.conf.sample && \
     echo "log_filename = 'postgresql.log'" >> /usr/share/postgresql/postgresql.conf.sample && \

--- a/scripts/test-e2e-docker.sh
+++ b/scripts/test-e2e-docker.sh
@@ -26,6 +26,7 @@ IMAGE_NAME="pg_durable:latest"
 # Tests that require a PostgreSQL mode Docker does not manage in this script
 SKIP_TESTS=(
     "00_requires_shared_preload"
+    "17_superuser_guc"
     "44_connection_limit_backpressure"
     "45_connection_limit_timeout"
     "46_connection_limit_startup_validation"


### PR DESCRIPTION
The Docker image was missing `pg_durable.enable_superuser_instances = on` in `postgresql.conf.sample`, which the local E2E "standard" phase sets. This caused Permission Test 6 (superuser HTTP privilege check in `06_http_and_ssrf.sql`) to fail with:

```
pg_durable: superuser instances are disabled. current_user "postgres" is a superuser,
but pg_durable.enable_superuser_instances is off.
```

**Fix:** Add the GUC to the Dockerfile's PostgreSQL config, matching the local test harness.