### PR TITLE
docs: clarify that df.break(value) takes a literal value, not SQL

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -180,7 +180,7 @@ df.sql('SELECT 1') ~> df.sql('SELECT 2')
 | `df.loop(body)` | Repeat forever | `df.loop(body)` |
 | `df.loop(body, cond)` | Repeat while condition is true | `df.loop(body, 'SELECT count(*) > 0 FROM q')` |
 | `df.break()` | Exit enclosing loop | `df.break()` |
-| `df.break(value)` | Exit loop with return value | `df.break('{"done": true}')` |
+| `df.break(value)` | Exit loop with **literal** return value (not auto-wrapped as SQL) | `df.break('{"done": true}')` |
 | `df.start(func, label, database)` | Start function (optionally in another database) | `df.start('SELECT 1', 'job')` |
 | `df.cancel(id, reason)` | Cancel function | `df.cancel('a1b2c3d4', 'Done')` |
 | `df.status(id)` | Get status | `df.status('a1b2c3d4')` |
@@ -1014,7 +1014,16 @@ SELECT df.start(
 );
 ```
 
-`df.break(value)` exits the loop and returns the value as the loop's final result.
+`df.break(value)` exits the loop and returns `value` as the loop's final result.
+
+> **Note:** Unlike most DSL functions, `df.break()` does **not** auto-wrap its argument as SQL. The string you pass is returned verbatim as a literal value (typically JSON or text). To break with the result of a SQL query, run the query first and reference the result via variable substitution:
+>
+> ```sql
+> df.loop(
+>     'SELECT summary FROM report' |=> 'r'
+>     ~> df.break('$r.summary')
+> )
+> ```
 
 ### Stopping a Loop Externally
 
@@ -2089,7 +2098,7 @@ SELECT df.start(df.loop(body, 'SELECT count(*) > 0 FROM queue'));
 
 -- Break out of loop
 df.break()                               -- exit loop
-df.break('{"done": true}')               -- exit with return value
+df.break('{"done": true}')               -- exit with literal return value (not SQL)
 
 -- Timers
 df.sleep(60)                             -- 60 seconds

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -328,12 +328,18 @@ pub fn loop_fn(body: &str, condition: default!(Option<&str>, "NULL")) -> String 
 ///
 /// When executed, the loop terminates and returns the provided value (or null).
 ///
+/// Unlike most DSL functions, `df.break()` does **not** auto-wrap its argument
+/// as SQL — the string is returned verbatim as a literal value (typically JSON
+/// or text). To break with the result of a SQL query, run the query first and
+/// reference the result via variable substitution, e.g.
+/// `'SELECT summary FROM r' |=> 'r' ~> df.break('$r.summary')`.
+///
 /// # Examples
 /// ```sql
 /// -- Break with no value
 /// df.break()
 ///
-/// -- Break with a return value
+/// -- Break with a literal return value (NOT executed as SQL)
 /// df.break('{"status": "complete"}')
 /// ```
 #[pg_extern(name = "break", schema = "df")]


### PR DESCRIPTION
## Summary

Clarifies that `df.break(value TEXT)` accepts a **literal** value and does not auto-wrap its argument as SQL, unlike the rest of the pg_durable DSL.

## Motivation

A user reported (against v0.1.1) that `df.break('SELECT ...')` returns the literal SQL string instead of executing it. The current behavior is intentional (the documented example uses a JSON literal `'{"done": true}'`), but the inconsistency with the auto-wrap convention used elsewhere is surprising. Changing the behavior would be a breaking change, so this PR addresses the docs gap.

## Changes

- USER_GUIDE.md: cheat-sheet table, "Breaking Out of Loops" section, and quick-reference cheat sheet now explicitly call out that `df.break(value)` is a literal, not auto-wrapped as SQL.
- USER_GUIDE.md: added the variable-substitution pattern (`'SELECT ... ' |=> 'r' ~> df.break('\.field')`) for users who want to break with a SQL result.
- src/dsl.rs: matching note in the `break_fn` doc comment.

No code/behavior changes. No upgrade-script changes needed.