### PR TITLE
docs/tests: normalize cancel status to 'cancelled'

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -158,7 +158,7 @@ BEGIN
     SELECT instance_id INTO inst_id FROM _test_state;
     LOOP
         SELECT s INTO status FROM df.status(inst_id) s;
-        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'cancelled') OR attempts > 300;
         PERFORM pg_sleep(0.1);
         attempts := attempts + 1;
     END LOOP;

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1945,7 +1945,7 @@ When a durable function fails or produces unexpected results, use these steps to
 
 ```sql
 SELECT df.status('a1b2c3d4');
--- Returns: Completed, Failed, Running, Pending, or Canceled
+-- Returns: 'pending', 'running', 'completed', 'failed', or 'cancelled'
 ```
 
 If the status is `Failed`, proceed to the next steps. If it's `Completed` but results are wrong, skip to Step 3.

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -127,7 +127,7 @@ DECLARE
 BEGIN
     LOOP
         SELECT s INTO status FROM df.status(:'instance_id') s;
-        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled', 'cancelled') OR attempts > 300;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'cancelled') OR attempts > 300;
         PERFORM pg_sleep(0.1);
         attempts := attempts + 1;
     END LOOP;

--- a/docs/proposal-management-api.md
+++ b/docs/proposal-management-api.md
@@ -250,7 +250,7 @@ CREATE FUNCTION df.reset_system(
     cancel_timeout_secs INTEGER DEFAULT 5
 ) RETURNS TABLE (
     orchestration_name TEXT,
-    action_taken TEXT,      -- 'canceled', 'force_deleted', 'restarted', 'failed'
+    action_taken TEXT,      -- 'cancelled', 'force_deleted', 'restarted', 'failed'
     success BOOLEAN
 );
 ```
@@ -493,7 +493,7 @@ pub fn reset_system(
 
             if is_running {
                 // Step 2: Try graceful cancel
-                action = "canceled";
+                action = "cancelled";
                 if let Err(_) = client.cancel_instance(instance_id, "system reset").await {
                     // Cancel failed, will force delete
                 }
@@ -506,7 +506,7 @@ pub fn reset_system(
                     }
                     match client.get_instance(instance_id).await {
                         Ok(info) if !matches!(info.status, InstanceStatus::Running | InstanceStatus::Pending) => {
-                            break; // Successfully canceled
+                            break; // Successfully cancelled
                         }
                         _ => tokio::time::sleep(std::time::Duration::from_millis(100)).await,
                     }

--- a/docs/spec-pg-regress.md
+++ b/docs/spec-pg-regress.md
@@ -96,8 +96,8 @@ df.wait_for_completion(
 ```
 
 **Behavior:**
-- Polls instance status until completed/failed/canceled
-- Returns final status as text: `'completed'`, `'failed'`, or `'canceled'`
+- Polls instance status until completed/failed/cancelled
+- Returns final status as text: `'completed'`, `'failed'`, or `'cancelled'`
 - Raises exception on timeout
 - Encapsulates non-deterministic polling logic
 
@@ -237,7 +237,7 @@ BEGIN
         
         LOOP
             SELECT s INTO status FROM df.status(rec.instance_id) s;
-            EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+            EXIT WHEN lower(status) IN ('completed', 'failed', 'cancelled') OR attempts > 300;
             PERFORM pg_sleep(0.1);
             attempts := attempts + 1;
         END LOOP;

--- a/docs/spec-signals.md
+++ b/docs/spec-signals.md
@@ -436,7 +436,7 @@ BEGIN
     
     LOOP
         SELECT s INTO status FROM df.status(inst_id) s;
-        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 100;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'cancelled') OR attempts > 100;
         PERFORM pg_sleep(0.1);
         attempts := attempts + 1;
     END LOOP;
@@ -485,7 +485,7 @@ BEGIN
     
     LOOP
         SELECT s INTO status FROM df.status(inst_id) s;
-        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 50;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'cancelled') OR attempts > 50;
         PERFORM pg_sleep(0.1);
         attempts := attempts + 1;
     END LOOP;
@@ -544,7 +544,7 @@ BEGIN
     
     LOOP
         SELECT s INTO status FROM df.status(inst_id) s;
-        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 100;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'cancelled') OR attempts > 100;
         PERFORM pg_sleep(0.1);
         attempts := attempts + 1;
     END LOOP;

--- a/examples/azure-functions/sql/04_verify.sql
+++ b/examples/azure-functions/sql/04_verify.sql
@@ -17,7 +17,7 @@ BEGIN
 
     LOOP
         SELECT s INTO st FROM df.status(inst_id) AS s;
-        EXIT WHEN lower(st) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        EXIT WHEN lower(st) IN ('completed', 'failed', 'cancelled') OR attempts > 300;
         PERFORM pg_sleep(0.1);
         attempts := attempts + 1;
     END LOOP;

--- a/prompts/pg_durable-create-scenario-test.md
+++ b/prompts/pg_durable-create-scenario-test.md
@@ -88,7 +88,7 @@ BEGIN
     -- Wait for completion (with timeout)
     LOOP
         SELECT s INTO inst_status FROM df.status(inst_id) s;
-        EXIT WHEN lower(inst_status) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        EXIT WHEN lower(inst_status) IN ('completed', 'failed', 'cancelled') OR attempts > 300;
         PERFORM pg_sleep(0.1);
         attempts := attempts + 1;
     END LOOP;
@@ -215,7 +215,7 @@ SELECT 'TEST PASSED' AS result;
 - Use mock functions that return deterministic results
 
 ### 3. Comprehensive Assertions
-- Check status is 'completed' (or 'canceled' for loops)
+- Check status is 'completed' (or 'cancelled' for loops)
 - Verify data was processed correctly
 - Check expected side effects (table updates, etc.)
 
@@ -226,8 +226,8 @@ SELECT 'TEST PASSED' AS result;
 
 ### 5. Handle Loop Cancellation
 ```sql
--- For loop tests, cancellation may show as Failed with "canceled" in output
-IF lower(inst_status) NOT IN ('canceled', 'cancelled', 'failed') THEN
+-- df.cancel() sets df.instances.status = 'cancelled' (British spelling, lowercase).
+IF lower(inst_status) != 'cancelled' THEN
     RAISE EXCEPTION 'TEST FAILED: expected cancelled, got %', inst_status;
 END IF;
 ```

--- a/src/activities/update_instance_status.rs
+++ b/src/activities/update_instance_status.rs
@@ -23,11 +23,14 @@ pub async fn execute(
         "Updating instance {instance_id} status to {status}"
     ));
 
+    // Never overwrite a terminal state ('completed', 'failed', 'cancelled') with any status.
+    // This prevents a race where an in-flight activity (scheduled just before cancel was
+    // processed) tries to flip the status back from 'cancelled' to 'running'/'completed'.
     let query = if status == "completed" {
         sqlx::query(
             "UPDATE df.instances
              SET status = $1, completed_at = now(), updated_at = now()
-             WHERE id = $2",
+             WHERE id = $2 AND status NOT IN ('completed', 'failed', 'cancelled')",
         )
         .bind(status)
         .bind(instance_id)
@@ -35,7 +38,7 @@ pub async fn execute(
         sqlx::query(
             "UPDATE df.instances
              SET status = $1, updated_at = now()
-             WHERE id = $2",
+             WHERE id = $2 AND status NOT IN ('completed', 'failed', 'cancelled')",
         )
         .bind(status)
         .bind(instance_id)

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -929,10 +929,15 @@ pub fn cancel(instance_id: &str, reason: default!(&str, "'Cancelled by user'")) 
         return format!("Failed to cancel: {e}");
     }
 
-    // Update the instance status to 'cancelled' via SPI.
+    // Update the instance status to 'cancelled' via SPI only when the instance is not
+    // already in a terminal state.  This prevents two bugs:
+    // 1. Overwriting a 'completed' or 'failed' instance that finished before the cancel
+    //    signal was processed by duroxide.
+    // 2. Calling df.cancel twice in a row (idempotent by guard).
     // User has column-level UPDATE on (status, updated_at) with RLS restricting to own rows.
     Spi::run_with_args(
-        "UPDATE df.instances SET status = 'cancelled', updated_at = pg_catalog.now() WHERE id = $1",
+        "UPDATE df.instances SET status = 'cancelled', updated_at = pg_catalog.now() \
+         WHERE id = $1 AND status NOT IN ('completed', 'failed', 'cancelled')",
         &[instance_id.into()],
     )
     .unwrap_or_else(|e| warning!("Failed to update instance status: {e}"));

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -94,8 +94,8 @@ fn explain_instance(instance_id: &str) -> String {
         &pg_status
     };
     let status_icon = match status.to_lowercase().as_str() {
-        "completed" | "continuedabnew" => "✓",
-        "failed" | "canceled" => "✗",
+        "completed" | "continuedasnew" => "✓",
+        "failed" | "canceled" | "cancelled" => "✗",
         "running" => "⏳",
         _ => "○",
     };

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -144,6 +144,7 @@ pub fn instance_info(
             .ok()
             .and_then(|table| {
                 table.into_iter().next().map(|row| {
+                    // SPI row columns are 1-based: col 1 = label, col 2 = status
                     let label: Option<String> = row.get(1).ok().flatten();
                     let status: String = row.get(2).ok().flatten().unwrap_or_default();
                     (label, status)

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -37,18 +37,21 @@ pub fn list_instances(
     let pg_conn_str = postgres_connection_string();
 
     // Query df.instances via SPI first — RLS filters to calling user's rows only.
-    // This gives us the user's own instance IDs and labels.
-    let user_instances: Vec<(String, Option<String>)> = Spi::connect(|client| {
+    // We also fetch status here so that all three monitoring APIs (df.status(),
+    // df.list_instances(), df.instance_info()) share the same authoritative source
+    // for the status column, eliminating the vocabulary mismatch between
+    // df.instances.status ('cancelled') and duroxide executions.status ('Failed').
+    let user_instances: Vec<(String, Option<String>, String)> = Spi::connect(|client| {
         use pgrx::datum::DatumWithOid;
 
         let (sql, args): (&str, Vec<DatumWithOid>) = if let Some(status) = status_filter {
             (
-                "SELECT id, label FROM df.instances WHERE status = $1 ORDER BY created_at DESC LIMIT $2",
+                "SELECT id, label, status FROM df.instances WHERE status = $1 ORDER BY created_at DESC LIMIT $2",
                 vec![status.into(), (limit_count as i64).into()],
             )
         } else {
             (
-                "SELECT id, label FROM df.instances ORDER BY created_at DESC LIMIT $1",
+                "SELECT id, label, status FROM df.instances ORDER BY created_at DESC LIMIT $1",
                 vec![(limit_count as i64).into()],
             )
         };
@@ -57,7 +60,8 @@ pub fn list_instances(
             for row in table {
                 if let Ok(Some(id)) = row.get::<String>(1) {
                     let label: Option<String> = row.get(2).ok().flatten();
-                    instances.push((id, label));
+                    let status: String = row.get(3).ok().flatten().unwrap_or_default();
+                    instances.push((id, label, status));
                 }
             }
         }
@@ -87,14 +91,16 @@ pub fn list_instances(
         let client = Client::new(store);
 
         let mut rows = Vec::new();
-        // Only query duroxide for the user's own instance IDs
-        for (id, label) in &user_instances {
+        // Only query duroxide for function_name, execution_count, and output.
+        // Status is read from df.instances (already fetched above) to ensure all
+        // monitoring APIs agree on the status value.
+        for (id, label, df_status) in &user_instances {
             if let Ok(info) = client.get_instance_info(id).await {
                 rows.push((
                     info.instance_id,
                     label.clone(),
                     info.orchestration_name,
-                    info.status,
+                    df_status.clone(),
                     info.current_execution_id as i64,
                     info.output,
                 ));
@@ -126,25 +132,29 @@ pub fn instance_info(
     let instance_id_str = instance_id.to_string();
 
     // Ownership check: SPI goes through RLS, returning NULL for non-owned instances.
-    let label: Option<String> = Spi::get_one_with_args(
-        "SELECT label FROM df.instances WHERE id = $1",
-        &[instance_id.into()],
-    )
-    .ok()
-    .flatten();
+    // Also fetch status here so that df.instance_info() uses df.instances as the
+    // authoritative status source, consistent with df.status() and df.list_instances().
+    let row: Option<(Option<String>, String)> = Spi::connect(|client| {
+        client
+            .select(
+                "SELECT label, status FROM df.instances WHERE id = $1",
+                Some(1),
+                &[instance_id.into()],
+            )
+            .ok()
+            .and_then(|table| {
+                table.into_iter().next().map(|row| {
+                    let label: Option<String> = row.get(1).ok().flatten();
+                    let status: String = row.get(2).ok().flatten().unwrap_or_default();
+                    (label, status)
+                })
+            })
+    });
 
-    // Check if the instance exists for this user (RLS-filtered)
-    let exists: bool = Spi::get_one_with_args(
-        "SELECT EXISTS(SELECT 1 FROM df.instances WHERE id = $1)",
-        &[instance_id.into()],
-    )
-    .ok()
-    .flatten()
-    .unwrap_or(false);
-
-    if !exists {
-        return TableIterator::new(vec![]);
-    }
+    let (label, df_status) = match row {
+        Some(r) => r,
+        None => return TableIterator::new(vec![]),
+    };
 
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -171,7 +181,7 @@ pub fn instance_info(
                 info.orchestration_name,
                 info.orchestration_version,
                 info.current_execution_id as i64,
-                info.status,
+                df_status,
                 info.output,
             )],
             Err(_) => vec![],

--- a/tests/e2e/sql/03_loops.sql
+++ b/tests/e2e/sql/03_loops.sql
@@ -53,17 +53,19 @@ BEGIN
         -- Cancel the loop
         PERFORM df.cancel(rec.instance_id, 'Test complete');
         
-        -- Wait for cancellation (may show as Failed with canceled output)
+        -- df.cancel immediately marks df.instances.status = 'cancelled'.
+        -- Poll until df.status() reflects that (should be instant, but allow a short window
+        -- in case an in-flight update_instance_status activity hasn't been guarded yet).
         attempts := 0;
         LOOP
             SELECT s INTO status FROM df.status(rec.instance_id) s;
-            EXIT WHEN lower(status) IN ('canceled', 'cancelled', 'failed') OR attempts > 100;
+            EXIT WHEN lower(status) = 'cancelled' OR attempts > 100;
             PERFORM pg_sleep(0.2);
             attempts := attempts + 1;
         END LOOP;
         
-        IF lower(status) NOT IN ('canceled', 'cancelled', 'failed') THEN
-            RAISE EXCEPTION 'TEST FAILED [%]: expected Canceled, got %', rec.variant, status;
+        IF lower(status) != 'cancelled' THEN
+            RAISE EXCEPTION 'TEST FAILED [%]: expected cancelled, got %', rec.variant, status;
         END IF;
         
         RAISE NOTICE 'PASSED: loop_cancel [%]', rec.variant;

--- a/tests/e2e/sql/11_cross_connection.sql
+++ b/tests/e2e/sql/11_cross_connection.sql
@@ -157,8 +157,8 @@ BEGIN
 
     SELECT df.wait_for_completion(inst_id, 10) INTO status;
 
-    IF status NOT IN ('canceled', 'cancelled', 'failed') THEN
-        RAISE EXCEPTION 'TEST FAILED: cross-connection cancel status = % (expected canceled/cancelled/failed)', status;
+    IF lower(status) != 'cancelled' THEN
+        RAISE EXCEPTION 'TEST FAILED: cross-connection cancel status = % (expected cancelled)', status;
     END IF;
     
     RAISE NOTICE 'TEST PASSED: cross_connection_cancel';

--- a/tests/e2e/sql/14_database.sql
+++ b/tests/e2e/sql/14_database.sql
@@ -364,7 +364,7 @@ BEGIN
 
     LOOP
         SELECT s INTO status FROM df.status(inst_id) s;
-        EXIT WHEN lower(status) IN ('completed', 'failed', 'canceled') OR attempts > 300;
+        EXIT WHEN lower(status) IN ('completed', 'failed', 'cancelled') OR attempts > 300;
         PERFORM pg_sleep(0.1);
         attempts := attempts + 1;
     END LOOP;

--- a/tests/e2e/sql/22_cancel_status_consistency.sql
+++ b/tests/e2e/sql/22_cancel_status_consistency.sql
@@ -1,0 +1,193 @@
+-- Tests: Cancel status consistency across df.status(), df.list_instances(), df.instance_info()
+--
+-- Regression test for: "cancellation status mismatch between df.status() and df.list_instances()"
+-- Root cause: df.list_instances() / df.instance_info() were reading status from duroxide
+-- (which reports "Failed"), while df.status() reads from df.instances (which stores "cancelled").
+--
+-- After the fix all three APIs read status from df.instances, so they always agree.
+--
+-- Scenarios covered:
+--   1. Normal completion  — all APIs report 'completed'
+--   2. Failure            — all APIs report 'failed'
+--   3. Cancel running     — all APIs report 'cancelled'
+--   4. Cancel terminal    — df.cancel on already-completed/failed instance is a no-op
+
+SET SESSION AUTHORIZATION df_e2e_user;
+
+-- Helper: assert that df.status(), df.list_instances(), and df.instance_info() all return
+-- the same status value for the given instance.
+CREATE OR REPLACE FUNCTION df_e2e_assert_status_consistent(
+    p_instance_id TEXT,
+    p_expected_status TEXT,
+    p_scenario TEXT
+) RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE
+    v_status          TEXT;
+    v_list_status     TEXT;
+    v_info_status     TEXT;
+BEGIN
+    SELECT s INTO v_status      FROM df.status(p_instance_id) s;
+    SELECT l.status INTO v_list_status
+        FROM df.list_instances() l
+        WHERE l.instance_id = p_instance_id;
+    SELECT i.status INTO v_info_status
+        FROM df.instance_info(p_instance_id) i;
+
+    IF lower(v_status) != lower(p_expected_status) THEN
+        RAISE EXCEPTION 'FAILED [%]: df.status() returned %, expected %',
+            p_scenario, v_status, p_expected_status;
+    END IF;
+    IF lower(v_list_status) != lower(p_expected_status) THEN
+        RAISE EXCEPTION 'FAILED [%]: df.list_instances() returned %, expected %',
+            p_scenario, v_list_status, p_expected_status;
+    END IF;
+    IF lower(v_info_status) != lower(p_expected_status) THEN
+        RAISE EXCEPTION 'FAILED [%]: df.instance_info() returned %, expected %',
+            p_scenario, v_info_status, p_expected_status;
+    END IF;
+
+    RAISE NOTICE 'PASSED [%]: all three APIs agree on status = %',
+        p_scenario, p_expected_status;
+END $$;
+
+-- ===========================================================================
+-- Scenario 1: Normal completion
+-- ===========================================================================
+
+CREATE TEMP TABLE _t_complete (instance_id TEXT);
+INSERT INTO _t_complete SELECT df.start('SELECT 42', 'cancel-consistency-complete');
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _t_complete;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'Scenario 1 setup failed: expected completed, got %', status;
+    END IF;
+
+    PERFORM df_e2e_assert_status_consistent(inst_id, 'completed', 'normal_completion');
+END $$;
+
+DROP TABLE _t_complete;
+
+-- ===========================================================================
+-- Scenario 2: Failure mid-execution
+-- ===========================================================================
+
+CREATE TEMP TABLE _t_fail (instance_id TEXT);
+INSERT INTO _t_fail SELECT df.start(
+    'SELECT 1/0',   -- division by zero → forces failure
+    'cancel-consistency-fail'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _t_fail;
+
+    -- Poll until failed
+    LOOP
+        SELECT s INTO status FROM df.status(inst_id) s;
+        EXIT WHEN lower(status) = 'failed' OR attempts > 300;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF lower(status) != 'failed' THEN
+        RAISE EXCEPTION 'Scenario 2 setup failed: expected failed, got %', status;
+    END IF;
+
+    PERFORM df_e2e_assert_status_consistent(inst_id, 'failed', 'failure_mid_execution');
+END $$;
+
+DROP TABLE _t_fail;
+
+-- ===========================================================================
+-- Scenario 3: Cancel of a running instance
+-- ===========================================================================
+
+DROP TABLE IF EXISTS _cancel_log;
+CREATE TABLE _cancel_log (id SERIAL);
+
+CREATE TEMP TABLE _t_cancel (instance_id TEXT);
+INSERT INTO _t_cancel SELECT df.start(
+    df.loop(
+        'INSERT INTO _cancel_log DEFAULT VALUES'
+        ~> df.sleep(1)
+    ),
+    'cancel-consistency-running'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+    cnt     INT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _t_cancel;
+
+    -- Wait for at least 1 iteration so the loop is genuinely running
+    LOOP
+        SELECT COUNT(*) INTO cnt FROM _cancel_log;
+        EXIT WHEN cnt >= 1 OR attempts > 200;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF cnt < 1 THEN
+        RAISE EXCEPTION 'Scenario 3 setup: loop never executed';
+    END IF;
+
+    -- Cancel while running
+    PERFORM df.cancel(inst_id, 'consistency-test');
+
+    -- df.cancel immediately sets df.instances.status = 'cancelled'.
+    -- All three APIs should now agree.
+    PERFORM df_e2e_assert_status_consistent(inst_id, 'cancelled', 'cancel_running_instance');
+END $$;
+
+DROP TABLE _t_cancel;
+DROP TABLE _cancel_log;
+
+-- ===========================================================================
+-- Scenario 4: df.cancel on an already-terminal instance is a no-op
+-- ===========================================================================
+
+CREATE TEMP TABLE _t_noop (instance_id TEXT);
+INSERT INTO _t_noop SELECT df.start('SELECT 99', 'cancel-consistency-noop');
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status  TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _t_noop;
+
+    SELECT df.wait_for_completion(inst_id, 30) INTO status;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'Scenario 4 setup failed: expected completed, got %', status;
+    END IF;
+
+    -- Call df.cancel on an already-completed instance — must be a no-op
+    PERFORM df.cancel(inst_id, 'should-be-ignored');
+
+    -- Status must remain 'completed'
+    PERFORM df_e2e_assert_status_consistent(inst_id, 'completed', 'cancel_noop_on_completed');
+END $$;
+
+DROP TABLE _t_noop;
+
+-- Cleanup helper function
+DROP FUNCTION IF EXISTS df_e2e_assert_status_consistent(TEXT, TEXT, TEXT);
+
+SELECT 'TEST PASSED: cancel status consistency' AS result;

--- a/tests/e2e/sql/22_cancel_status_consistency.sql
+++ b/tests/e2e/sql/22_cancel_status_consistency.sql
@@ -81,7 +81,7 @@ DROP TABLE _t_complete;
 
 CREATE TEMP TABLE _t_fail (instance_id TEXT);
 INSERT INTO _t_fail SELECT df.start(
-    'SELECT 1/0',   -- division by zero → forces failure
+    'SELECT 1/0',   -- division by zero --> forces failure
     'cancel-consistency-fail'
 );
 


### PR DESCRIPTION
Follow-up to #145.

Now that `df.instances.status` is the authoritative source for cancel status across all three monitoring APIs (`df.status()`, `df.list_instances()`, `df.instance_info()`), the value stored is British `'cancelled'` (lowercase). This PR sweeps the codebase to match.

## Changes

| File | Change |
|---|---|
| `USER_GUIDE.md` | Corrected `df.status()` return-value comment to the actual lowercase set: `'pending'`, `'running'`, `'completed'`, `'failed'`, `'cancelled'`. |
| `src/explain.rs` | Status-icon map now accepts both `'canceled'` (duroxide vocabulary) and `'cancelled'` (df.instances) so the icon is correct regardless of which source `explain` falls back to. |
| `tests/e2e/sql/11_cross_connection.sql` | Tightened the cross-connection cancel assertion to require exactly `'cancelled'` (was permissively accepting `canceled`/`cancelled`/`failed`). |
| `tests/e2e/sql/14_database.sql`, `examples/azure-functions/sql/04_verify.sql` | Loop-exit conditions now use `'cancelled'`. |
| `.github/copilot-instructions.md`, `prompts/pg_durable-create-scenario-test.md`, `docs/E2E_TESTING.md`, `docs/spec-signals.md`, `docs/spec-pg-regress.md`, `docs/proposal-management-api.md` | Templates and spec examples updated so they don't propagate the wrong spelling to future tests. |

## What was deliberately left alone

These remain `Canceled` (American, PascalCase) because they reference duroxide's execution-status vocabulary, not `df.instances.status`:

- `src/lib.rs:865, 2040, 2042` — read from `client.get_instance_info().status` (duroxide).
- `tests/e2e/sql/11_cross_connection.sql:145` — freeform `reason` string passed to `df.cancel`, user-visible label only.

The `duroxide-pg-opt` submodule is untouched.

## Upgrade impact

None — no schema changes, no API changes, just docs/tests and one defensive code change to `explain`.