### PR TITLE
Clarify signal text payload guidance

### DIFF
--- a/.github/skills/pg-durable-sql/SKILL.md
+++ b/.github/skills/pg-durable-sql/SKILL.md
@@ -115,8 +115,10 @@ df.cancel(instance_id TEXT, reason TEXT DEFAULT 'Cancelled by user') → TEXT
 df.signal(
     instance_id TEXT,                   -- Target instance
     signal_name TEXT,                   -- Must match df.wait_for_signal() name
-    signal_data TEXT DEFAULT '{}'       -- JSON payload
+    signal_data TEXT DEFAULT '{}'       -- Text payload; valid JSON remains structured, other text becomes a JSON string
 ) → TEXT
+
+Use a JSON object when workflow SQL expects structured fields; use plain text for simple opaque values.
 
 -- Query status
 df.status(instance_id TEXT) → TEXT      -- 'Running', 'Completed', 'Failed', 'Cancelled'

--- a/docs/spec-signals.md
+++ b/docs/spec-signals.md
@@ -21,12 +21,15 @@ df.wait_for_signal('signal_name', 3600)  -- 1 hour timeout
 ```sql
 -- Send signal to a running instance
 SELECT df.signal('instance_id', 'signal_name', '{"data": "value"}');
+SELECT df.signal('instance_id', 'signal_name', 'approve');
 ```
 
 **Parameters:**
 - `instance_id` - The durable function instance ID (labels not supported, not unique)
 - `signal_name` - Name of the signal to send
-- `signal_data` - JSON payload (optional, defaults to `'{}'`)
+- `signal_data` - Optional text payload (defaults to `'{}'`). Valid JSON is preserved as structured JSON; non-JSON text is delivered as a JSON string.
+
+Send a JSON object when workflow SQL expects structured fields such as `data.approved`. Send plain text for simple opaque values such as `approve`.
 
 ## Signal Result Format
 
@@ -38,6 +41,15 @@ The `df.wait_for_signal()` function returns a JSON object:
   "signal_name": "approval",
   "timed_out": false,
   "data": {"approved": true, "approver": "jane@acme.com"}
+}
+```
+
+**Signal received with plain text payload:**
+```json
+{
+    "signal_name": "approval",
+    "timed_out": false,
+    "data": "approve"
 }
 ```
 


### PR DESCRIPTION
## Summary

Clarifies the remaining signal payload guidance after #173 so all docs describe `df.signal(..., signal_data text)` consistently.

## Changes

- Updates `docs/spec-signals.md` to describe signal payloads as text, with valid JSON preserved as structured JSON and non-JSON text delivered as a JSON string.
- Adds a plain-text signal example and result shape.
- Updates the `pg-durable-sql` skill guidance with the same structured JSON vs plain text rule.

## Validation

- `git diff --check`