### PR TITLE
Prepare release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,43 @@
 
 Pre-1.0 note: while `pg_durable` is in major version `0`, minor releases may include breaking changes.
 
-## Unreleased
+## [0.2.2] - 2026-05-28
 
-- Fix: `df.signal()` now propagates the event to running sub-orchestrations spawned by `df.race` / `df.join` / `df.join3`, so `df.wait_for_signal` inside a parallel branch wakes as expected. Known limitation: signals raised before the target sub-orchestration is in the `Running` state are not yet redelivered when it starts; a proper fix requires unmatched-event forwarding in duroxide (#154).
-- Fix: `df.start()`, RLS policies on `df.instances` / `df.nodes` / `df.vars`, and `df.vars` reads/writes no longer fail with `role "..." does not exist` when `current_user` requires quoting (mixed case, spaces, embedded quotes). All `current_user::regrole` casts are now wrapped with `quote_ident()` so the role lookup preserves the original identifier casing (#161, #162). Schema upgrade DDL is in `sql/pg_durable--0.2.1--0.2.2.sql`.
+### Breaking Changes
 
-- Behavior change (bug fix): `df.join` / `df.join3` results are now a proper JSON array of objects instead of an array of double-encoded JSON strings. Consumers that previously unescaped each element (e.g. `(elem #>> '{}')::jsonb`) must now read the element directly (#143)
+- **Provider compatibility boundary:** `pg_durable` now uses the crates.io `duroxide-pg` provider instead of the `duroxide-pg-opt` submodule. This is the first open-source release in the `duroxide-pg` provider line. Upgrade testing treats `v0.2.2` as the compatibility start for this line; Azure's fork owns upgrade compatibility for the earlier `duroxide-pg-opt` line (#158).
+- **`df.join` / `df.join3` result shape:** join results are now a proper JSON array of objects instead of an array of double-encoded JSON strings. Consumers that previously unescaped each element, for example `(elem #>> '{}')::jsonb`, must now read the element directly (#143).
+
+### Added
+
+- **Typed SQL result decoding:** SQL node execution now preserves richer PostgreSQL column types in JSON results instead of treating all values as strings (#135).
+- **Composite capture support:** `|=>` captures are now honored on composite THEN / IF / LOOP nodes (#163).
+
+### Changed
+
+- **Dependencies:** switched from `duroxide-pg-opt` to crates.io `duroxide-pg = 0.1.34` and bumped `duroxide` to `0.1.29` (#158).
+- **License:** changed project licensing from MIT to PostgreSQL License (#187).
+- **Cancel status spelling:** status handling and documentation now consistently use `cancelled` (#145, #160).
+- **Signal payloads:** `df.signal(text)` now accepts non-JSON text payloads as its SQL signature implies (#173).
+
+### Fixed
+
+- **JOIN/RACE branch state:** variables, labels, and named results now propagate correctly through JOIN/RACE subtrees (#137, #138).
+- **Instance status transition:** instances are marked `running` before graph execution begins, so monitoring reflects active work promptly (#136).
+- **Loop throttling:** `df.loop()` enforces a minimum iteration delay to avoid busy-spin behavior (#141).
+- **Branch breaks:** `df.break()` is no longer silently ignored inside JOIN/RACE branches (#140).
+- **Signals in sub-orchestrations:** `df.signal()` now propagates events to running sub-orchestrations spawned by `df.race`, `df.join`, and `df.join3`, so `df.wait_for_signal` inside a parallel branch wakes as expected. Known limitation: signals raised before the target sub-orchestration is in the `Running` state are not yet redelivered when it starts; a proper fix requires unmatched-event forwarding in duroxide (#154).
+- **Quoted role names:** `df.start()`, RLS policies on `df.instances` / `df.nodes` / `df.vars`, and `df.vars` reads/writes no longer fail with `role "..." does not exist` when `current_user` requires quoting, such as mixed case, spaces, or embedded quotes. Schema upgrade DDL is in `sql/pg_durable--0.2.1--0.2.2.sql` (#161, #162).
+
+### Security
+
+- **Workflow composition hardening:** variable setup helpers are rejected inside workflow composition where they would mutate session state during graph construction (#153).
+- **Dependency update:** bumped `openssl` from `0.10.78` to `0.10.80` (#176).
+
+### Documentation
+
+- Clarified that `df.break(value)` takes a literal value, not SQL (#157).
+- Clarified text payload guidance for `df.signal(text)` (#174).
 
 ## v0.2.1 (Released)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pg_durable"
 version = "0.2.2"
 edition = "2021"
-license = "MIT"
+license = "PostgreSQL"
 repository = "https://github.com/Azure/pg_durable"
 description = "Durable SQL Functions for PostgreSQL"
 

--- a/README.md
+++ b/README.md
@@ -188,4 +188,4 @@ The runtime is powered by [duroxide](https://github.com/microsoft/duroxide), a d
 
 ## License
 
-MIT
+PostgreSQL License


### PR DESCRIPTION
Prepares the v0.2.2 release notes and cleans up license metadata after the PostgreSQL License switch.

Summary:
- Convert the changelog Unreleased section into a dated v0.2.2 entry with Keep a Changelog-style categories.
- Document the notable changes since v0.2.1, including the duroxide-pg provider boundary, join result shape change, signal fixes, quoted-role fix, typed SQL decoding, and security/dependency updates.
- Update Cargo metadata and README license references to PostgreSQL License.

Validation:
- Skipped local build/test gates that are covered by CI.
- Ran `git diff --check`.
- Ran `cargo metadata --no-deps --format-version 1` and confirmed version `0.2.2` and license `PostgreSQL`.