### PR TITLE
docs: README disambiguator + rework Architecture for duroxide/duroxide-pg layering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 pg_durable brings durable execution to PostgreSQL. Define long-running, fault-tolerant functions entirely in SQL—no external orchestrators, no YAML, no separate deployment.
 
-> **Not to be confused with [duroxide-pg](https://github.com/microsoft/duroxide-pg).** duroxide-pg is the lower-level PostgreSQL provider for the [duroxide](https://github.com/microsoft/duroxide) Rust durable-execution runtime, aimed at developers writing workflows in Rust. pg_durable sits on top of both and exposes durable execution as a SQL-native PostgreSQL extension — reach for it when you want everything inside PG.
-
 ## Features
 
 - **Durable** — Function state persists to PostgreSQL. Survives crashes, restarts, and failovers.
@@ -29,6 +27,10 @@ SELECT df.start(
 2. **Start functions** with `df.start()` which returns an instance ID
 3. **Runtime executes durably** — each step is checkpointed, survives crashes via replay
 4. **Query progress** anytime from standard PostgreSQL tables
+
+## Relationship With duroxide-pg
+* Use pg_durable when you want pipelines or durable functions directly in SQL and PostgreSQL, no other moving parts needed.
+* Use [duroxide-pg](https://github.com/microsoft/duroxide-pg) when you prefer to define functions in Rust, Python, or Node, using PostgreSQL only as a persistent store.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ SELECT df.start(
 3. **Runtime executes durably** — each step is checkpointed, survives crashes via replay
 4. **Query progress** anytime from standard PostgreSQL tables
 
-## Relationship With duroxide-pg
-* Use pg_durable when you want pipelines or durable functions directly in SQL and PostgreSQL, no other moving parts needed.
-* Use [duroxide-pg](https://github.com/microsoft/duroxide-pg) when you prefer to define functions in Rust, Python, or Node, using PostgreSQL only as a persistent store.
-
 ## Prerequisites
 
 - PostgreSQL 17
@@ -160,31 +156,37 @@ See [tests/e2e/](tests/e2e/) for details.
 
 ## Architecture
 
-pg_durable consists of:
+pg_durable is a PostgreSQL extension (built with [pgrx](https://github.com/pgcentralfoundation/pgrx)) — everything runs inside the PostgreSQL server, no external services. The extension exposes a SQL DSL for building function graphs and registers a background worker that executes them durably on top of two lower-level Rust libraries:
 
-1. **SQL DSL Layer** — Operators that build function graphs
-2. **Duroxide Runtime** — Background worker that executes functions durably
-3. **PostgreSQL Tables** — Store function definitions, state, and history
-
-The runtime is powered by [duroxide](https://github.com/microsoft/duroxide), a durable task framework for Rust.
+- [duroxide](https://github.com/microsoft/duroxide) — a durable task framework providing the orchestration runtime (deterministic replay, checkpoints, sub-orchestrations, timers).
+- [duroxide-pg](https://github.com/microsoft/duroxide-pg) — a PostgreSQL-backed state provider for duroxide. It persists runtime state (instances, history, work queues) in a dedicated `duroxide.*` schema owned by the extension.
 
 ```
-┌────────────────────────────────────────────────────────────────┐
-│                         PostgreSQL                             │
-│  ┌──────────────────────────────────────────────────────────┐  │
-│  │                pg_durable Extension (pgrx)               │  │
-│  │                                                          │  │
-│  │   DSL:  'sql' |=> 'name' ~> 'sql2'                      │  │
-│  │   Functions: durable.if() | durable.join() | durable.loop() │
-│  │                                                          │  │
-│  │   Duroxide Runtime (background worker)                   │  │
-│  │   • Polls for work, executes functions, checkpoints     │  │
-│  │                                                          │  │
-│  └──────────────────────────────────────────────────────────┘  │
-│                                                                │
-│  df schema: nodes | instances | (duroxide internals)          │
-└────────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────┐
+│                             PostgreSQL                             │
+│                                                                    │
+│  ┌──────────────────────────────────────────────────────────────┐  │
+│  │                 pg_durable extension (pgrx)                  │  │
+│  │                                                              │  │
+│  │  SQL DSL     'sql' |=> 'name' ~> 'sql2'                      │  │
+│  │              df.if() | df.join() | df.loop()                 │  │
+│  │                                                              │  │
+│  │  Background worker (hosts the duroxide runtime in-process)   │  │
+│  │  ┌────────────────────────────────────────────────────────┐  │  │
+│  │  │  duroxide        (orchestration runtime)               │  │  │
+│  │  │  ┌──────────────────────────────────────────────────┐  │  │  │
+│  │  │  │  duroxide-pg   (PostgreSQL state provider)       │  │  │  │
+│  │  │  └──────────────────────────────────────────────────┘  │  │  │
+│  │  └────────────────────────────────────────────────────────┘  │  │
+│  └──────────────────────────────────────────────────────────────┘  │
+│                                                                    │
+│  Schemas                                                           │
+│    df.*         DSL graphs (nodes, instances, vars)                │
+│    duroxide.*   runtime state (owned by duroxide-pg)               │
+└────────────────────────────────────────────────────────────────────┘
 ```
+
+If you'd rather author durable workflows in Rust, Python, or Node while still persisting state in PostgreSQL, you can use duroxide and duroxide-pg directly from your host language — pg_durable is what you'd build on top of that pair when you'd prefer authoring in SQL.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 pg_durable brings durable execution to PostgreSQL. Define long-running, fault-tolerant functions entirely in SQL—no external orchestrators, no YAML, no separate deployment.
 
+> **Not to be confused with [duroxide-pg](https://github.com/microsoft/duroxide-pg).** duroxide-pg is the lower-level PostgreSQL provider for the [duroxide](https://github.com/microsoft/duroxide) Rust durable-execution runtime, aimed at developers writing workflows in Rust. pg_durable sits on top of both and exposes durable execution as a SQL-native PostgreSQL extension — reach for it when you want everything inside PG.
+
 ## Features
 
 - **Durable** — Function state persists to PostgreSQL. Survives crashes, restarts, and failovers.


### PR DESCRIPTION
README changes that clarify how pg_durable relates to duroxide-pg and includes duroxide-pg in the Architecture section.
See also:

- microsoft/duroxide-pg#12 — symmetric disambiguator on the duroxide-pg side
- microsoft/duroxide#24 — full "Duroxide family" overview in the hub repo