### PR TITLE
website: hold live-exec animation, add HorizonDB rail, logo mark + favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
+<div align="center">
+
+<img src="docs/website/favicon.svg" alt="pg_durable logo" width="96" height="96" />
+
 # pg_durable
 
-**Durable SQL Functions for PostgreSQL**
+**Durable SQL workflows for PostgreSQL — no extra infra.**
 
-pg_durable brings durable execution to PostgreSQL. Define long-running, fault-tolerant functions entirely in SQL—no external orchestrators, no YAML, no separate deployment.
+Long-running, fault-tolerant functions defined entirely in SQL. Composable operators,
+automatic checkpointing, crash-safe replay, and parallel execution. Built on Postgres —
+no external orchestrators, no YAML, no separate deployment.
+
+[Website](https://microsoft.github.io/pg_durable/) · [Docs](docs/) · [Quick Example](#quick-example) · [GitHub](https://github.com/microsoft/pg_durable)
+
+[![License](https://img.shields.io/badge/license-PostgreSQL%20License-3d86c6.svg)](LICENSE.txt)
+[![Built for PostgreSQL 17](https://img.shields.io/badge/built%20for-PostgreSQL%2017-336791?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
+
+<br />
+
+<img src="docs/website/workflow-graph.svg" alt="A durable function fans out into three parallel queries — count users, count orders, sum revenue — that join into a dashboard step" width="480" />
+
+</div>
 
 ## Features
 

--- a/docs/website/favicon.svg
+++ b/docs/website/favicon.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="pg_durable logo">
+  <defs>
+    <linearGradient id="pgGrad" x1="8" y1="6" x2="54" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#86cdf2"/>
+      <stop offset="0.45" stop-color="#5a96e8"/>
+      <stop offset="1" stop-color="#8a5cf0"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Hexagon shell -->
+  <path d="M32 3 L57.12 17.5 L57.12 46.5 L32 61 L6.88 46.5 L6.88 17.5 Z"
+        fill="#0d1426" stroke="url(#pgGrad)" stroke-width="3" stroke-linejoin="round"/>
+
+  <!-- Gear (gradient) -->
+  <g fill="url(#pgGrad)">
+    <g>
+      <rect x="28.5" y="8.6" width="7" height="10" rx="1.5"/>
+      <rect x="28.5" y="8.6" width="7" height="10" rx="1.5" transform="rotate(45 32 32)"/>
+      <rect x="28.5" y="8.6" width="7" height="10" rx="1.5" transform="rotate(90 32 32)"/>
+      <rect x="28.5" y="8.6" width="7" height="10" rx="1.5" transform="rotate(135 32 32)"/>
+      <rect x="28.5" y="8.6" width="7" height="10" rx="1.5" transform="rotate(180 32 32)"/>
+      <rect x="28.5" y="8.6" width="7" height="10" rx="1.5" transform="rotate(225 32 32)"/>
+      <rect x="28.5" y="8.6" width="7" height="10" rx="1.5" transform="rotate(270 32 32)"/>
+      <rect x="28.5" y="8.6" width="7" height="10" rx="1.5" transform="rotate(315 32 32)"/>
+    </g>
+    <!-- Gear body -->
+    <circle cx="32" cy="32" r="15.2"/>
+  </g>
+
+  <!-- White hub -->
+  <circle cx="32" cy="32" r="9.6" fill="#ffffff"/>
+
+  <!-- Tilde + arrow glyph -->
+  <g fill="none" stroke="#0e1730" stroke-width="2.7" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M24.4 32.8 C 25.8 30.4, 27.5 30.3, 29.1 32.4 C 30.4 34.1, 31.8 34.2, 33.1 32.6"/>
+  </g>
+  <path d="M33.6 28.8 L40.2 32 L33.6 35.2 L33.6 33.5 L31.5 33.5 L31.5 30.5 L33.6 30.5 Z" fill="#0e1730"/>
+</svg>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -8,6 +8,9 @@
       name="description"
       content="Build durable, fault-tolerant workflows in pure SQL. Retries, scheduling, parallel execution, and conditional branching — all inside PostgreSQL."
     />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="mask-icon" href="favicon.svg" color="#3d86c6" />
+    <meta name="theme-color" content="#0d1426" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -19,7 +22,10 @@
   <body>
     <header class="site-header">
       <div class="container nav">
-        <a class="brand" href="#top">pg_durable</a>
+        <a class="brand" href="#top">
+          <img class="brand-mark" src="favicon.svg" alt="" width="30" height="30" />
+          <span class="brand-word">pg<span class="brand-us">_</span>durable</span>
+        </a>
         <nav class="nav-links" aria-label="Primary">
           <a href="#how-it-works">How It Works</a>
           <a href="#why">Why pg_durable</a>
@@ -861,6 +867,28 @@ SELECT job.id, v.ord, v.name, v.query, v.deps FROM job, (VALUES
 
     </main>
 
+    <!-- Always-on cloud rail: pinned to the right edge, expands on hover/focus -->
+    <a
+      class="cloud-rail"
+      href="#horizondb"
+      aria-label="Run pg_durable in the cloud on Azure HorizonDB"
+    >
+      <img
+        class="cloud-rail-logo"
+        src="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/1374850-Icon-Hero-HorizonDB-24x24?resMode=sharp2&op_usm=1.5,0.65,15,0&wid=48&hei=48&qlt=100&fit=constrain"
+        alt=""
+        width="34"
+        height="34"
+      />
+      <span class="cloud-rail-text">
+        <span class="cloud-rail-kicker">Run it in the cloud</span>
+        <span class="cloud-rail-title">
+          Azure HorizonDB <span class="cloud-rail-badge">Preview</span>
+        </span>
+      </span>
+      <span class="cloud-rail-arrow" aria-hidden="true">→</span>
+    </a>
+
     <footer>
       <div class="container">
         <strong>pg_durable</strong>
@@ -899,12 +927,13 @@ SELECT job.id, v.ord, v.name, v.query, v.deps FROM job, (VALUES
           { at: 5350, nodes: { join: "running" }, logs: ["\u25b6 join \u2192 refresh dashboard"] },
           { at: 6150, nodes: { join: "done" }, logs: ["\u2713 dashboard ready in 1.9s \u2014 durable \u26a1"] },
         ];
-        var LOOP = 8200;
+        var LAST_AT = TL[TL.length - 1].at;
 
         var t = 0,
           fired = {},
           timer = null,
-          playing = false;
+          playing = false,
+          finished = false;
 
         function setNode(key, state) {
           var el = nodes[key];
@@ -918,6 +947,7 @@ SELECT job.id, v.ord, v.name, v.query, v.deps FROM job, (VALUES
         function reset() {
           log.textContent = "";
           fired = {};
+          t = 0;
           Object.keys(nodes).forEach(function (k) {
             setNode(k, "pending");
           });
@@ -931,6 +961,15 @@ SELECT job.id, v.ord, v.name, v.query, v.deps FROM job, (VALUES
             });
         }
 
+        function finish() {
+          if (timer) clearInterval(timer);
+          timer = null;
+          playing = false;
+          finished = true;
+          toggle.textContent = "\u21bb Replay";
+          toggle.setAttribute("aria-pressed", "false");
+        }
+
         function tick() {
           for (var i = 0; i < TL.length; i++) {
             if (t >= TL[i].at && !fired[i]) {
@@ -938,14 +977,20 @@ SELECT job.id, v.ord, v.name, v.query, v.deps FROM job, (VALUES
               apply(TL[i]);
             }
           }
-          t += 100;
-          if (t >= LOOP) {
-            t = 0;
-            setTimeout(reset, 300);
+          // Once the final step has fired, hold on the completed state.
+          if (t >= LAST_AT) {
+            finish();
+            return;
           }
+          t += 100;
         }
 
         function play() {
+          // Restart from the beginning if the run already completed.
+          if (finished) {
+            finished = false;
+            reset();
+          }
           playing = true;
           toggle.textContent = "\u23f8 Pause";
           toggle.setAttribute("aria-pressed", "true");
@@ -966,7 +1011,7 @@ SELECT job.id, v.ord, v.name, v.query, v.deps FROM job, (VALUES
         if (reduced) {
           reset();
           TL.forEach(apply);
-          pause();
+          finish();
         } else {
           reset();
           play();

--- a/docs/website/styles.css
+++ b/docs/website/styles.css
@@ -147,16 +147,30 @@ main,
   font-size: 1.25rem;
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.55rem;
 }
 
-.brand::before {
-  content: "";
-  width: 11px;
-  height: 11px;
-  border-radius: 3px;
+.brand-mark {
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  filter: drop-shadow(0 0 10px var(--pg-blue-glow));
+  transition: transform 0.25s ease;
+}
+
+.brand:hover .brand-mark {
+  transform: rotate(-8deg) scale(1.05);
+}
+
+.brand-word {
+  color: var(--text);
+}
+
+.brand-word .brand-us {
   background: linear-gradient(135deg, var(--pg-blue-light), var(--copper));
-  box-shadow: 0 0 14px var(--pg-blue-glow);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 
 .nav-links {
@@ -394,6 +408,7 @@ main,
 /* Terminal */
 .engine-terminal {
   border-bottom: 1px solid var(--border);
+  min-width: 0;
 }
 
 @media (min-width: 760px) {
@@ -566,6 +581,7 @@ main,
 .comparison-col {
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }
 
 .comparison-without,
@@ -1174,6 +1190,23 @@ pre {
   font-size: 0.88rem;
 }
 
+pre {
+  max-width: 100%;
+}
+
+img,
+svg {
+  max-width: 100%;
+}
+
+/* Larger, comfortable tap targets on touch devices */
+@media (hover: none) and (pointer: coarse) {
+  .nav-links a,
+  .button-text {
+    padding-block: 0.35rem;
+  }
+}
+
 /* syntax highlighting */
 .kw { color: #c9a6ff; font-weight: 600; }
 .fn { color: var(--pg-blue-light); }
@@ -1560,4 +1593,234 @@ footer p {
 .horizon-note {
   color: var(--muted);
   font-size: 0.85rem;
+}
+
+/* ── Always-on cloud rail ──────────────────────────────────────────────── */
+.cloud-rail {
+  position: fixed;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  max-width: 66px; /* collapsed: only the logo strip shows */
+  padding: 0.7rem 0.85rem;
+  border: 1px solid rgba(58, 160, 255, 0.4);
+  border-right: none;
+  border-radius: 16px 0 0 16px;
+  background: linear-gradient(135deg, rgba(20, 28, 46, 0.96), rgba(12, 18, 32, 0.96));
+  box-shadow: -10px 0 34px -18px rgba(44, 139, 255, 0.7);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  text-decoration: none;
+  color: #eaf2ff;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: max-width 0.34s cubic-bezier(0.2, 0.7, 0.2, 1), box-shadow 0.25s,
+    border-color 0.25s;
+}
+
+.cloud-rail:hover,
+.cloud-rail:focus-visible {
+  max-width: 300px;
+  border-color: rgba(58, 160, 255, 0.75);
+  box-shadow: -16px 0 44px -16px rgba(44, 139, 255, 0.85);
+  outline: none;
+}
+
+.cloud-rail-logo {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+}
+
+.cloud-rail-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+}
+
+.cloud-rail-kicker {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #7fbcff;
+}
+
+.cloud-rail-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.98rem;
+}
+
+.cloud-rail-badge {
+  font-size: 0.56rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.12rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(58, 160, 255, 0.18);
+  border: 1px solid rgba(58, 160, 255, 0.45);
+  color: #aed6ff;
+}
+
+.cloud-rail-arrow {
+  flex: 0 0 auto;
+  color: #7fbcff;
+  font-weight: 700;
+  opacity: 0;
+  transform: translateX(-6px);
+  transition: opacity 0.25s, transform 0.25s;
+}
+
+.cloud-rail:hover .cloud-rail-arrow,
+.cloud-rail:focus-visible .cloud-rail-arrow {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .cloud-rail-logo {
+    animation: cloudPulse 3.2s ease-in-out infinite;
+  }
+  @keyframes cloudPulse {
+    0%,
+    100% {
+      filter: drop-shadow(0 0 0 rgba(44, 139, 255, 0));
+    }
+    50% {
+      filter: drop-shadow(0 0 8px rgba(44, 139, 255, 0.7));
+    }
+  }
+}
+
+/* Hide on narrow screens so it never covers content */
+@media (max-width: 820px) {
+  .cloud-rail {
+    display: none;
+  }
+}
+
+/* ── Mobile / small-screen polish ────────────────────────── */
+@media (max-width: 760px) {
+  /* Roomier gutters but never edge-to-edge */
+  .container {
+    width: min(1140px, 90vw);
+  }
+
+  /* Header: brand left, links wrap tidily below */
+  .nav {
+    flex-wrap: wrap;
+    row-gap: 0.55rem;
+    padding: 0.8rem 0;
+  }
+  .nav-links {
+    gap: 0.85rem 1.15rem;
+  }
+  .nav-links a {
+    font-size: 0.86rem;
+  }
+
+  /* Tighter vertical rhythm */
+  .hero {
+    padding: 3.2rem 0 2.4rem;
+  }
+  .comparison,
+  .horizon {
+    padding: 2.8rem 0;
+  }
+  .callout {
+    padding: 2.4rem 0;
+  }
+  .use-cases {
+    padding: 2.6rem 0;
+  }
+  .cta-section {
+    padding: 3rem 0;
+  }
+
+  .subtitle {
+    font-size: 1.04rem;
+  }
+
+  /* Full-width, easy-to-tap CTAs */
+  .cta-row {
+    width: 100%;
+  }
+  .cta-row .button,
+  .cta-row .button-outline {
+    flex: 1 1 100%;
+    justify-content: center;
+    padding-block: 0.9rem;
+  }
+  .cta-row .button-text {
+    flex: 1 1 100%;
+    text-align: center;
+  }
+
+  /* Engine panel header can wrap */
+  .engine-head {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  /* Comparison code: smaller, scrollable */
+  .comparison-with pre,
+  .comparison-blur-code pre {
+    font-size: 0.74rem;
+    padding: 1.1rem;
+  }
+
+  /* Cloud upsell box: less padding on phones */
+  .horizon-box {
+    padding: 1.5rem 1.3rem;
+  }
+  .horizon-head {
+    flex-wrap: wrap;
+  }
+  .horizon-cta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .horizon-cta .button-azure,
+  .horizon-cta .button-azure-outline {
+    text-align: center;
+  }
+
+  /* Scenarios banner + CTA card stack vertically */
+  .cta-card {
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+  }
+  .cta-card .arrow {
+    align-self: flex-end;
+  }
+}
+
+@media (max-width: 460px) {
+  .container {
+    width: 92vw;
+  }
+  .hero h1 {
+    font-size: clamp(2.45rem, 11vw, 3rem);
+  }
+  .brand {
+    font-size: 1.12rem;
+  }
+  .brand-mark {
+    width: 26px;
+    height: 26px;
+  }
+  /* Comfortable reading size, avoid zoom-on-focus quirks */
+  .subtitle,
+  .section-lede {
+    font-size: 1rem;
+  }
 }

--- a/docs/website/workflow-graph.svg
+++ b/docs/website/workflow-graph.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 460 320" width="460" height="320" role="img" aria-label="df.start fans out to three parallel queries — count users, count orders, sum revenue — that join into a dashboard step">
+  <defs>
+    <linearGradient id="gDone" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2f7a55"/>
+      <stop offset="1" stop-color="#245d41"/>
+    </linearGradient>
+    <linearGradient id="gRun" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#3d86c6"/>
+      <stop offset="1" stop-color="#2a6299"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Panel -->
+  <rect x="1" y="1" width="458" height="318" rx="18" fill="#0f1626" stroke="#243049" stroke-width="1.5"/>
+
+  <!-- Fan-out / fan-in connectors -->
+  <g fill="none" stroke="#3d86c6" stroke-width="2" stroke-dasharray="6 5" stroke-linecap="round" opacity="0.75">
+    <path d="M230 64 L95 132"/>
+    <path d="M230 64 L230 132"/>
+    <path d="M230 64 L365 132"/>
+    <path d="M95 170 L230 240"/>
+    <path d="M230 170 L230 240"/>
+    <path d="M365 170 L230 240"/>
+  </g>
+
+  <!-- Start node (done) -->
+  <g>
+    <rect x="161" y="24" width="138" height="40" rx="10" fill="url(#gDone)" stroke="#3a8c62" stroke-width="1.5"/>
+    <text x="230" y="49" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="13.5" font-weight="600"><tspan fill="#eafff3">df.start()</tspan><tspan dx="7" font-weight="700" fill="#8fe3a6">✓</tspan></text>
+  </g>
+
+  <!-- Parallel branch (done) -->
+  <g>
+    <rect x="35" y="132" width="120" height="38" rx="9" fill="url(#gDone)" stroke="#3a8c62" stroke-width="1.5"/>
+    <text x="95" y="156" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="11.5" font-weight="600"><tspan fill="#eafff3">count users</tspan><tspan dx="6" font-weight="700" fill="#8fe3a6">✓</tspan></text>
+  </g>
+  <g>
+    <rect x="170" y="132" width="120" height="38" rx="9" fill="url(#gDone)" stroke="#3a8c62" stroke-width="1.5"/>
+    <text x="230" y="156" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="11.5" font-weight="600"><tspan fill="#eafff3">count orders</tspan><tspan dx="6" font-weight="700" fill="#8fe3a6">✓</tspan></text>
+  </g>
+  <g>
+    <rect x="305" y="132" width="120" height="38" rx="9" fill="url(#gDone)" stroke="#3a8c62" stroke-width="1.5"/>
+    <text x="365" y="156" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="11.5" font-weight="600"><tspan fill="#eafff3">sum revenue</tspan><tspan dx="6" font-weight="700" fill="#8fe3a6">✓</tspan></text>
+  </g>
+
+  <!-- Join node (running) -->
+  <g>
+    <rect x="142" y="240" width="176" height="40" rx="10" fill="url(#gRun)" stroke="#6bb3ec" stroke-width="1.5"/>
+    <text x="230" y="265" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="13.5" font-weight="600"><tspan fill="#ffffff">dashboard ready</tspan><tspan dx="8" font-weight="700" fill="#cfe6ff">▶</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Post-merge polish for the pg_durable docs website (`docs/website/`).

### Changes
- **Live-execution animation**: now plays once and holds on the final snippet instead of looping, so the code stays readable. Adds a **↻ Replay** button to restart on demand. Respects `prefers-reduced-motion` (shows the completed state).
- **Always-on HorizonDB rail**: a fixed, Azure-blue tab pinned to the right edge (logo + subtle pulse) that expands on hover/focus to reveal "Run it in the cloud · Azure HorizonDB · Preview →" and links to the cloud section. Auto-hides below 820px so it never covers content on mobile.
- **Logo + favicon**: recreated the pg_durable mark (gradient hexagon + white gear + fast-forward arrow) as a scalable `favicon.svg`. Used in the header as a logo lockup with a gradient wordmark, and wired as the favicon via `rel="icon"` (SVG), `mask-icon`, and a `theme-color` meta.

### Notes
- The GitHub Pages deploy workflow uploads all of `docs/website/` as the site root, so the favicon and assets ship automatically — no CI change needed.
- Verified in-browser: animation stops/holds with working Replay, rail expands to ~300px on hover, logo mark renders, and the favicon link resolves.