### PR TITLE
website: inline header logo to avoid broken image

### DIFF
--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -23,7 +23,23 @@
     <header class="site-header">
       <div class="container nav">
         <a class="brand" href="#top">
-          <img class="brand-lockup" src="lockup_arrow_dark.svg" alt="pg_durable" width="157" height="50" />
+          <svg class="brand-mark" viewBox="0 0 256 256" role="img" aria-label="pg_durable logo mark">
+            <defs>
+              <linearGradient id="brand-g" x1="0" y1="0" x2="1" y2="1">
+                <stop offset="0%" stop-color="#13b5a6" />
+                <stop offset="52%" stop-color="#3b82f6" />
+                <stop offset="100%" stop-color="#7c4dde" />
+              </linearGradient>
+            </defs>
+            <g transform="translate(18 18) scale(0.86)">
+              <path d="M128 30 L212.87 79 L212.87 177 L128 226 L43.13 177 L43.13 79 Z" fill="none" stroke="url(#brand-g)" stroke-width="11" stroke-linejoin="round" />
+              <path d="M119.03 82.88 L116.29 69.15 L139.71 69.15 L136.97 82.88 L153.56 89.75 L161.33 78.11 L177.89 94.67 L166.25 102.44 L173.12 119.03 L186.85 116.29 L186.85 139.71 L173.12 136.97 L166.25 153.56 L177.89 161.33 L161.33 177.89 L153.56 166.25 L136.97 173.12 L139.71 186.85 L116.29 186.85 L119.03 173.12 L102.44 166.25 L94.67 177.89 L78.11 161.33 L89.75 153.56 L82.88 136.97 L69.15 139.71 L69.15 116.29 L82.88 119.03 L89.75 102.44 L78.11 94.67 L94.67 78.11 L102.44 89.75 Z" fill="url(#brand-g)" />
+              <circle cx="128" cy="128" r="27" fill="#fff" />
+              <path transform="translate(109.10 140.24) scale(0.018 -0.018)" d="M406 860Q480 860 534.5 830Q589 800 632.5 760Q676 720 716.5 690Q757 660 802 660Q859 660 899.5 700.5Q940 741 980 817L1157 737Q1115 644 1064.5 573Q1014 502 948.5 461.5Q883 421 794 421Q722 421 667.5 451Q613 481 569 521Q525 561 484 591Q443 621 398 621Q340 621 299.5 579Q259 537 220 465L43 544Q84 628 134 700Q184 772 250 816Q316 860 406 860Z" fill="#15294d" />
+              <path transform="translate(125.30 140.24) scale(0.018 -0.018)" d="M279 1225 1061 741V515L282 31L139 246L789 628L139 998Z" fill="#15294d" />
+            </g>
+          </svg>
+          <span class="brand-word">pg<span class="brand-us">_</span>durable</span>
         </a>
         <nav class="nav-links" aria-label="Primary">
           <a href="#how-it-works">How It Works</a>

--- a/docs/website/styles.css
+++ b/docs/website/styles.css
@@ -150,16 +150,16 @@ main,
   gap: 0.55rem;
 }
 
-.brand-lockup {
-  width: 157px;
-  height: auto;
+.brand-mark {
+  width: 30px;
+  height: 30px;
   flex: 0 0 auto;
   filter: drop-shadow(0 0 10px var(--pg-blue-glow));
   transition: transform 0.25s ease;
 }
 
-.brand:hover .brand-lockup {
-  transform: scale(1.03);
+.brand:hover .brand-mark {
+  transform: rotate(-8deg) scale(1.05);
 }
 
 .brand-word {
@@ -1814,8 +1814,9 @@ footer p {
   .brand {
     font-size: 1.12rem;
   }
-  .brand-lockup {
-    width: 136px;
+  .brand-mark {
+    width: 26px;
+    height: 26px;
   }
   /* Comfortable reading size, avoid zoom-on-focus quirks */
   .subtitle,


### PR DESCRIPTION
## Summary
- replace the header external lockup image with an inline SVG logo mark
- restore the pg_durable text label beside the mark
- keep the supplied lockup asset for README/brand uses while avoiding a broken-image placeholder in the site header

## Validation
- VS Code diagnostics: website HTML and CSS report no errors