### PR TITLE
docs: standardize README terminology to durable functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/website/lockup_arrow_dark.svg" alt="pg_durable logo" width="560" />
 
-## Durable SQL workflows for PostgreSQL — no extra infra.
+## Durable SQL functions for PostgreSQL — no extra infra.
 
 Long-running, fault-tolerant functions defined entirely in SQL. Composable operators,
 automatic checkpointing, crash-safe replay, and parallel execution. Built on Postgres —
@@ -201,7 +201,7 @@ pg_durable is a PostgreSQL extension (built with [pgrx](https://github.com/pgcen
 └────────────────────────────────────────────────────────────────────┘
 ```
 
-If you'd rather author durable workflows in Rust, Python, or Node while still persisting state in PostgreSQL, you can use duroxide and duroxide-pg directly from your host language — pg_durable is what you'd build on top of that pair when you'd prefer authoring in SQL.
+If you'd rather author durable functions in Rust, Python, or Node while still persisting state in PostgreSQL, you can use duroxide and duroxide-pg directly from your host language — pg_durable is what you'd build on top of that pair when you'd prefer authoring in SQL.
 
 ## Status
 

--- a/docs/pg_durable_spec.md
+++ b/docs/pg_durable_spec.md
@@ -1,6 +1,6 @@
 # pg_durable
 
-**SQL-native durable workflows for PostgreSQL**
+**SQL-native durable functions for PostgreSQL**
 
 ---
 

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>pg_durable — Durable SQL workflows for PostgreSQL</title>
+    <title>pg_durable — Durable SQL functions for PostgreSQL</title>
     <meta
       name="description"
-      content="Build durable, fault-tolerant workflows in pure SQL. Retries, scheduling, parallel execution, and conditional branching — all inside PostgreSQL."
+      content="Build durable, fault-tolerant functions in pure SQL. Retries, scheduling, parallel execution, and conditional branching — all inside PostgreSQL."
     />
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="mask-icon" href="favicon.svg" color="#3d86c6" />
@@ -58,7 +58,7 @@
       <section class="hero">
         <div class="container hero-inner">
           <span class="hero-eyebrow">Open-source · durable functions for Postgres</span>
-          <h1>Durable, crash-proof workflows<br />built into <span class="accent">Postgres</span></h1>
+          <h1>Durable, crash-proof functions<br />built into <span class="accent">Postgres</span></h1>
           <p class="subtitle">
             Orchestrate retries, scheduling, parallel fan-out, and conditional branching with a tiny SQL DSL.
             Built on Postgres&nbsp;+ a background worker — no containers, no external services, just Postgres.
@@ -813,7 +813,7 @@ SELECT job.id, v.ord, v.name, v.query, v.deps FROM job, (VALUES
             </div>
             <p class="horizon-lede">
               Azure HorizonDB is Microsoft's new PostgreSQL cloud service — engineered for performance and built
-              with pg_durable inside. Keep the durable workflows you write here, and add enterprise scale,
+              with pg_durable inside. Keep the durable functions you write here, and add enterprise scale,
               security, and AI without managing a single server.
             </p>
             <div class="horizon-grid">

--- a/examples/operational-scenarios/README.md
+++ b/examples/operational-scenarios/README.md
@@ -31,7 +31,7 @@ psql -h <host> -U <user> -d <database>
 
 > ⚠️ **These scripts are illustrative.** Two things to keep in mind before running the `pg_durable` versions verbatim:
 >
-> - **`VACUUM` cannot run inside a transaction block.** The durable worker executes each node inside a transaction, so a bare `VACUUM` step will error at runtime. Treat the `VACUUM (...)` nodes as illustrative — in production, trigger vacuum from a separate maintenance connection (e.g. an out-of-band `psql` session or a scheduled job) once the durable workflow signals it's safe.
+> - **`VACUUM` cannot run inside a transaction block.** The durable worker executes each node inside a transaction, so a bare `VACUUM` step will error at runtime. Treat the `VACUUM (...)` nodes as illustrative — in production, trigger vacuum from a separate maintenance connection (e.g. an out-of-band `psql` session or a scheduled job) once the durable function signals it's safe.
 > - **Approval steps pause the workflow.** Each remediation branch uses `df.wait_for_signal('approve-…')`. In these demo scripts a short `timeout_seconds` is supplied so the workflow auto-continues instead of hanging. In production, omit the timeout and have an operator approve explicitly with `df.signal('<instance_id>', 'approve-…')`.
 
 ## Blocker Identification Reference


### PR DESCRIPTION
## Summary
- update README header text from "Durable SQL workflows" to "Durable SQL functions"
- replace one "durable workflows" phrase in the architecture section with "durable functions"

## Why
Keeps terminology consistent across descriptions and avoids the "durable workflows" combination while still allowing "workflows" as a general descriptive term where appropriate.

## Testing
- docs-only change; no code/runtime impact