### PR TITLE
docs: reference pg_durable.database GUC instead of PGDATABASE env var

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1881,11 +1881,11 @@ pg_durable: waiting for CREATE EXTENSION pg_durable...
 **Solution**:
 1. Verify you're creating the extension in the correct database
 2. Check which database the background worker connects to:
-   - Defaults to the database specified by `PGDATABASE` environment variable or `postgres`
+   - Controlled by the `pg_durable.database` GUC (set in `postgresql.conf`); defaults to `postgres`
    - The background worker only processes functions in **one** database
 3. If you need pg_durable in a different database:
    - Create the extension in the database the background worker uses, OR
-   - Update environment variables and restart PostgreSQL
+   - Update `pg_durable.database` in `postgresql.conf` and restart PostgreSQL
 
 ### Extension Drop/Recreate Issues
 

--- a/docs/extension_lifecycle.md
+++ b/docs/extension_lifecycle.md
@@ -313,7 +313,7 @@ This design uses `sqlx` polling (checking `pg_extension` table every 5 seconds):
     - `CREATE EXTENSION pg_durable` validates prerequisites before allowing installation:
       - **Validates shared_preload_libraries**: Extension creation fails if `pg_durable` is not in `shared_preload_libraries` (checked in `_PG_init`)
       - **Validates target database**: Extension creation fails if run in the wrong database
-        - Background worker connects to ONE database (determined by `POSTGRES_DB` or `PGDATABASE` environment variable, defaults to `postgres`)
+        - Background worker connects to ONE database (determined by the `pg_durable.database` GUC, defaults to `postgres`)
         - Extension must be created in that exact database
         - Validation runs during `CREATE EXTENSION` via SQL block that calls `df.target_database()` function
         - Error message clearly indicates which database should be used
@@ -417,7 +417,7 @@ The duroxide schema is extension-owned but its contents are BGW-managed:
     - Clear error message directs users to add pg_durable to `shared_preload_libraries` and restart
 
 2. **Single database limitation** ✅ **VALIDATED**
-   - Background worker connects to ONE database (POSTGRES_DB/PGDATABASE env var, defaults to `postgres`)
+   - Background worker connects to ONE database (controlled by the `pg_durable.database` GUC, defaults to `postgres`)
    - CREATE EXTENSION now validates the current database matches the background worker's target database
    - **Mitigation (implemented):** Extension creation fails with clear error if run in wrong database
    - **Future:** Support multi-database (would require multiple background workers or more complex architecture)


### PR DESCRIPTION
## Summary

Audited references to `PGDATABASE` (and related env vars) across the repo. The runtime moved to the `pg_durable.database` GUC a while back, but a few user-facing docs still claimed the background worker reads its target database from `POSTGRES_DB`/`PGDATABASE`.

## Changes

- `USER_GUIDE.md` — troubleshooting section now points at the `pg_durable.database` GUC in `postgresql.conf`.
- `docs/extension_lifecycle.md` — two spots in the lifecycle/known-limitations sections corrected to reference the GUC.

## Audit notes (no code changes needed)

- Runtime is already GUC-driven: `src/lib.rs` registers `pg_durable.database`; `src/types.rs::get_database()` reads it and defaults to `postgres`.
- The CREATE EXTENSION database-validation message and the frozen `sql/pg_durable--0.1.1.sql` install fixture already reference the GUC correctly.
- Shell uses of `PGDATABASE` in `scripts/pg-common.sh`, `Makefile`, `scripts/test-upgrade.sh`, `scripts/test-e2e-local.sh`, `docs/TESTING.md`, and `examples/azure-http-domains/scripts/run-test.sh` are intentional dev/test ergonomics — they translate the env var into the GUC at cluster-config time.
- `docker-compose.yml` sets `POSTGRES_DB` (postgres image convention) and also passes `-c pg_durable.database=pg_durable` explicitly. Correct.

Other env vars audited at the same time:
- `PGHOST` — real runtime dependency in `src/types.rs` for the BGW connection string, defaults to `127.0.0.1`. Already documented in `docs/security-review/workbook-data.md`.
- `DUROXIDE_PG_POOL_MAX` — internal; the worker sets it from `pg_durable.max_duroxide_connections`.
- `RUST_LOG` — documented.
- `PGUSER` / `PGPORT` — not used; worker uses the `pg_durable.worker_role` GUC and `PostPortNumber` from the postmaster.