### PR TITLE
Followup to #190: harden release job and drop arm64 scaffolding

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag/version to package, for example v0.2.2'
+        description: 'v-tag to package, for example v0.2.2'
         required: true
         type: string
-      publish_release:
-        description: 'Upload assets to the GitHub release'
+      publish:
+        description: 'Upload assets to the GitHub release after packaging and validation'
         required: true
         default: false
         type: boolean
@@ -36,12 +36,29 @@ env:
   PACKAGE_HTTP_FEATURE: http-allow-azure-domains
 
 concurrency:
-  group: package-release-${{ github.event.inputs.tag || github.ref }}
+  group: package-release-${{ inputs.tag || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  validate-inputs:
+    name: Validate package inputs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require v-tag for manual packaging
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          case "${{ inputs.tag }}" in
+            v*) ;;
+            *)
+              echo "::error::tag input must be a v-tag, for example v0.2.2"
+              exit 1
+              ;;
+          esac
+
   build-packages:
     name: Build PG${{ matrix.pg_version }} ${{ matrix.platform.type }} package
+    needs: validate-inputs
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -55,15 +72,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       # Release tooling (scripts, packaging helpers) must come from the commit
       # that defines this workflow, not from the target tag. For
-      # workflow_dispatch, GitHub runs the workflow YAML from the default
-      # branch HEAD while the primary checkout above is pinned to an older
-      # tag, so the tag may predate these scripts. github.sha tracks the
-      # workflow's own commit for both workflow_dispatch (main HEAD) and
-      # push:tags (the tagged commit), keeping YAML and scripts in sync.
+      # workflow_dispatch, this allows a PR branch to run its updated pipeline
+      # while the primary checkout above is pinned to the v-tag being packaged.
+      # github.sha tracks the workflow's own commit for workflow_dispatch and
+      # push:tags, keeping YAML and scripts in sync with the branch that ran it.
       - name: Checkout release tooling
         uses: actions/checkout@v4
         with:
@@ -73,7 +89,7 @@ jobs:
       - name: Set version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "VERSION=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+            echo "VERSION=${{ inputs.tag }}" >> "$GITHUB_ENV"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             crate_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
             echo "VERSION=${crate_version}~pr${{ github.event.pull_request.number }}+${GITHUB_SHA::7}" >> "$GITHUB_ENV"
@@ -183,7 +199,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       # See build-packages: validation tooling must come from the workflow's
       # own commit (github.sha), not the target tag, so a tag predating these
@@ -223,17 +239,18 @@ jobs:
 
   build-source:
     name: Build source archives
+    needs: validate-inputs
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - name: Set version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "VERSION=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+            echo "VERSION=${{ inputs.tag }}" >> "$GITHUB_ENV"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             crate_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
             echo "VERSION=${crate_version}~pr${{ github.event.pull_request.number }}+${GITHUB_SHA::7}" >> "$GITHUB_ENV"
@@ -261,19 +278,19 @@ jobs:
     name: Upload release assets
     needs: [validate-packages, build-source]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.inputs.publish_release == 'true'
+    if: github.event_name == 'push' || inputs.publish == true
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - name: Set version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "VERSION=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+            echo "VERSION=${{ inputs.tag }}" >> "$GITHUB_ENV"
           else
             echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -57,6 +57,19 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
+      # Release tooling (scripts, packaging helpers) must come from the commit
+      # that defines this workflow, not from the target tag. For
+      # workflow_dispatch, GitHub runs the workflow YAML from the default
+      # branch HEAD while the primary checkout above is pinned to an older
+      # tag, so the tag may predate these scripts. github.sha tracks the
+      # workflow's own commit for both workflow_dispatch (main HEAD) and
+      # push:tags (the tagged commit), keeping YAML and scripts in sync.
+      - name: Checkout release tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: _release_tooling
+
       - name: Set version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -127,7 +140,7 @@ jobs:
                 --no-default-features \
                 --features "$FEATURES"
 
-              scripts/package-deb.sh \
+              _release_tooling/scripts/package-deb.sh \
                 "$VERSION" \
                 "$PWD/target/release/pg_durable-pg${{ matrix.pg_version }}" \
                 "${{ matrix.platform.type }}" \
@@ -172,6 +185,15 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
+      # See build-packages: validation tooling must come from the workflow's
+      # own commit (github.sha), not the target tag, so a tag predating these
+      # scripts still validates correctly.
+      - name: Checkout release tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: _release_tooling
+
       - name: Download package artifact
         uses: actions/download-artifact@v4
         with:
@@ -186,7 +208,7 @@ jobs:
             -w /work \
             --user root \
             debian:bookworm \
-            bash -euxo pipefail -c 'scripts/validate-deb-package.sh "${{ matrix.pg_version }}" "${{ matrix.platform.type }}"'
+            bash -euxo pipefail -c '_release_tooling/scripts/validate-deb-package.sh "${{ matrix.pg_version }}" "${{ matrix.platform.type }}"'
 
       - name: Upload validation diagnostics on failure
         if: failure()

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -27,7 +27,7 @@ on:
       - 'sql/**'
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -100,8 +100,7 @@ jobs:
                 libxml2-dev \
                 libxslt1-dev \
                 libicu-dev \
-                file \
-                zip
+                file
 
               install -d -m 0755 /usr/share/keyrings
               curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
@@ -148,19 +147,12 @@ jobs:
           dpkg-deb -x "$deb_file" check-package
           file "check-package/usr/lib/postgresql/${{ matrix.pg_version }}/lib/pg_durable.so" | grep -E "${{ matrix.platform.file_pattern }}"
 
-      - name: Create package archive
-        run: |
-          cd dist
-          zip "pg-durable-${VERSION}-pg${{ matrix.pg_version }}-${{ matrix.platform.type }}.zip" \
-            pg-durable-postgresql-${{ matrix.pg_version }}_*_${{ matrix.platform.type }}.deb
-
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:
           name: pg-durable-package-${{ github.run_id }}-pg${{ matrix.pg_version }}-${{ matrix.platform.type }}
           path: |
             dist/*.deb
-            dist/*.zip
           retention-days: 30
 
   validate-packages:
@@ -248,6 +240,8 @@ jobs:
     needs: [validate-packages, build-source]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.inputs.publish_release == 'true'
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -278,5 +272,11 @@ jobs:
               --draft
           fi
 
-          find artifacts -type f \( -name '*.zip' -o -name '*.tar.gz' -o -name '*.tar.bz2' \) -print0 \
+          mkdir -p release-assets
+          find artifacts -type f \( -name '*.deb' -o -name '*.tar.gz' -o -name '*.tar.bz2' \) \
+            -exec cp -t release-assets {} +
+
+          ( cd release-assets && sha256sum -- * > SHA256SUMS )
+
+          find release-assets -type f -print0 \
             | xargs -0 -I {} gh release upload "$VERSION" "{}" --clobber

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ CREATE EXTENSION pg_durable;
 
 The default pg_durable database is `postgres`; see [User Guide](USER_GUIDE.md) for background worker configuration and privilege setup.
 
-Release assets also include source archives for building from source.
+Each release also publishes source archives for building from source and a `SHA256SUMS` file for verifying downloaded assets.
 
 ## Development Installation
 

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -22,9 +22,6 @@ case "$ARCH" in
     amd64|x86_64)
         DEB_ARCH="amd64"
         ;;
-    arm64|aarch64)
-        DEB_ARCH="arm64"
-        ;;
     *)
         echo "unsupported architecture: $ARCH" >&2
         exit 2

--- a/scripts/validate-deb-package.sh
+++ b/scripts/validate-deb-package.sh
@@ -19,9 +19,6 @@ case "$ARCH" in
     amd64|x86_64)
         DEB_ARCH="amd64"
         ;;
-    arm64|aarch64)
-        DEB_ARCH="arm64"
-        ;;
     *)
         echo "unsupported architecture: $ARCH" >&2
         exit 2


### PR DESCRIPTION
Followup to #190 (merged) addressing review feedback and self-review items that were not part of the squashed merge.

## Changes
- **Drop unused arm64 scaffolding** — the build/validate matrices and README are amd64-only, so the `arm64`/`aarch64` branches in `scripts/package-deb.sh` and `scripts/validate-deb-package.sh` were dead code. They now reject unsupported architectures explicitly. (Addresses the Copilot review comments on #190 about the arm64 description/implementation mismatch.)
- **Least-privilege permissions** — scope `contents: write` to the `release` job only; the rest of the workflow runs with `contents: read`.
- **Publish `.deb` assets directly** — upload the `.deb` files as release assets instead of wrapping them in zips, matching the README's documented asset names. Removes the now-unused zip step and `zip` build dependency.
- **Asset integrity** — publish a `SHA256SUMS` file so downloaders can verify release assets; README updated to mention it.

## Validation
- `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow
- `bash -n` on both packaging scripts
- `git diff --check`