### PR TITLE
Default worker role to postgres instead of azuresu

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ GRANT pg_durable_user TO app_backend, etl_service;
 > **Note:** `GRANT EXECUTE ON ALL FUNCTIONS` only applies to functions that exist when the grant runs. After upgrading pg_durable with `ALTER EXTENSION pg_durable UPDATE`, re-run `df.grant_usage('role')` (or re-issue the manual grants) so new functions are accessible.
 
 **Key points:**
-- The background worker role (`pg_durable.worker_role` GUC, default: `azuresu`) **must be a superuser** — it bypasses RLS to manage all users' instances
+- The background worker role (`pg_durable.worker_role` GUC, default: `postgres`) **must be a superuser** — it bypasses RLS to manage all users' instances
 - Users get `SELECT` + `INSERT` on `df.instances` / `df.nodes`, column-level `UPDATE (status, updated_at)` on instances for `df.cancel()`
 - Identity column (`submitted_by`) cannot be modified by users
 - **`df.vars` uses per-user scoping** — each user has their own variable namespace via an `owner` column and RLS. Superusers bypass RLS but DSL functions still scope to the calling user via explicit filters. Avoid storing secrets in plain text

--- a/docs/rls.md
+++ b/docs/rls.md
@@ -206,7 +206,7 @@ Superusers bypass all permission checks in PostgreSQL, including RLS. This means
 - No additional GRANTs to the worker role needed
 - Consistent with the existing trust model: the extension is installed by a superuser, and the worker is trusted code
 
-The worker role is configured via `pg_durable.worker_role` GUC (defaults to `azuresu`). The extension should document that this role must be a superuser.
+The worker role is configured via `pg_durable.worker_role` GUC (defaults to `postgres`). The extension should document that this role must be a superuser.
 
 ### Decision 7: `df.cancel()` and `df.signal()` ownership checks
 
@@ -298,7 +298,7 @@ The worker role must be a superuser (see Decision 6). Superusers bypass RLS auto
 
 ```sql
 -- No RLS bypass configuration needed.
--- The worker role (pg_durable.worker_role GUC, default: azuresu) must be a superuser.
+-- The worker role (pg_durable.worker_role GUC, default: postgres) must be a superuser.
 -- Superusers bypass all permission checks including RLS.
 ```
 

--- a/docs/security-review/threat-model.dfd-lite.yaml
+++ b/docs/security-review/threat-model.dfd-lite.yaml
@@ -10,7 +10,7 @@ model:
     - "Single-tenant PostgreSQL deployment — one organization per database instance"
     - "Extension installed by superuser (trusted extension model)"
     - "pg_hba.conf configured for trust or peer auth on localhost for background worker connections"
-    - "Background worker role (azuresu) is a PostgreSQL superuser"
+    - "Background worker role (postgres) is a PostgreSQL superuser"
     - "No external services — everything runs inside the PostgreSQL server process"
     - "Users have database role accounts with appropriate PostgreSQL RBAC"
   externalDependencies:

--- a/docs/security-review/workbook-data.md
+++ b/docs/security-review/workbook-data.md
@@ -16,14 +16,14 @@ pg_durable does not use token-based authentication. All identity is PostgreSQL r
 |---|---|---|---|---|
 | session_user (login_role) | pg_hba.conf authentication | `GetSessionUserId()` C API | df.instances.login_role, df.nodes.login_role | Connection authentication for per-user SQL execution |
 | current_user (submitted_by) | PostgreSQL SET ROLE / default | `GetOuterUserId()` C API | df.instances.submitted_by, df.nodes.submitted_by | SET ROLE target for privilege isolation; RLS policy column |
-| worker_role | GUC `pg_durable.worker_role` | Configuration (default: "azuresu") | postgresql.conf | Background worker sqlx pool authentication |
+| worker_role | GUC `pg_durable.worker_role` | Configuration (default: "postgres") | postgresql.conf | Background worker sqlx pool authentication |
 
 ### Least Privilege Assessment
 
 | Identity | Privileges | Minimum Required | Delta |
 |---|---|---|---|
 | Database user | EXECUTE on all df.* functions, SELECT/INSERT on df.tables, USAGE on df schema | EXECUTE on needed df.* functions only; no df.http() unless needed | Too broad — PUBLIC has EXECUTE on all functions including df.http() |
-| Worker role (azuresu) | SUPERUSER (bypasses RLS, connects as any role) | BYPASSRLS + CREATEROLE or trust-auth connect-as capability | Could explore non-superuser with BYPASSRLS if PostgreSQL supports connect-as without superuser |
+| Worker role (postgres) | SUPERUSER (bypasses RLS, connects as any role) | BYPASSRLS + CREATEROLE or trust-auth connect-as capability | Could explore non-superuser with BYPASSRLS if PostgreSQL supports connect-as without superuser |
 | Per-user SQL connection | User's own RBAC (login_role + SET ROLE submitted_by) | Exactly what the user has outside durable functions | ✅ Correct — no privilege amplification |
 
 ---
@@ -115,7 +115,7 @@ pg_durable does not use token-based authentication. All identity is PostgreSQL r
 
 | GUC | Default | Scope | Security Relevance |
 |---|---|---|---|
-| `pg_durable.worker_role` | "azuresu" | Postmaster | Determines background worker's PostgreSQL identity; must be superuser |
+| `pg_durable.worker_role` | "postgres" | Postmaster | Determines background worker's PostgreSQL identity; must be superuser |
 | `pg_durable.database` | "postgres" | Postmaster | Target database for extension operations |
 | `df.in_workflow` | unset | Session | Custom GUC set on worker connections; prevents variable mutation during execution |
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::ffi::CString;
 // ============================================================================
 
 pub static WORKER_ROLE: GucSetting<Option<CString>> =
-    GucSetting::<Option<CString>>::new(Some(c"azuresu"));
+    GucSetting::<Option<CString>>::new(Some(c"postgres"));
 
 pub static DATABASE: GucSetting<Option<CString>> =
     GucSetting::<Option<CString>>::new(Some(c"postgres"));
@@ -532,7 +532,7 @@ DECLARE
 BEGIN
     wrole := pg_catalog.current_setting('pg_durable.worker_role', true);
     IF wrole IS NULL OR wrole OPERATOR(pg_catalog.=) '' THEN
-        wrole := 'azuresu';
+        wrole := 'postgres';
     END IF;
 
     SELECT rolsuper INTO is_super FROM pg_catalog.pg_roles WHERE rolname OPERATOR(pg_catalog.=) wrole;

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,12 +20,12 @@ use uuid::Uuid;
 // ============================================================================
 
 /// Get the worker role from the `pg_durable.worker_role` GUC.
-/// Falls back to `"azuresu"` if the GUC is not set.
+/// Falls back to `"postgres"` if the GUC is not set.
 pub fn get_worker_role() -> String {
     crate::WORKER_ROLE
         .get()
         .map(|cs: CString| cs.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "azuresu".to_string())
+        .unwrap_or_else(|| "postgres".to_string())
 }
 
 /// Get the database from the `pg_durable.database` GUC.


### PR DESCRIPTION
## Summary

The `pg_durable.worker_role` GUC defaulted to `azuresu`, the privileged admin role on Azure Database for PostgreSQL — Flexible Server. On any non-Azure PostgreSQL (vanilla, RDS, Cloud SQL, self-hosted) that role does not exist, so out of the box the background worker emitted "role does not exist" warnings and silently failed to process workflows until an operator overrode the GUC.

This changes the default to the vendor-neutral `postgres` role, which matches the Dockerfile and upgrade-test configuration and works on most setups.

## Changes

- `src/lib.rs` — `WORKER_ROLE` GUC default and the SQL install-script fallback now use `postgres`
- `src/types.rs` — `get_worker_role()` fallback and its doc comment updated
- Docs that cite the default value updated: `README.md`, `docs/rls.md`, `docs/security-review/workbook-data.md`, `docs/security-review/threat-model.dfd-lite.yaml`

All three runtime fallbacks (GUC default, SQL install fallback, `get_worker_role()`) are kept in sync.

## Notes

- Behavior change only, not a schema change — the worker role is read at runtime, not stored. The Dockerfile and `test-upgrade.sh` already pin `postgres`, so they are unaffected.
- `sql/pg_durable--0.1.1.sql` is intentionally left unchanged (historical version fixture for upgrade testing).
- No Azure-specific operator note was added, since only operators set this GUC.

## Validation

- `cargo build --features pg17` succeeds
- `cargo fmt -p pg_durable -- --check` passes