### PR TITLE
Update HorizonDB links in website section

### DIFF
--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -813,7 +813,7 @@ SELECT job.id, v.ord, v.name, v.query, v.deps FROM job, (VALUES
             </div>
             <p class="horizon-lede">
               Azure HorizonDB is Microsoft's new PostgreSQL cloud service — engineered for performance and built
-              with pg_durable inside. Keep the durable functions you write here, and add enterprise scale,
+              with <a href="https://aka.ms/horizondb_pg_durable">pg_durable inside</a>. Keep the durable functions you write here, and add enterprise scale,
               security, and AI without managing a single server.
             </p>
             <div class="horizon-grid">
@@ -859,8 +859,8 @@ SELECT job.id, v.ord, v.name, v.query, v.deps FROM job, (VALUES
               </div>
             </div>
             <div class="horizon-cta">
-              <a class="button-azure" href="https://aka.ms/horizondb_pg_durable">Explore Azure HorizonDB →</a>
-              <a class="button-azure-outline" href="https://aka.ms/horizondb_pg_durable">AI pipelines →</a>
+              <a class="button-azure" href="http://aka.ms/AzureHorizonDB">Explore Azure HorizonDB →</a>
+              <a class="button-azure-outline" href="https://aka.ms/horizondb-ai-pipelines">AI pipelines →</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- link the `pg_durable` phrase in the HorizonDB description to the HorizonDB pg_durable documentation
- update the primary HorizonDB CTA to the current `aka.ms` destination
- update the AI pipelines CTA to the dedicated HorizonDB AI pipelines link

## Files changed
- docs/website/index.html