### PR TITLE
Add HorizonDB try-now callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Long-running, fault-tolerant SQL functions for teams that already keep their sta
 
 Durable execution is now a standard industry pattern, and pg_durable brings it inside Postgres with no extra service infrastructure required. Part of our mission to bring compute close to data.
 
+> <img src="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/1374850-Icon-Hero-HorizonDB-24x24?resMode=sharp2&op_usm=1.5,0.65,15,0&wid=48&hei=48&qlt=100&fit=constrain" alt="Azure HorizonDB logo" width="24" /> <sub>Run it in the cloud <strong>Preview</strong></sub><br />
 > **Try pg_durable now in [Azure HorizonDB](https://aka.ms/AzureHorizonDB):** Azure HorizonDB is Microsoft's new PostgreSQL cloud service -- engineered for performance and built with [pg_durable inside](https://aka.ms/horizondb_pg_durable).
 
 ## Is this for me?

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Long-running, fault-tolerant SQL functions for teams that already keep their sta
 
 Durable execution is now a standard industry pattern, and pg_durable brings it inside Postgres with no extra service infrastructure required. Part of our mission to bring compute close to data.
 
-> <img src="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/1374850-Icon-Hero-HorizonDB-24x24?resMode=sharp2&op_usm=1.5,0.65,15,0&wid=48&hei=48&qlt=100&fit=constrain" alt="Azure HorizonDB logo" width="24" /> <sub>Run it in the cloud <strong>Preview</strong></sub><br />
+> <img src="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/1374850-Icon-Hero-HorizonDB-24x24?resMode=sharp2&op_usm=1.5,0.65,15,0&wid=48&hei=48&qlt=100&fit=constrain" alt="Azure HorizonDB logo" width="24" /><br />
 > **Try pg_durable now in [Azure HorizonDB](https://aka.ms/AzureHorizonDB):** Azure HorizonDB is Microsoft's new PostgreSQL cloud service -- engineered for performance and built with [pg_durable inside](https://aka.ms/horizondb_pg_durable).
 
 ## Is this for me?

--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ Long-running, fault-tolerant SQL functions for teams that already keep their sta
 
 Durable execution is now a standard industry pattern, and pg_durable brings it inside Postgres with no extra service infrastructure required. Part of our mission to bring compute close to data.
 
-> <img src="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/1374850-Icon-Hero-HorizonDB-24x24?resMode=sharp2&op_usm=1.5,0.65,15,0&wid=48&hei=48&qlt=100&fit=constrain" alt="Azure HorizonDB logo" width="24" /> <sub>Try pg_durable now in <a href="https://aka.ms/AzureHorizonDB">Azure HorizonDB</a></sub>
->
-> Azure HorizonDB is Microsoft's new PostgreSQL cloud service -- engineered for performance and built with [pg_durable inside](https://aka.ms/horizondb_pg_durable).
+> <img src="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/1374850-Icon-Hero-HorizonDB-24x24?resMode=sharp2&op_usm=1.5,0.65,15,0&wid=48&hei=48&qlt=100&fit=constrain" alt="Azure HorizonDB logo" width="24" /> <strong>Try pg_durable now in <a href="https://aka.ms/AzureHorizonDB">Azure HorizonDB</a>,</strong> Microsoft's new PostgreSQL cloud service engineered for performance and built with <a href="https://aka.ms/horizondb_pg_durable">pg_durable inside</a>
 
 ## Is this for me?
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ Long-running, fault-tolerant SQL functions for teams that already keep their sta
 
 Durable execution is now a standard industry pattern, and pg_durable brings it inside Postgres with no extra service infrastructure required. Part of our mission to bring compute close to data.
 
-> <img src="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/1374850-Icon-Hero-HorizonDB-24x24?resMode=sharp2&op_usm=1.5,0.65,15,0&wid=48&hei=48&qlt=100&fit=constrain" alt="Azure HorizonDB logo" width="24" /><br />
-> **Try pg_durable now in [Azure HorizonDB](https://aka.ms/AzureHorizonDB):** Azure HorizonDB is Microsoft's new PostgreSQL cloud service -- engineered for performance and built with [pg_durable inside](https://aka.ms/horizondb_pg_durable).
+<table>
+    <tr>
+        <td width="36"><img src="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/1374850-Icon-Hero-HorizonDB-24x24?resMode=sharp2&op_usm=1.5,0.65,15,0&wid=48&hei=48&qlt=100&fit=constrain" alt="Azure HorizonDB logo" width="24" /></td>
+        <td><strong>Try pg_durable now in <a href="https://aka.ms/AzureHorizonDB">Azure HorizonDB</a></strong><br /><sub>Azure HorizonDB is Microsoft's new PostgreSQL cloud service -- engineered for performance and built with <a href="https://aka.ms/horizondb_pg_durable">pg_durable inside</a>.</sub></td>
+    </tr>
+</table>
 
 ## Is this for me?
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,9 @@ Long-running, fault-tolerant SQL functions for teams that already keep their sta
 
 Durable execution is now a standard industry pattern, and pg_durable brings it inside Postgres with no extra service infrastructure required. Part of our mission to bring compute close to data.
 
-<table>
-    <tr>
-        <td width="36"><img src="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/1374850-Icon-Hero-HorizonDB-24x24?resMode=sharp2&op_usm=1.5,0.65,15,0&wid=48&hei=48&qlt=100&fit=constrain" alt="Azure HorizonDB logo" width="24" /></td>
-        <td><strong>Try pg_durable now in <a href="https://aka.ms/AzureHorizonDB">Azure HorizonDB</a></strong><br /><sub>Azure HorizonDB is Microsoft's new PostgreSQL cloud service -- engineered for performance and built with <a href="https://aka.ms/horizondb_pg_durable">pg_durable inside</a>.</sub></td>
-    </tr>
-</table>
+> <img src="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/1374850-Icon-Hero-HorizonDB-24x24?resMode=sharp2&op_usm=1.5,0.65,15,0&wid=48&hei=48&qlt=100&fit=constrain" alt="Azure HorizonDB logo" width="24" /> <sub>Try pg_durable now in <a href="https://aka.ms/AzureHorizonDB">Azure HorizonDB</a></sub>
+>
+> Azure HorizonDB is Microsoft's new PostgreSQL cloud service -- engineered for performance and built with [pg_durable inside](https://aka.ms/horizondb_pg_durable).
 
 ## Is this for me?
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Long-running, fault-tolerant SQL functions for teams that already keep their sta
 
 Durable execution is now a standard industry pattern, and pg_durable brings it inside Postgres with no extra service infrastructure required. Part of our mission to bring compute close to data.
 
+> **Try pg_durable now in [Azure HorizonDB](https://aka.ms/AzureHorizonDB):** Azure HorizonDB is Microsoft's new PostgreSQL cloud service -- engineered for performance and built with [pg_durable inside](https://aka.ms/horizondb_pg_durable).
+
 ## Is this for me?
 
 ### Who it's for


### PR DESCRIPTION
## Summary
- add a prominent Azure HorizonDB try-now callout after the README intro
- link Azure HorizonDB and the pg_durable-inside explainer to the corresponding shortlinks

## Testing
- Not run (docs-only change)