### PR TITLE
Upgrade `pg_durable` to pgrx v0.18.1

### DIFF
--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -43,11 +43,11 @@ else
 fi
 
 # Install cargo-pgrx
-echo "Installing cargo-pgrx 0.16.1..."
+echo "Installing cargo-pgrx 0.18.1..."
 if [ "$SMOKE_MODE" = "1" ]; then
     echo "Smoke mode: skipping cargo-pgrx install"
 else
-    cargo install cargo-pgrx --version 0.16.1 --locked
+    cargo install cargo-pgrx --version 0.18.1 --locked
 fi
 
 # Initialize pgrx with PostgreSQL 17 (pgrx will download and compile PG17)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,7 +100,7 @@ For Scenario A, treat the upgrade path as the contract for already-shipped versi
 
 ## Dependencies
 
-- **pgrx 0.16.1**: PostgreSQL extension framework (pinned version)
+- **pgrx 0.18.1**: PostgreSQL extension framework (pinned version)
 - **duroxide**: Durable execution runtime (crates.io dependency pinned in [`Cargo.toml`](../Cargo.toml))
 - **duroxide-pg**: duroxide provider/stores engine state in PostgreSQL (crates.io dependency pinned in [`Cargo.toml`](../Cargo.toml)); keep pinned with `duroxide` as a compatible pair
 - **sqlx**: Async PostgreSQL from background worker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           path: |
             ~/.cargo/.crates2.json
             ~/.cargo/bin/cargo-pgrx
-          key: ${{ runner.os }}-cargo-pgrx-0.16.1-v1
+          key: ${{ runner.os }}-cargo-pgrx-0.18.1-v1
 
       - name: Cache Cargo dependency sources
         uses: actions/cache@v5
@@ -158,10 +158,10 @@ jobs:
 
       - name: Install cargo-pgrx
         run: |
-          if ! command -v cargo-pgrx &> /dev/null || ! cargo pgrx --version | grep -q "0.16.1"; then
-            cargo install cargo-pgrx --version 0.16.1 --locked
+          if ! command -v cargo-pgrx &> /dev/null || ! cargo pgrx --version | grep -q "0.18.1"; then
+            cargo install cargo-pgrx --version 0.18.1 --locked
           else
-            echo "cargo-pgrx 0.16.1 already installed, skipping"
+            echo "cargo-pgrx 0.18.1 already installed, skipping"
           fi
 
       - name: Initialize pgrx

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -50,7 +50,7 @@ jobs:
           path: |
             ~/.cargo/.crates2.json
             ~/.cargo/bin/cargo-pgrx
-          key: ${{ runner.os }}-copilot-setup-cargo-pgrx-0.16.1-v1
+          key: ${{ runner.os }}-copilot-setup-cargo-pgrx-0.18.1-v1
 
       - name: Cache Cargo dependency sources
         uses: actions/cache@v5
@@ -69,14 +69,14 @@ jobs:
             ~/.pgrx/config.toml
             ~/.pgrx/17.*
             ~/.pgrx/18.*
-          key: ${{ runner.os }}-copilot-setup-pgrx-0.16.1-pg17-18-v1
+          key: ${{ runner.os }}-copilot-setup-pgrx-0.18.1-pg17-18-v1
 
       - name: Install cargo-pgrx
         run: |
-          if ! command -v cargo-pgrx &> /dev/null || ! cargo pgrx --version | grep -q "0.16.1"; then
-            cargo install cargo-pgrx --version 0.16.1 --locked
+          if ! command -v cargo-pgrx &> /dev/null || ! cargo pgrx --version | grep -q "0.18.1"; then
+            cargo install cargo-pgrx --version 0.18.1 --locked
           else
-            echo "cargo-pgrx 0.16.1 already installed, skipping"
+            echo "cargo-pgrx 0.18.1 already installed, skipping"
           fi
 
       - name: Initialize pgrx (PostgreSQL 17 and 18)

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -32,7 +32,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  CARGO_PGRX_VERSION: 0.16.1
+  CARGO_PGRX_VERSION: 0.18.1
   PACKAGE_HTTP_FEATURE: http-allow-azure-domains
 
 concurrency:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "annotate-snippets",
  "bitflags",
@@ -213,24 +213,9 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -328,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -338,7 +323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -505,9 +490,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -667,6 +652,16 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -878,12 +873,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,25 +1030,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
@@ -1270,7 +1247,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -1743,12 +1720,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1848,12 +1873,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pathsearch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdcfb88f7fa9ba42b4ea9d1f85a1d968bbb407cc30308b35f73bdfe6c966f64b"
+checksum = "06eb76205437c489284e76c3910c81378d525e3e7e8364c31875ec105cc63cd1"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -1927,15 +1946,15 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e35193b7e71e2f612d336cecd00db0f049f4cc609f2b1c9a34755b5ec559d7"
+checksum = "92b64cb3d6abab7fa588a83cb154938ba403e5bd41349cf5cbe82eca971ab0a2"
 dependencies = [
  "bindgen",
  "cc",
@@ -1945,16 +1964,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "shlex",
+ "shlex 2.0.1",
  "syn",
  "walkdir",
 ]
 
 [[package]]
 name = "pgrx-macros"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab542dd4041773874f90cd8e3448195749548dc3fb1daf501e7e11ebfb1dd22"
+checksum = "cd9d49f184d3a9d5f66c55ec489c2288b31313843007570636b007c7a6fddde4"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1964,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff9b29df94c3f9fcb0cde220f92eea6975ed05962784a98fb557754ad663501"
+checksum = "2b061c1ee4e22341c6efffb578e081fc87904e000e056adc9c87e53d073954e3"
 dependencies = [
  "cargo_toml",
  "codepage",
@@ -1976,17 +1995,17 @@ dependencies = [
  "pathsearch",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
- "toml",
+ "thiserror 1.0.69",
+ "toml 0.5.11",
  "url",
  "winapi",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934f2536953ccb6722bef2cfdfb1f8d6d3cd4a4f2c508d56ec85b649c5680c2b"
+checksum = "32d5d61594a030a34bd68dfa1cc3b51cdfd58f96d77548c12def496a0d800ca7"
 dependencies = [
  "cee-scape",
  "libc",
@@ -1998,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a767cb9faa612f1ba7f13718136d4006950d6f253b414ef487a03e85c47a94"
+checksum = "82169b961269f7436bfba3b9464f4d6be6b500f0ace1de694be77398b58c09a7"
 dependencies = [
  "convert_case",
  "eyre",
@@ -2008,34 +2027,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "unescape",
 ]
 
 [[package]]
 name = "pgrx-tests"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d5d5f614a32310af2cc1b9587c69e041d97e8ab812d8d31fdcd3d33d27325c"
+checksum = "455747374115c38c70635861fa2f35c6ce01f1b7d34743b9c97291c9a5acd7ca"
 dependencies = [
  "clap-cargo",
  "eyre",
  "libc",
  "owo-colors",
- "paste",
  "pgrx",
  "pgrx-macros",
  "pgrx-pg-config",
  "postgres",
- "proptest",
- "rand 0.9.4",
+ "rand 0.10.1",
  "regex",
- "serde",
- "serde_json",
- "shlex",
+ "shlex 2.0.1",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "winapi",
 ]
 
@@ -2210,31 +2225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,12 +2232,6 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -2268,18 +2252,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2304,16 +2278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,27 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.5",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -2527,18 +2473,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -2731,6 +2665,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3074,14 +3014,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.34.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 
@@ -3295,6 +3237,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3525,12 +3476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unescape"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3601,9 +3546,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3628,15 +3573,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"
@@ -3873,12 +3809,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3887,10 +3834,34 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3898,6 +3869,17 @@ name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3916,10 +3898,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3928,6 +3931,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3977,6 +3998,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,7 @@ repository = "https://github.com/microsoft/pg_durable"
 description = "Durable SQL Functions for PostgreSQL"
 
 [lib]
-crate-type = ["cdylib", "lib"]
-
-[[bin]]
-name = "pgrx_embed_pg_durable"
-path = "./src/bin/pgrx_embed.rs"
+crate-type = ["cdylib"]
 
 [features]
 default = ["pg17"]
@@ -28,7 +24,7 @@ unsafe = ["pgrx/unsafe-postgres"]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.16.1"
+pgrx = "=0.18.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
@@ -53,7 +49,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "nat
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-pgrx-tests = "=0.16.1"
+pgrx-tests = "=0.18.1"
 
 [profile.dev]
 panic = "unwind"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install cargo-pgrx
-RUN cargo install cargo-pgrx --version 0.16.1 --locked
+RUN cargo install cargo-pgrx --version 0.18.1 --locked
 
 # Initialize pgrx with PG17 (use system PostgreSQL)
 RUN cargo pgrx init --pg17 /usr/lib/postgresql/17/bin/pg_config

--- a/NOTICE
+++ b/NOTICE
@@ -27,11 +27,11 @@ Rust dependencies declared in Cargo.toml:
   License: MIT
   Source: https://github.com/microsoft/duroxide-pg
 
-- pgrx 0.16.1
+- pgrx 0.18.1
   License: MIT
   Source: https://github.com/pgcentralfoundation/pgrx/
 
-- pgrx-tests 0.16.1
+- pgrx-tests 0.18.1
   License: MIT
   Source: https://github.com/pgcentralfoundation/pgrx/
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Release assets also include source archives for building from source.
 
 - PostgreSQL 17 or 18
 - Rust (nightly)
-- [cargo-pgrx](https://github.com/pgcentralfoundation/pgrx) 0.16.1
+- [cargo-pgrx](https://github.com/pgcentralfoundation/pgrx) 0.18.1
 
 ### GitHub Codespace
 

--- a/docs/CODESPACES_PREBUILDS.md
+++ b/docs/CODESPACES_PREBUILDS.md
@@ -35,7 +35,7 @@ Codespaces has two distinct phases:
   - Duration: depends on cache state and network conditions; it is the slow phase and runs only when the prebuild needs to be refreshed
    - Installs:
      - System dependencies (libssl, clang, bison, etc.)
-     - cargo-pgrx 0.16.1
+     - cargo-pgrx 0.18.1
      - PostgreSQL 17 (downloaded and compiled via pgrx)
    - Rust dependencies from crates.io
     - Builds and installs pg_durable
@@ -95,7 +95,7 @@ When you need to update system dependencies or pgrx version:
 Example: Updating pgrx version
 ```bash
 # In .devcontainer/onCreateCommand.sh
-cargo install cargo-pgrx --version 0.16.1 --locked  # Updated from 0.15.0
+cargo install cargo-pgrx --version 0.18.1 --locked  # Updated from 0.16.1
 ```
 
 ## Troubleshooting

--- a/docs/security-review/threat-model.dfd-lite.yaml
+++ b/docs/security-review/threat-model.dfd-lite.yaml
@@ -19,7 +19,7 @@ model:
     - "duroxide-pg (PostgreSQL persistence provider for duroxide)"
     - "sqlx (async PostgreSQL driver for background worker connections)"
     - "reqwest (HTTP client for df.http() activity)"
-    - "pgrx 0.16.1 (PostgreSQL extension framework)"
+    - "pgrx 0.18.1 (PostgreSQL extension framework)"
 
 diagrams:
   - name: "pg_durable System Overview"

--- a/docs/superuser_guc.md
+++ b/docs/superuser_guc.md
@@ -100,7 +100,7 @@ GucRegistry::define_bool_guc(
 );
 ```
 
-Note: in pgrx 0.16.1, `GucFlags::NO_SHOW_ALL` is a combined constant that sets both
+Note: in pgrx, `GucFlags::NO_SHOW_ALL` is a combined constant that sets both
 `GUC_NO_SHOW_ALL` (hides from `SHOW ALL` and `pg_settings`) and `GUC_NOT_IN_SAMPLE`
 (hides from the sample `postgresql.conf`). However, `GUC_NO_SHOW_ALL` also hides the
 GUC from `pg_settings`, which breaks any unit tests that query that view to verify

--- a/scripts/pg-common.sh
+++ b/scripts/pg-common.sh
@@ -34,8 +34,10 @@ set_pg_conf() {
     local key="$1"
     local value="$2"
 
-    if grep -q "^${key}\s*=" "$PG_CONF" 2>/dev/null; then
-        sed -i "s|^${key}\s*=.*|${key} = '${value}'|" "$PG_CONF"
+    if grep -q "^${key}[[:space:]]*=" "$PG_CONF" 2>/dev/null; then
+        # Use a backup suffix so `sed -i` is portable across GNU and BSD/macOS sed.
+        sed -i.bak "s|^${key}[[:space:]]*=.*|${key} = '${value}'|" "$PG_CONF"
+        rm -f "$PG_CONF.bak"
     else
         echo "${key} = '${value}'" >> "$PG_CONF"
     fi
@@ -95,12 +97,12 @@ wait_for_local_postgres() {
 }
 
 detect_admin_user() {
-    if "$PSQL" -h localhost -p "$PG_PORT" -U postgres -d postgres -Atqc "SELECT 1" >/dev/null 2>&1; then
+    if "$PSQL" -X -h localhost -p "$PG_PORT" -U postgres -d postgres -Atqc "SELECT 1" >/dev/null 2>&1; then
         echo "postgres"
         return 0
     fi
 
-    if "$PSQL" -h localhost -p "$PG_PORT" -U "$USER" -d postgres -Atqc "SELECT 1" >/dev/null 2>&1; then
+    if "$PSQL" -X -h localhost -p "$PG_PORT" -U "$USER" -d postgres -Atqc "SELECT 1" >/dev/null 2>&1; then
         echo "$USER"
         return 0
     fi
@@ -120,7 +122,7 @@ ensure_superuser_role() {
         return 1
     fi
 
-    "$PSQL" -h localhost -p "$PG_PORT" -U "$admin_user" -d postgres \
+    "$PSQL" -X -h localhost -p "$PG_PORT" -U "$admin_user" -d postgres \
         -v ON_ERROR_STOP=1 \
         -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${role_name}') THEN EXECUTE format('CREATE ROLE %I WITH LOGIN SUPERUSER', '${role_name}'); END IF; END \$\$;" >/dev/null
 }
@@ -150,17 +152,17 @@ ensure_pg_durable_extension() {
 
     # Create the target database if it doesn't exist (e.g. contrib_regression for pg_regress)
     if [ "$db" != "postgres" ]; then
-        "$PSQL" -h localhost -p "$PG_PORT" -U postgres -d postgres -Atqc \
+        "$PSQL" -X -h localhost -p "$PG_PORT" -U postgres -d postgres -Atqc \
             "SELECT 1 FROM pg_database WHERE datname = '${db}'" 2>/dev/null | grep -q 1 || \
-        "$PSQL" -h localhost -p "$PG_PORT" -U postgres -d postgres -v ON_ERROR_STOP=1 \
+        "$PSQL" -X -h localhost -p "$PG_PORT" -U postgres -d postgres -v ON_ERROR_STOP=1 \
             -c "CREATE DATABASE \"${db}\";" >/dev/null
     fi
 
-    "$PSQL" -h localhost -p "$PG_PORT" -U postgres -d "$db" -v ON_ERROR_STOP=1 \
+    "$PSQL" -X -h localhost -p "$PG_PORT" -U postgres -d "$db" -v ON_ERROR_STOP=1 \
         -c "CREATE EXTENSION IF NOT EXISTS pg_durable;" >/dev/null
 }
 
 pg_durable_version() {
     local db="${PGDATABASE:-postgres}"
-    "$PSQL" -h localhost -p "$PG_PORT" -U postgres -d "$db" -Atqc "SELECT df.version();"
+    "$PSQL" -X -h localhost -p "$PG_PORT" -U postgres -d "$db" -Atqc "SELECT df.version();"
 }

--- a/src/bin/pgrx_embed.rs
+++ b/src/bin/pgrx_embed.rs
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the PostgreSQL License.
-
-::pgrx::pgrx_embed!();


### PR DESCRIPTION
This PR upgrades the project to pgrx v0.18.1 in 7e7d0c2d443f376788a2bb812c280fd619fb2866 and then fixes some issues running the test suite on macOS in e275752eb328f0c42761eb310300c14f37b66cfa.

As evidenced by the commit attributions, this was 100% written by Claude.  

Nonetheless, pgrx v0.18.1 is a **significant** upgrade over 0.16.1 as it completely eliminates a full round of compilation on every build, which ought to make CI and your developers of this project a lot happier.

I'm happy to participate in the review of this and cleanup anything y'all think is necessary.

The test suite passed locally for me on macOS (with e275752eb328f0c42761eb310300c14f37b66cfa) for pg17 and pg18.  I did not run the Docker e2e tests as I do not (and will not ever) have Docker installed.