### PR TITLE
docs: fix PR 219 follow-up findings

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -193,7 +193,8 @@ df.sql('SELECT 1') ~> df.sql('SELECT 2')
 | `df.wait_for_signal(name)` | Wait for external signal | `df.wait_for_signal('approval')` |
 | `df.wait_for_signal(name, timeout)` | Wait with timeout (seconds) | `df.wait_for_signal('approval', 3600)` |
 | `df.signal(id, name, data)` | Send signal to instance | `df.signal('a1b2', 'go', '{}')` |
-| `df.wait_for_completion(id, timeout)` | Block until instance completes (default 30s timeout) | `df.wait_for_completion('a1b2c3d4', 60)` |
+| `df.wait_for_completion(id)` | Block until instance completes (default 30s timeout) | `df.wait_for_completion('a1b2c3d4')` |
+| `df.wait_for_completion(id, timeout)` | Block until instance completes with explicit timeout in seconds | `df.wait_for_completion('a1b2c3d4', 60)` |
 
 ### Operators
 
@@ -317,9 +318,10 @@ SELECT df.result('a1b2c3d4')::jsonb->'rows'->0->>'answer';
 ```
 
 **Special cases:**
-- A query returning no rows produces: `{"rows": [], "row_count": 0}`
-- `df.sleep()` and `df.wait_for_schedule()` produce no result (NULL)
-- `df.http()` results contain `status`, `body`, and `headers` fields inside the row
+- A SQL query returning no rows produces: `{"rows": [], "row_count": 0}`
+- `df.sleep()` returns a top-level JSON object like `{"slept": true, "seconds": 60}`
+- `df.wait_for_schedule()` returns a top-level JSON object: `{"scheduled": true}`
+- `df.http()` returns a top-level JSON object with `status`, `body`, `headers`, `ok`, and `duration_ms` fields
 - `df.break('value')` stores the literal value as the loop result (not wrapped in `rows`)
 
 
@@ -1998,7 +2000,7 @@ CREATE EXTENSION pg_durable;
 
 **Symptom**: A superuser calling `df.start()` gets an error like:
 ```
-Superuser-submitted instances are disabled. Set pg_durable.enable_superuser_instances = true to allow.
+pg_durable: superuser instances are disabled. current_user "postgres" is a superuser, but pg_durable.enable_superuser_instances is off. Set pg_durable.enable_superuser_instances = on to allow this.
 ```
 
 **Cause**: By default, `pg_durable.enable_superuser_instances` is `false`. This is a security safeguard — superuser-submitted workflows bypass RLS and run with full privileges, which could be dangerous in shared environments.
@@ -2006,20 +2008,20 @@ Superuser-submitted instances are disabled. Set pg_durable.enable_superuser_inst
 **Solution**: If you intentionally want to submit workflows as a superuser:
 1. Add to `postgresql.conf`:
    ```ini
-   pg_durable.enable_superuser_instances = true
+   pg_durable.enable_superuser_instances = on
    ```
 2. Restart PostgreSQL (this is a Postmaster-context GUC)
 
 Alternatively, create a dedicated non-superuser role for workflow submission and grant it the necessary privileges.
 
-### "current_user lacks LOGIN attribute" Error
+### "current_user does not have LOGIN privilege" Error
 
 **Symptom**: Calling `df.start()` returns an error:
 ```
-current_user 'role_name' does not have the LOGIN attribute
+current_user "role_name" does not have LOGIN privilege. The background worker must connect as this role to execute SQL. Grant LOGIN to this role or call df.start() as a role with LOGIN.
 ```
 
-**Cause**: The background worker must connect to PostgreSQL as the role that submitted the workflow. Roles without the `LOGIN` attribute cannot be authenticated, so `df.start()` rejects the submission.
+**Cause**: The background worker must connect to PostgreSQL as the role that submitted the workflow. Roles without the `LOGIN` privilege cannot be authenticated, so `df.start()` rejects the submission.
 
 This commonly happens when you use `SET ROLE` to switch to a group role (typically `NOLOGIN`) before calling `df.start()`.
 

--- a/docs/rls.md
+++ b/docs/rls.md
@@ -95,7 +95,7 @@ CREATE POLICY instances_user_isolation ON df.instances
 
 This is the correct choice because:
 - `current_user` in an SPI call from a SECURITY INVOKER function = the calling user
-- `submitted_by` is set by trusted extension code via `GetOuterUserId()` — users cannot forge it
+- `submitted_by` is set by trusted extension code via `GetUserId()` — users cannot forge it
 - `REGROLE` comparison handles OID-based identity correctly
 
 **Decision**: Use `submitted_by = current_user::regrole`. ✅ No ambiguity.
@@ -111,7 +111,7 @@ CREATE POLICY instances_user_isolation ON df.instances
     WITH CHECK (submitted_by = current_user::regrole);
 ```
 
-This ensures a user can only INSERT rows where `submitted_by` matches their own identity. Since `df.start()` sets `submitted_by` via `GetOuterUserId()`, this is always true for legitimate calls. It also prevents a user from manually inserting a row with a forged `submitted_by`.
+This ensures a user can only INSERT rows where `submitted_by` matches their own identity. Since `df.start()` sets `submitted_by` via `GetUserId()`, this is always true for legitimate calls. It also prevents a user from manually inserting a row with a forged `submitted_by`.
 
 **Decision**: Single FOR ALL policy with both USING and WITH CHECK. ✅ No ambiguity.
 

--- a/docs/security-review/ThreatModelDFD.md
+++ b/docs/security-review/ThreatModelDFD.md
@@ -113,7 +113,7 @@ sequenceDiagram
     participant HTTP as External HTTP
 
     User->>Backend: SELECT df.start(df.sql('...'))
-    Note over Backend: Captures current_user (outer_user_oid);<br/>validates LOGIN attribute
+    Note over Backend: Captures current_user via GetUserId();<br/>validates LOGIN attribute
     Backend->>Tables: INSERT nodes + instance<br/>(SPI as calling user, RLS)
     Backend->>Duroxide: Enqueue orchestration<br/>(via cached duroxide client)
     Backend-->>User: Returns instance_id
@@ -159,10 +159,10 @@ EE-USER ──[PostgreSQL wire protocol]──> P-BACKEND
 |---|---|---|---|
 | **S** Spoofing | Attacker impersonates legitimate user | PostgreSQL pg_hba.conf authentication (password, cert, GSSAPI) | ✅ Mitigated |
 | **T** Tampering | Man-in-middle modifies SQL commands | TLS encryption (if configured in pg_hba.conf); not enforced by default | ⚠️ Partial |
-| **R** Repudiation | User denies submitting a durable function | submitted_by captured at df.start() via GetOuterUserId(); current_user must have LOGIN | ✅ Mitigated |
+| **R** Repudiation | User denies submitting a durable function | submitted_by captured at df.start() via GetUserId(); current_user must have LOGIN | ✅ Mitigated |
 | **I** Information Disclosure | Eavesdropping on wire protocol | TLS encryption (if configured); plaintext by default on localhost | ⚠️ Partial |
 | **D** Denial of Service | Flooding with df.start() calls | No rate limiting implemented | ⛔ NOT IMPLEMENTED |
-| **E** Elevation of Privilege | User escalates via SECURITY DEFINER | GetOuterUserId() captures *caller* not *definer*; tested in E2E | ✅ Mitigated |
+| **E** Elevation of Privilege | User exposes a SECURITY DEFINER wrapper around df.start() | GetUserId() captures current_user; SECURITY DEFINER submissions run as the definer, so wrapper authors must restrict EXECUTE appropriately | ⚠️ Documented |
 
 ### DF-2: Graph Persistence (SPI)
 
@@ -310,7 +310,7 @@ P-WORKER ──[sqlx per-user connection (TCP localhost)]──> DS-TABLES
 
 | STRIDE | Threat | Mitigation | Status |
 |---|---|---|---|
-| **S** Spoofing | Worker impersonates wrong user | submitted_by captured via C API (GetOuterUserId); must have LOGIN attribute; cannot be spoofed | ✅ Mitigated |
+| **S** Spoofing | Worker impersonates wrong user | submitted_by captured via C API (GetUserId); must have LOGIN attribute; cannot be spoofed | ✅ Mitigated |
 | **T** Tampering | User SQL modifies data beyond their privileges | Connection authenticated directly as submitted_by; standard PostgreSQL RBAC applies | ✅ Mitigated |
 | **E** Elevation via RESET ROLE | User SQL contains `RESET ROLE` to escape to worker | RESET ROLE reverts to submitted_by (user's own identity), not worker role; connection is separate | ✅ Mitigated |
 | **E** Elevation via SET ROLE | User attempts `SET ROLE postgres` | SET ROLE requires role membership (checked against submitted_by); standard PostgreSQL RBAC | ✅ Mitigated |
@@ -414,7 +414,7 @@ graph LR
         A["pg_hba.conf<br/>Authentication"] --> B["PostgreSQL Backend<br/>session_user established"]
         B --> C["Optional: SET ROLE<br/>current_user changes"]
         C --> D["df.start() called"]
-        D --> F["GetOuterUserId()<br/>→ submitted_by"]
+        D --> F["GetUserId()<br/>→ submitted_by"]
         D --> V["Validates LOGIN attribute"]
         F --> G["Stored in df.instances<br/>& df.nodes"]
     end

--- a/docs/security-review/security-review.md
+++ b/docs/security-review/security-review.md
@@ -29,7 +29,7 @@ The extension demonstrates strong security design for its core threat model:
 **Strengths:**
 - Privilege isolation via per-user sqlx connections is well-designed and correctly implemented
 - RLS enforcement on all user-facing tables with appropriate policies
-- Identity capture via PostgreSQL C API (GetSessionUserId/GetOuterUserId) is unforgeable from SQL
+- Identity capture via PostgreSQL C API (GetUserId) records current_user at df.start() time
 - Comprehensive SSRF protection with IP blocklist, DNS rebinding prevention, and redirect disabling 
 - SQL injection mitigated in critical paths (df.status, df.result use parameterized SPI)
 - Thorough security documentation with explicit threat model
@@ -100,9 +100,9 @@ The extension demonstrates strong security design for its core threat model:
 | ID | Finding | Severity | Status |
 |---|---|---|---|
 | S-1 | PostgreSQL authentication delegates to pg_hba.conf — extension does not add its own auth layer | Info | ✅ Appropriate for trusted extension model |
-| S-2 | User identity captured via unforgeable C API call (GetOuterUserId); current_user must have LOGIN attribute | Info | ✅ Well-implemented |
+| S-2 | User identity captured via unforgeable C API call (GetUserId); current_user must have LOGIN attribute | Info | ✅ Well-implemented |
 | S-3 | Per-user SQL connections authenticated directly as submitted_by via trust auth on localhost | Medium | ✅ Mitigated — pg_hba.conf trust is intentional and appropriate for same-host background worker |
-| S-4 | SECURITY DEFINER functions: GetOuterUserId correctly captures caller, not definer | Info | ✅ Tested (E2E test 27_user_isolation) |
+| S-4 | SECURITY DEFINER functions: GetUserId captures current_user, so SECURITY DEFINER submissions run as the definer | Info | ✅ Tested (E2E test 27_user_isolation) |
 
 ### 3.2 Tampering
 
@@ -159,7 +159,7 @@ The extension demonstrates strong security design for its core threat model:
 |---|---|---|---|
 | E-1 | **RESET ROLE cannot escalate**: Per-user connections authenticated directly as submitted_by; RESET ROLE returns to user's own identity | Info | ✅ Well-designed |
 | E-2 | **SET ROLE membership-checked**: Standard PostgreSQL RBAC applies on per-user connections | Info | ✅ Correct |
-| E-3 | **SECURITY DEFINER correctly handled**: GetOuterUserId captures caller, not definer. E2E tested. | Info | ✅ Tested |
+| E-3 | **SECURITY DEFINER behavior documented**: GetUserId captures current_user, so SECURITY DEFINER submissions run as the definer. | Info | ✅ Tested |
 | E-4 | **EXECUTE on all df.* functions granted to PUBLIC**: Any database user can use the extension. Consider defaulting to a specific role. | Medium | ⚠️ Recommend REVOKE from PUBLIC, grant to specific role |
 | E-5 | **df.http() EXECUTE not restricted by default**: Per T9 in threat model, HTTP access should default to restricted | High | ⛔ NOT IMPLEMENTED |
 | E-6 | **Worker superuser validates at startup**: lib.rs checks if worker role is superuser — warns if not, but does not prevent startup | Medium | ⚠️ Consider hard-fail |

--- a/docs/security-review/threat-model.dfd-lite.yaml
+++ b/docs/security-review/threat-model.dfd-lite.yaml
@@ -105,8 +105,7 @@ diagrams:
         description: >
           Core extension tables storing function graph definitions (df.nodes)
           and instance metadata (df.instances). Protected by RLS policies
-          (submitted_by = current_user::regrole). Contains user identity
-          columns (submitted_by, login_role) for privilege isolation.
+          (submitted_by = current_user::regrole). Contains the submitted_by column for privilege isolation.
         properties:
           Store Type: "SQL Relational Database"
           Stores Credentials: "No"
@@ -210,8 +209,7 @@ diagrams:
         to: "DS-TABLES"
         description: >
           load_function_graph activity reads df.instances and df.nodes
-          to reconstruct the function graph for execution. Reads submitted_by
-          and login_role for privilege isolation.
+          to reconstruct the function graph for execution. Reads submitted_by for privilege isolation.
         properties:
           Source Authenticated: "Yes"
           Provides Integrity: "Yes"
@@ -233,7 +231,7 @@ diagrams:
         to: "DS-TABLES"
         description: >
           execute_sql activity creates a per-user sqlx connection (authenticated
-          as login_role, SET ROLE to submitted_by) and executes user-supplied
+          directly as submitted_by) and executes user-supplied
           SQL queries. Results returned as JSON to the orchestration.
         properties:
           Source Authenticated: "Yes"

--- a/docs/security-review/workbook-data.md
+++ b/docs/security-review/workbook-data.md
@@ -14,7 +14,7 @@ pg_durable does not use token-based authentication. All identity is PostgreSQL r
 
 | Identity | Source | Capture Method | Stored In | Used For |
 |---|---|---|---|---|
-| current_user (submitted_by) | PostgreSQL current_user at df.start() time | `GetOuterUserId()` C API | df.instances.submitted_by, df.nodes.submitted_by | Direct connection authentication for per-user SQL execution; RLS policy column |
+| current_user (submitted_by) | PostgreSQL current_user at df.start() time | `GetUserId()` C API | df.instances.submitted_by, df.nodes.submitted_by | Direct connection authentication for per-user SQL execution; RLS policy column |
 | worker_role | GUC `pg_durable.worker_role` | Configuration (default: "postgres") | postgresql.conf | Background worker sqlx pool authentication |
 
 ### Least Privilege Assessment


### PR DESCRIPTION
## Summary
- document the default `df.wait_for_completion(id)` form and correct non-SQL result shapes
- align troubleshooting snippets with actual `df.start()` error text
- update security docs to use the implemented `GetUserId()` / `current_user` identity model

## Validation
- git diff --check
- VS Code diagnostics for edited docs