### PR TITLE
ci: add Dependabot for weekly cargo updates and remove nightly CI run

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Dependabot configuration for weekly dependency updates.
+#
+# Dependabot opens dependency PRs through its own permission system, which is
+# NOT governed by the "Allow GitHub Actions to create and approve pull requests"
+# org/repo setting. This lets it raise update PRs even where that setting is
+# disabled by policy.
+#
+# versioning-strategy: lockfile-only keeps Cargo.toml requirements untouched and
+# only refreshes Cargo.lock — equivalent to `cargo update`. This preserves the
+# exact `=` pins on pgrx, duroxide, and duroxide-pg (and the duroxide /
+# duroxide-pg compatible-pair invariant) while still picking up patched
+# transitive and range-versioned dependencies.
+#
+# The single "cargo" group collapses all updates into one weekly PR instead of
+# one PR per crate. That PR is validated by the normal CI workflow.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+      timezone: "Etc/UTC"
+    versioning-strategy: lockfile-only
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      cargo:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, synchronize, reopened, labeled]
   push:
     branches: [main]  # Runs on main after merge
-  schedule:
-    - cron: '0 2 * * *'  # Nightly at 2 AM UTC
   workflow_dispatch:
     inputs:
       pg_version:


### PR DESCRIPTION
## What

Closes #22.

- **Add `.github/dependabot.yml`** — native Dependabot config that opens a **single grouped** cargo update PR **weekly** (Monday 03:00 UTC), labeled `dependencies`.
- **Remove the nightly `schedule:` trigger from `.github/workflows/ci.yml`** — CI now runs on PRs, pushes to `main`, and manual dispatch only.

## Why Dependabot instead of a custom workflow

The first revision of this PR used a custom workflow with `peter-evans/create-pull-request`. As @pinodeca pointed out in review, that approach depends on the **"Allow GitHub Actions to create and approve pull requests"** repo/org setting, which can't be enabled here due to org policy.

Dependabot raises PRs through a **separate permission system that is not governed by that setting**, so it works regardless. This is "Option 1" from the review discussion. The custom `deps-update.yml` workflow has been removed entirely.

## Key config choices

- `versioning-strategy: lockfile-only` — updates **only `Cargo.lock`**, never the requirements in `Cargo.toml`. This preserves the exact `=` pins on `pgrx`, `duroxide`, and `duroxide-pg` (and the duroxide/duroxide-pg compatible-pair invariant) while still pulling in patched transitive and range-versioned dependencies. Equivalent to `cargo update`.
- `groups: { cargo: { patterns: ["*"] } }` — collapses everything into **one weekly PR** instead of one-per-crate.
- `commit-message: { prefix: chore, include: scope }` — produces `chore(deps): ...` commit titles, matching the repo's conventional-commit style.
- The generated PR is validated by the existing CI (clippy, unit, E2E, upgrade tests).

## Notes

- The independent nightly build in `docker.yml` is intentionally left untouched.
- No `CHANGELOG.md` entry — this is CI tooling, not a user-facing/release change.
