### PR TITLE
refactor: wire try_from_json() into production and clean up test memory

### DIFF
--- a/src/explain.rs
+++ b/src/explain.rs
@@ -197,7 +197,7 @@ fn explain_expression(expr: &str) -> String {
     use crate::types::Durofut;
 
     // First try to parse as Durofut JSON
-    if let Ok(root) = serde_json::from_str::<Durofut>(expr) {
+    if let Ok(root) = Durofut::try_from_json(expr) {
         // Build in-memory node map from nested structure with generated IDs
         let mut nodes = HashMap::new();
         let mut id_counter = 0;
@@ -236,9 +236,9 @@ fn explain_expression(expr: &str) -> String {
     };
 
     // Parse the resulting JSON
-    let root = match serde_json::from_str::<Durofut>(&root_json) {
+    let root = match Durofut::try_from_json(&root_json) {
         Ok(d) => d,
-        Err(e) => return format!("Failed to parse Durofut JSON: {e:?}"),
+        Err(e) => return format!("Failed to parse Durofut JSON: {e}"),
     };
 
     // Build in-memory node map from nested structure with generated IDs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2672,24 +2672,21 @@ mod tests {
 
         // Build a shallow-but-wide graph using a JOIN node with many extra_nodes.
         // This exceeds MAX_GRAPH_NODES without exceeding MAX_GRAPH_DEPTH (stays at depth 1).
+        // Serialize the template node once and clone via vec![...; N] for predictable memory.
         let sql_node = Durofut {
             node_type: "SQL".to_string(),
             query: Some("SELECT 1".to_string()),
             ..Default::default()
         };
 
-        // Construct extra_nodes JSON array with enough entries to exceed the limit.
-        // The JOIN node itself + left + right + extra_nodes = 3 + N nodes.
-        let extra_count = MAX_GRAPH_NODES; // guarantees we exceed the limit
-        let extra_nodes: Vec<serde_json::Value> = (0..extra_count)
-            .map(|_| serde_json::to_value(&sql_node).unwrap())
-            .collect();
+        let sql_value = serde_json::to_value(&sql_node).unwrap();
+        let extra_nodes: Vec<serde_json::Value> = vec![sql_value; MAX_GRAPH_NODES];
         let config = serde_json::json!({ "extra_nodes": extra_nodes });
 
         let join_node = Durofut {
             node_type: "JOIN".to_string(),
             left_node: Some(Box::new(sql_node.clone())),
-            right_node: Some(Box::new(sql_node.clone())),
+            right_node: Some(Box::new(sql_node)),
             query: Some(config.to_string()),
             ..Default::default()
         };

--- a/src/types.rs
+++ b/src/types.rs
@@ -1624,29 +1624,32 @@ mod tests {
         assert!(result.is_ok(), "should accept graph within depth limit");
     }
 
-    #[test]
-    fn test_validate_recursive_node_count_limit() {
-        // Build a shallow-but-wide graph: a JOIN with many extra_nodes.
-        // This stays at depth 1 but exceeds MAX_GRAPH_NODES.
+    /// Build a wide JOIN node with `n` extra children for testing node-count limits.
+    /// Serializes the template node once and clones, keeping memory predictable.
+    fn build_wide_join(n: usize) -> Durofut {
         let sql_node = Durofut {
             node_type: "SQL".to_string(),
             query: Some("SELECT 1".to_string()),
             ..Default::default()
         };
-
-        let extra_count = MAX_GRAPH_NODES; // exceeds limit when added to root+left+right
-        let extra_nodes: Vec<serde_json::Value> = (0..extra_count)
-            .map(|_| serde_json::to_value(&sql_node).unwrap())
-            .collect();
+        let sql_value = serde_json::to_value(&sql_node).unwrap();
+        let extra_nodes: Vec<serde_json::Value> = vec![sql_value; n];
         let config = serde_json::json!({ "extra_nodes": extra_nodes });
 
-        let join_node = Durofut {
+        Durofut {
             node_type: "JOIN".to_string(),
             left_node: Some(Box::new(sql_node.clone())),
-            right_node: Some(Box::new(sql_node.clone())),
+            right_node: Some(Box::new(sql_node)),
             query: Some(config.to_string()),
             ..Default::default()
-        };
+        }
+    }
+
+    #[test]
+    fn test_validate_recursive_node_count_limit() {
+        // Build a shallow-but-wide graph: a JOIN with many extra_nodes.
+        // This stays at depth 1 but exceeds MAX_GRAPH_NODES.
+        let join_node = build_wide_join(MAX_GRAPH_NODES);
 
         let result = join_node.validate_recursive();
         assert!(result.is_err(), "should reject graph exceeding node count");
@@ -1659,25 +1662,7 @@ mod tests {
     #[test]
     fn test_validate_recursive_node_count_within_limit() {
         // A graph with a moderate number of nodes should pass
-        let sql_node = Durofut {
-            node_type: "SQL".to_string(),
-            query: Some("SELECT 1".to_string()),
-            ..Default::default()
-        };
-
-        let extra_count = 50;
-        let extra_nodes: Vec<serde_json::Value> = (0..extra_count)
-            .map(|_| serde_json::to_value(&sql_node).unwrap())
-            .collect();
-        let config = serde_json::json!({ "extra_nodes": extra_nodes });
-
-        let join_node = Durofut {
-            node_type: "JOIN".to_string(),
-            left_node: Some(Box::new(sql_node.clone())),
-            right_node: Some(Box::new(sql_node.clone())),
-            query: Some(config.to_string()),
-            ..Default::default()
-        };
+        let join_node = build_wide_join(50);
 
         let result = join_node.validate_recursive();
         assert!(


### PR DESCRIPTION
Follow-up to #220 addressing review feedback from @pinodeca:

1. **Wire `try_from_json()` into a production caller** — replaced direct `serde_json::from_str::<Durofut>` calls in `explain.rs` with `Durofut::try_from_json()`, so the fallible deserializer is no longer an unused parallel API.

2. **Test memory cleanup** — extracted a `build_wide_join(n)` helper that serializes the template node once and clones via `vec![value; n]` instead of calling `to_value()` per-iteration 10k times. Both node-count tests in `types.rs` and the `pg_test` in `lib.rs` now use this pattern for predictable memory.

Net: -18 lines, no behavioral changes.