### PR TITLE
fix(deps): bump reqwest requirement to 0.13 to match lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,7 +3064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,14 @@ bigdecimal = "0.4"
 cron = "0.13"
 chrono = "0.4"
 
-# For HTTP requests (df.http)
-reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
+# For HTTP requests (df.http). We set default-features = false and select
+# native-tls explicitly: in reqwest 0.13 the `default-tls` feature resolves to
+# rustls, NOT native-tls, so enabling defaults would silently switch our TLS
+# backend. native-tls keeps the openssl-backed connector (hyper-tls +
+# tokio-native-tls). duroxide-pg also selects native-tls on the same resolved
+# reqwest version; Cargo feature unification merges them, so the whole graph
+# stays on native-tls with no rustls/ring/aws-lc in the tree.
+reqwest = { version = "0.13", default-features = false, features = ["json", "native-tls"] }
 
 # For duroxide tracing integration
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
## What

Bumps the `reqwest` requirement in `Cargo.toml` from `"0.12"` to `"0.13"` so the manifest matches `Cargo.lock`.

## Why

PR #236 (the first Dependabot grouped `cargo update`) moved `Cargo.lock`'s `reqwest` to **0.13.3** — deduplicating against `duroxide-pg`, which already requires 0.13.3, via Cargo feature unification — but left `Cargo.toml` requiring `"0.12"` (`>=0.12.0, <0.13.0`). That makes the manifest and lockfile **inconsistent**, which breaks `--locked` builds (the package-build CI jobs).

`versioning-strategy: lockfile-only` is supposed to avoid manifest-violating bumps, but a *grouped* lockfile-only update can still dedup a transitively-required major version onto a directly-pinned crate. This realigns the manifest deliberately.

## Changes

- `Cargo.toml`: `reqwest = "0.12"` → `"0.13"`. Kept `default-features = false` + explicit `native-tls`, with a comment explaining the hazard: **in reqwest 0.13 the `default-tls` feature resolves to rustls, not native-tls**, so relying on defaults would silently switch the TLS backend.
- `Cargo.lock`: pinned to the already-present 0.13.3 via a narrow `cargo update -p reqwest --precise 0.13.3` (plus one incidental `getrandom` re-dedup under `tempfile`).

## Verification

- `cargo build --features pg17` — succeeds.
- `cargo fmt -p pg_durable -- --check` — clean.
- `cargo test --lib ssrf` — **36/36 pass**, including `resolver_tests` that exercise the custom `reqwest::dns::Resolve` impl in `src/ssrf.rs` against the 0.13 DNS API (the main breaking-change surface).
- `cargo tree` confirms the graph stays on **native-tls / hyper-tls / tokio-native-tls** with no `rustls` / `ring` / `aws-lc` backend.

## Notes

No `Cargo.toml` requirements other than reqwest change. Going forward, with the requirement at `"0.13"`, Dependabot will only propose lockfile-safe 0.13.x patch updates.