### PR TITLE
Simplify df.grant_usage/df.revoke_usage privilege helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Pre-1.0 note: while `pg_durable` is in major version `0`, minor releases may inc
 
 ## [0.2.4] - Unreleased
 
+### Changed
+
+- **`df.grant_usage()` / `df.revoke_usage()`:** dropped the explicit per-function `EXECUTE` allowlist. Schema `USAGE` on `df` is the real access gate for ordinary `df.*` functions, so the helpers now grant/revoke schema `USAGE`, the table privileges, and `EXECUTE` only on the sensitive functions (`df.http`, `df.grant_usage`, `df.revoke_usage`). Function signatures are unchanged and existing privileges are unaffected (#242).
+
 ## [0.2.3] - 2026-06-17
 
 Provider-line note: v0.2.3 stays in the `duroxide-pg` provider compatibility line started in v0.2.2, so the upgrade source is v0.2.2 (`sql/pg_durable--0.2.2--0.2.3.sql`).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1637,6 +1637,8 @@ SELECT df.grant_usage('admin_role', include_http => true, with_grant => true);
 
 This function is purely additive — it never issues REVOKE. To downgrade a role's privileges (e.g., remove HTTP access), call `df.revoke_usage()` first, then `df.grant_usage()` with the desired options.
 
+> **Granting to `PUBLIC`:** `df.grant_usage('public')` is allowed and grants `df` access to **every role in the cluster**, defeating the deny-by-default posture that a fresh install sets up. This is a deliberate, visible action (the same as any `GRANT ... TO PUBLIC`), not a mistake the helper blocks — use it only when you intend cluster-wide access. Naming a role that doesn't exist fails naturally on the first `GRANT`.
+
 **Parameters:**
 
 | Parameter | Default | Description |
@@ -1648,49 +1650,20 @@ This function is purely additive — it never issues REVOKE. To downgrade a role
 <details>
 <summary>Equivalent manual grants (for reference)</summary>
 
+The ordinary DSL functions (`df.sql`, `df.start`, `df.status`, etc.) keep PostgreSQL's default `PUBLIC EXECUTE`, so granting `USAGE ON SCHEMA df` is the single access gate that makes them callable — no per-function `GRANT EXECUTE` is required. Only the **sensitive** functions (`df.http`, `df.grant_usage`, `df.revoke_usage`) have `PUBLIC EXECUTE` revoked at install time and must be granted explicitly.
+
 ```sql
+-- Access gate: schema USAGE makes every ordinary df.* function callable
 GRANT USAGE ON SCHEMA df TO app_role;
--- Standard functions (df.http, df.grant_usage, df.revoke_usage are NOT included)
-GRANT EXECUTE ON FUNCTION df.sql(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.seq(text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.as(text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.sleep(bigint) TO app_role;
-GRANT EXECUTE ON FUNCTION df.wait_for_schedule(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.loop(text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.break(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.if(text, text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.if_rows(text, text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.join(text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.join3(text, text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.race(text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.wait_for_signal(text, integer) TO app_role;
-GRANT EXECUTE ON FUNCTION df.signal(text, text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.start(text, text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.setvar(text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.getvar(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.unsetvar(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.clearvars() TO app_role;
-GRANT EXECUTE ON FUNCTION df.status(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.result(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.cancel(text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.wait_for_completion(text, integer) TO app_role;
-GRANT EXECUTE ON FUNCTION df.run(text) TO app_role;  -- NOTE: stub, not yet implemented
-GRANT EXECUTE ON FUNCTION df.list_instances(text, integer) TO app_role;
-GRANT EXECUTE ON FUNCTION df.instance_info(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.instance_nodes(text, integer) TO app_role;
-GRANT EXECUTE ON FUNCTION df.instance_executions(text, integer) TO app_role;
-GRANT EXECUTE ON FUNCTION df.metrics() TO app_role;
-GRANT EXECUTE ON FUNCTION df.as_op(text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.if_then_op(text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.if_else_op(text, text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.ensure_durofut(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.loop_prefix_op(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.version() TO app_role;
-GRANT EXECUTE ON FUNCTION df.debug_connection() TO app_role;
-GRANT EXECUTE ON FUNCTION df.explain(text) TO app_role;
-GRANT EXECUTE ON FUNCTION df.target_database() TO app_role;
+
 -- Optional: HTTP access (include_http => true)
 -- GRANT EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) TO app_role;
+
+-- Optional: delegated administration (with_grant => true)
+-- GRANT EXECUTE ON FUNCTION df.grant_usage(text, boolean, boolean) TO app_role;
+-- GRANT EXECUTE ON FUNCTION df.revoke_usage(text) TO app_role;
+
+-- Table privileges
 GRANT SELECT ON df.instances TO app_role;
 GRANT UPDATE (status, updated_at) ON df.instances TO app_role;
 GRANT SELECT ON df.nodes TO app_role;
@@ -1698,6 +1671,8 @@ GRANT INSERT (id, label, root_node, submitted_by, database) ON df.instances TO a
 GRANT INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database) ON df.nodes TO app_role;
 GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO app_role;
 ```
+
+> With `with_grant => true`, every `GRANT` above is issued `WITH GRANT OPTION` so the role can re-delegate access.
 
 </details>
 
@@ -1746,9 +1721,11 @@ To remove a role's access to pg_durable:
 SELECT df.revoke_usage('app_role');
 ```
 
-This revokes all privileges previously granted by `df.grant_usage()`. As a safety measure, `df.revoke_usage()` prevents revoking privileges from a role the caller is a member of (including the caller's own role).
+This revokes all privileges previously granted by `df.grant_usage()`. It removes schema `USAGE`, EXECUTE on the sensitive functions (`df.http`, `df.grant_usage`, `df.revoke_usage`), and the table privileges — the mirror image of what `df.grant_usage()` grants.
 
-For non-superusers, `df.revoke_usage()` is still subject to PostgreSQL's normal grantor rules because it is a SECURITY INVOKER helper. In practice, that means a delegated admin can only revoke the privileges that delegated admin granted; removing grants made by another role requires the original grantor or a superuser.
+There is no explicit self-revoke guard, and none is needed: PostgreSQL's `REVOKE` only removes grants made by the current role. A non-superuser therefore cannot revoke privileges another role (e.g. a superuser) granted to it, so calling `df.revoke_usage()` on your own role is harmless — it cannot lock you out of grants you didn't issue yourself.
+
+For non-superusers, `df.revoke_usage()` is subject to PostgreSQL's normal grantor rules because it is a SECURITY INVOKER helper. In practice, that means a delegated admin can only revoke the privileges that delegated admin granted; removing grants made by another role requires the original grantor or a superuser.
 
 ### Hardening Upgraded Installs
 

--- a/docs/upgrade-testing.md
+++ b/docs/upgrade-testing.md
@@ -203,6 +203,17 @@ gate, so they never need to be added to the exclude list.
 Each schema-changing PR should add a section here documenting what changed,
 what the upgrade script handles, and any backward compatibility considerations.
 
+### v0.2.3 → v0.2.4
+
+#### Simplify `df.grant_usage()` — drop the explicit function allowlist
+- **DDL change (df schema):** `df.grant_usage()` no longer loops over a hard-coded `func_sigs` array issuing `GRANT EXECUTE` per function. Fresh installs (`src/lib.rs`) and the upgrade script (`sql/pg_durable--0.2.3--0.2.4.sql`) both `CREATE OR REPLACE` the function with a body that grants `USAGE ON SCHEMA df` plus the table privileges, and conditionally grants `df.http()` / the admin helpers. The signature `df.grant_usage(text, boolean, boolean)` is unchanged.
+- **DDL change (df schema):** `df.revoke_usage()` is made symmetric with the new `grant_usage()`. It no longer loops over every `df.*` function in `pg_proc` issuing `REVOKE EXECUTE` (which, post-simplification, only produced "no privileges could be revoked" warnings since ordinary functions are never granted per-function EXECUTE). The new body revokes only what `grant_usage()` grants: schema `USAGE`, EXECUTE on the sensitive functions (`df.http`, `df.grant_usage`, `df.revoke_usage`), and the table privileges. The signature `df.revoke_usage(text)` is unchanged.
+- **Rationale:** The ordinary `df.*` functions retain PostgreSQL's default PUBLIC `EXECUTE`, so schema `USAGE` is the real access gate; the per-function grants/revokes were redundant. The sensitive functions have PUBLIC `EXECUTE` revoked at install time and were never in the allowlist, so their protection is unchanged.
+- **Behavioral note:** A newly added `df.*` function is now callable by any role with schema `USAGE` by default. To keep a future function private, `REVOKE EXECUTE ... FROM PUBLIC` at install time and grant it explicitly in `df.grant_usage()`.
+- **Legacy cleanup caveat:** A role that was granted under the *old* `grant_usage()` (explicit per-function EXECUTE) and is later revoked under the new `revoke_usage()` may retain inert EXECUTE entries on ordinary functions. These are harmless — revoking schema `USAGE` fully locks the role out — and clear on the next drop/regrant cycle.
+- **Scenario A considerations:** Signatures are identical on the fresh-install and upgrade paths (only the bodies differ), so the function-signature equivalence contract passes.
+- **Scenario B1/B2 considerations:** No schema/data migration and no new objects. The replaced bodies work against the existing schema and change no privileges already granted.
+
 ### v0.2.2 → v0.2.3
 
 #### Rename duroxide provider schema to `_duroxide` for fresh installs

--- a/scripts/run-pgspot.sh
+++ b/scripts/run-pgspot.sh
@@ -36,6 +36,14 @@ PGSPOT_ALLOW=(
   # example, `df.sql(...) ~> df.sql(...)`) so users do not need df in search_path.
   # pgspot reports the generated CREATE OPERATOR name as an unqualified object.
   '^PS017: Unqualified object reference: ~> at line [0-9]+$'
+  # Upgrade scripts CREATE OR REPLACE df.grant_usage()/df.revoke_usage() to
+  # migrate pre-existing installs. pgspot flags PS002 because a standalone
+  # upgrade script has no `CREATE SCHEMA df` to prove df is extension-owned (the
+  # install SQL does, so it is not flagged there). PostgreSQL 14.5+ blocks a
+  # CREATE OR REPLACE in an extension script that would replace a non-extension
+  # object, so this is safe. Scoped to these two functions only.
+  '^PS002: Unsafe function creation: df\.grant_usage\(p_role text,include_http boolean,with_grant boolean\) at line [0-9]+$'
+  '^PS002: Unsafe function creation: df\.revoke_usage\(p_role text\) at line [0-9]+$'
 )
 
 # Whole codes to suppress globally (pgspot --ignore). Prefer PGSPOT_ALLOW. Empty.

--- a/sql/pg_durable--0.2.3--0.2.4.sql
+++ b/sql/pg_durable--0.2.3--0.2.4.sql
@@ -3,7 +3,127 @@
 
 -- pg_durable upgrade: 0.2.3 → 0.2.4
 --
--- No schema changes yet in this release.
--- Add DDL here for any df-schema changes that land in 0.2.4. See
--- docs/upgrade-testing.md for the upgrade-script and backward-compatibility
+-- See docs/upgrade-testing.md for the upgrade-script and backward-compatibility
 -- requirements (Scenario A / B1 / B2).
+
+-- ============================================================================
+-- Simplify df.grant_usage(): drop the explicit per-function allowlist.
+--
+-- The previous body looped over a hard-coded list of df.* function signatures
+-- and issued GRANT EXECUTE on each. That list was redundant: the ordinary
+-- df.* functions retain PostgreSQL's default PUBLIC EXECUTE privilege, so the
+-- real access gate is USAGE on schema df (granted below). The list added no
+-- access boundary while requiring maintenance on every new function and
+-- masquerading as a security allowlist.
+--
+-- The sensitive functions (df.http, df.grant_usage, df.revoke_usage) had their
+-- PUBLIC EXECUTE revoked at install time and were never in the list; they are
+-- still granted explicitly here, so their protection is unchanged.
+--
+-- This CREATE OR REPLACE brings pre-existing installs in line with fresh
+-- 0.2.4 installs (see src/lib.rs). The new body works against the existing
+-- schema and changes no privileges already granted.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION df.grant_usage(
+    p_role TEXT,
+    include_http boolean DEFAULT false,
+    with_grant boolean DEFAULT false
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $fn$
+DECLARE
+    grant_opt TEXT := '';
+BEGIN
+    IF with_grant THEN
+        grant_opt := ' WITH GRANT OPTION';
+    END IF;
+
+    -- Schema access — the access gate for ordinary df.* functions (see header).
+    EXECUTE pg_catalog.format('GRANT USAGE ON SCHEMA df TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+
+    -- df.http() — opt-in because it makes outbound network requests.
+    IF include_http THEN
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    END IF;
+
+    -- Admin helpers — only for delegated administrators.
+    IF with_grant THEN
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.grant_usage(text, boolean, boolean) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.revoke_usage(text) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    END IF;
+
+    -- Table privileges
+    EXECUTE pg_catalog.format('GRANT SELECT ON df.instances TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT UPDATE (status, updated_at) ON df.instances TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT SELECT ON df.nodes TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT INSERT (id, label, root_node, submitted_by, database) ON df.instances TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database) ON df.nodes TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+
+    RAISE NOTICE 'pg_durable: granted df usage privileges to "%"', p_role;
+END;
+$fn$;
+
+-- ============================================================================
+-- Simplify df.revoke_usage(): make it symmetric with the new df.grant_usage().
+--
+-- The previous body looped over every df.* function in pg_proc issuing
+-- REVOKE EXECUTE. With the simplified grant_usage() that no longer grants
+-- per-function EXECUTE on ordinary functions, those revokes target privileges
+-- the role never explicitly held (its access comes from schema USAGE + the
+-- default PUBLIC EXECUTE), producing only "no privileges could be revoked"
+-- warnings. Revoking USAGE on schema df is the access gate, so it alone locks
+-- the role out of every ordinary df.* function.
+--
+-- The new body undoes exactly what grant_usage() grants: schema USAGE, EXECUTE
+-- on the sensitive functions, and the table privileges. Note: a role granted
+-- under the OLD grant_usage() (explicit per-function EXECUTE) may retain inert
+-- EXECUTE entries on ordinary functions after this revoke; they are harmless
+-- because schema USAGE is gone, and clear on the next drop/regrant cycle.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION df.revoke_usage(p_role TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $fn$
+BEGIN
+    -- Mirror of df.grant_usage(): undo exactly what it grants. Revoking schema
+    -- USAGE is the access gate that locks the role out of ordinary df.*
+    -- functions; the sensitive functions and table privileges are undone below.
+    -- CASCADE also removes any sub-grants the role made via WITH GRANT OPTION.
+
+    -- Sensitive functions (granted explicitly by grant_usage()).  A delegated
+    -- admin may lack privilege on some of these (e.g. df.http); skip those.
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.grant_usage(text, boolean, boolean) FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.revoke_usage(text) FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+
+    -- Table privileges.
+    -- Column-level revokes must match the column-level grants from grant_usage().
+    EXECUTE pg_catalog.format('REVOKE SELECT, INSERT, UPDATE, DELETE ON df.vars FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database) ON df.nodes FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE SELECT ON df.nodes FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE INSERT (id, label, root_node, submitted_by, database) ON df.instances FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE UPDATE (status, updated_at) ON df.instances FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE SELECT ON df.instances FROM %I CASCADE', p_role);
+
+    -- Schema access — the access gate for all ordinary df.* functions.
+    EXECUTE pg_catalog.format('REVOKE USAGE ON SCHEMA df FROM %I CASCADE', p_role);
+
+    RAISE NOTICE 'pg_durable: revoked df usage privileges granted by "%" from "%"', current_user, p_role;
+END;
+$fn$;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,37 +326,23 @@ CREATE POLICY vars_user_isolation ON df.vars
     USING (owner OPERATOR(pg_catalog.=) pg_catalog.quote_ident(current_user)::pg_catalog.regrole)
     WITH CHECK (owner OPERATOR(pg_catalog.=) pg_catalog.quote_ident(current_user)::pg_catalog.regrole);
 
--- No automatic PUBLIC grants. Admins must explicitly grant privileges
--- to application roles after CREATE EXTENSION.
--- Use df.grant_usage('role_name') (recommended) or see USER_GUIDE.md
--- "Privilege Grants" for the equivalent manual GRANT statements.
+-- No automatic PUBLIC grants — admins call df.grant_usage('role') after
+-- CREATE EXTENSION (or see USER_GUIDE.md "Privilege Grants" for manual GRANTs).
 
--- Helper: grant all required df privileges to a role in one call.
--- Authorization model: This function is SECURITY INVOKER and EXECUTE is
--- revoked from PUBLIC, so only roles explicitly granted EXECUTE (via
--- with_grant => true or a direct superuser GRANT) can call it. The inner
--- GRANT statements run as the caller, so the caller must also hold the
--- underlying privileges WITH GRANT OPTION (automatically true for
--- superusers; for delegated admins, df.grant_usage(..., with_grant => true)
--- grants all privileges WITH GRANT OPTION).
+-- Helper: grant all required df privileges to a role in one call. Additive
+-- only (never REVOKEs); call df.revoke_usage() first to downgrade. SECURITY
+-- INVOKER with EXECUTE revoked from PUBLIC, so the caller must hold the
+-- underlying privileges WITH GRANT OPTION (superusers and with_grant => true
+-- admins do). See USER_GUIDE.md "Privilege Grants" for full details.
 --
--- This function is purely additive — it never issues REVOKE.  To downgrade
--- a role's privileges, call df.revoke_usage() first, then df.grant_usage()
--- with the desired options.
---
--- include_http controls whether the role is granted EXECUTE on df.http().
--- Default is false: HTTP access is opt-in because df.http() makes outbound
--- network requests and requires explicit administrator approval.
---
--- with_grant controls whether the target role receives privileges WITH GRANT
--- OPTION and can itself call df.grant_usage() / df.revoke_usage() to manage
--- other roles' access.  Authorization is enforced by PostgreSQL's native
--- WITH GRANT OPTION mechanism: the caller must hold each underlying
--- privilege WITH GRANT OPTION, which is automatically true for superusers
--- and for delegated admins granted via with_grant => true.
---
--- MAINTENANCE: when adding a new df.* function, add it to the func_sigs
--- array below.  Functions NOT in this list are deny-by-default.
+-- Access gate: schema USAGE makes the ordinary df.* functions callable (they
+-- keep PostgreSQL's default PUBLIC EXECUTE). Sensitive functions (df.http,
+-- df.grant_usage, df.revoke_usage) have PUBLIC EXECUTE revoked at install time
+-- and are granted explicitly below — keep a new private function private the
+-- same way (REVOKE ... FROM PUBLIC in rls_and_grants, then grant it here).
+--   include_http => true  also grants EXECUTE on df.http() (opt-in: network).
+--   with_grant   => true  grants everything WITH GRANT OPTION and lets the role
+--                         call df.grant_usage()/df.revoke_usage() for others.
 CREATE OR REPLACE FUNCTION df.grant_usage(
     p_role TEXT,
     include_http boolean DEFAULT false,
@@ -364,158 +350,84 @@ CREATE OR REPLACE FUNCTION df.grant_usage(
 )
 RETURNS VOID
 LANGUAGE plpgsql
-SET search_path = pg_catalog, df, pg_temp
+SET search_path = pg_catalog, pg_temp
 AS $fn$
 DECLARE
     grant_opt TEXT := '';
-    func_sig TEXT;
-    -- Explicit list of df.* functions to grant.  Sensitive functions
-    -- (df.http, df.grant_usage, df.revoke_usage) are excluded from this
-    -- list and granted conditionally below.
-    func_sigs TEXT[] := ARRAY[
-        -- DSL functions
-        'df.sql(text)',
-        'df.seq(text, text)',
-        'df.as(text, text)',
-        'df.sleep(bigint)',
-        'df.wait_for_schedule(text)',
-        'df.loop(text, text)',
-        'df.break(text)',
-        'df.if(text, text, text)',
-        'df.if_rows(text, text, text)',
-        'df.join(text, text)',
-        'df.join3(text, text, text)',
-        'df.race(text, text)',
-        'df.wait_for_signal(text, integer)',
-        'df.signal(text, text, text)',
-        'df.start(text, text, text)',
-        'df.setvar(text, text)',
-        'df.getvar(text)',
-        'df.unsetvar(text)',
-        'df.clearvars()',
-        -- Monitoring functions
-        'df.status(text)',
-        'df.result(text)',
-        'df.cancel(text, text)',
-        'df.wait_for_completion(text, integer)',
-        'df.run(text)',
-        'df.list_instances(text, integer)',
-        'df.instance_info(text)',
-        'df.instance_nodes(text, integer)',
-        'df.instance_executions(text, integer)',
-        'df.metrics()',
-        -- Internal helpers (operators, version, etc.)
-        'df.as_op(text, text)',
-        'df.if_then_op(text, text)',
-        'df.if_else_op(text, text)',
-        'df.ensure_durofut(text)',
-        'df.loop_prefix_op(text)',
-        'df.version()',
-        'df.debug_connection()',
-        'df.explain(text)',
-        'df.target_database()'
-    ];
 BEGIN
-    -- Validate the role exists
-    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = p_role) THEN
-        RAISE EXCEPTION 'role "%" does not exist', p_role;
-    END IF;
-
     IF with_grant THEN
         grant_opt := ' WITH GRANT OPTION';
     END IF;
 
-    -- Schema access
-    EXECUTE format('GRANT USAGE ON SCHEMA df TO %I', p_role) || grant_opt;
-
-    -- Grant EXECUTE on each standard function explicitly.
-    FOREACH func_sig IN ARRAY func_sigs LOOP
-        EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO %I', func_sig, p_role) || grant_opt;
-    END LOOP;
+    -- Schema access — the access gate for ordinary df.* functions (see header).
+    EXECUTE pg_catalog.format('GRANT USAGE ON SCHEMA df TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
 
     -- df.http() — opt-in because it makes outbound network requests.
     IF include_http THEN
-        EXECUTE format('GRANT EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) TO %I', p_role) || grant_opt;
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
     END IF;
 
     -- Admin helpers — only for delegated administrators.
     IF with_grant THEN
-        EXECUTE format('GRANT EXECUTE ON FUNCTION df.grant_usage(text, boolean, boolean) TO %I', p_role) || grant_opt;
-        EXECUTE format('GRANT EXECUTE ON FUNCTION df.revoke_usage(text) TO %I', p_role) || grant_opt;
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.grant_usage(text, boolean, boolean) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.revoke_usage(text) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
     END IF;
 
     -- Table privileges
-    EXECUTE format('GRANT SELECT ON df.instances TO %I', p_role) || grant_opt;
-    EXECUTE format('GRANT UPDATE (status, updated_at) ON df.instances TO %I', p_role) || grant_opt;
-    EXECUTE format('GRANT SELECT ON df.nodes TO %I', p_role) || grant_opt;
-    EXECUTE format('GRANT INSERT (id, label, root_node, submitted_by, database) ON df.instances TO %I', p_role) || grant_opt;
-    EXECUTE format('GRANT INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database) ON df.nodes TO %I', p_role) || grant_opt;
-    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO %I', p_role) || grant_opt;
+    EXECUTE pg_catalog.format('GRANT SELECT ON df.instances TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT UPDATE (status, updated_at) ON df.instances TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT SELECT ON df.nodes TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT INSERT (id, label, root_node, submitted_by, database) ON df.instances TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database) ON df.nodes TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
 
     RAISE NOTICE 'pg_durable: granted df usage privileges to "%"', p_role;
 END;
 $fn$;
 
--- Revoke all df privileges previously granted by df.grant_usage().
--- Authorization: same model as df.grant_usage() — EXECUTE is revoked from
--- PUBLIC, caller must hold the underlying privileges to revoke them.
--- Safety: format(%I) quotes identifiers to prevent SQL injection. Additionally,
--- this is SECURITY INVOKER so it cannot escalate beyond the caller's privileges.
+-- Revoke everything df.grant_usage() grants (same authorization model).
+-- format(%I) quotes identifiers; SECURITY INVOKER caps it at the caller's
+-- own privileges.
 CREATE OR REPLACE FUNCTION df.revoke_usage(p_role TEXT)
 RETURNS VOID
 LANGUAGE plpgsql
-SET search_path = pg_catalog, df, pg_temp
+SET search_path = pg_catalog, pg_temp
 AS $fn$
-DECLARE
-    func_oid oid;
 BEGIN
-    -- Validate the role exists
-    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = p_role) THEN
-        RAISE EXCEPTION 'role "%" does not exist', p_role;
-    END IF;
+    -- Mirror of df.grant_usage(): undo exactly what it grants. Revoking schema
+    -- USAGE is the access gate that locks the role out of ordinary df.*
+    -- functions; the sensitive functions and table privileges are undone below.
+    -- CASCADE also removes any sub-grants the role made via WITH GRANT OPTION.
 
-    -- Prevent accidentally revoking your own access.  pg_has_role checks
-    -- both direct identity (current_user = p_role) and inherited membership
-    -- (current_user is a member of p_role), so revoking a parent role that
-    -- the caller depends on is also caught.
-    -- Superusers are exempt: pg_has_role returns true for all roles when the
-    -- caller is a superuser, and superusers can always re-grant themselves.
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_roles
-        WHERE rolname = current_user
-          AND rolsuper
-    )
-       AND pg_has_role(current_user, p_role, 'MEMBER') THEN
-        RAISE EXCEPTION 'cannot revoke df privileges from "%" because the current role ("%") is a member of it — use a different administrator', p_role, current_user;
-    END IF;
+    -- Sensitive functions (granted explicitly by grant_usage()).  A delegated
+    -- admin may lack privilege on some of these (e.g. df.http); skip those.
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.grant_usage(text, boolean, boolean) FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.revoke_usage(text) FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
 
-    -- CASCADE: if the target role granted sub-grants (via WITH GRANT OPTION),
-    -- CASCADE ensures those dependent privileges are also revoked.
+    -- Table privileges.
     -- Column-level revokes must match the column-level grants from grant_usage().
-    EXECUTE format('REVOKE SELECT, INSERT, UPDATE, DELETE ON df.vars FROM %I CASCADE', p_role);
-    EXECUTE format('REVOKE INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database) ON df.nodes FROM %I CASCADE', p_role);
-    EXECUTE format('REVOKE SELECT ON df.nodes FROM %I CASCADE', p_role);
-    EXECUTE format('REVOKE INSERT (id, label, root_node, submitted_by, database) ON df.instances FROM %I CASCADE', p_role);
-    EXECUTE format('REVOKE UPDATE (status, updated_at) ON df.instances FROM %I CASCADE', p_role);
-    EXECUTE format('REVOKE SELECT ON df.instances FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE SELECT, INSERT, UPDATE, DELETE ON df.vars FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database) ON df.nodes FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE SELECT ON df.nodes FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE INSERT (id, label, root_node, submitted_by, database) ON df.instances FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE UPDATE (status, updated_at) ON df.instances FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE SELECT ON df.instances FROM %I CASCADE', p_role);
 
-    -- Revoke EXECUTE per-function rather than using the blanket
-    -- REVOKE ON ALL FUNCTIONS.  A delegated admin may lack privilege on
-    -- some functions (e.g. df.http); per-function revokes let us skip those.
-    FOR func_oid IN
-        SELECT p.oid FROM pg_proc p
-        JOIN pg_namespace n ON p.pronamespace = n.oid
-        WHERE n.nspname = 'df'
-    LOOP
-        BEGIN
-            EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM %I CASCADE', func_oid::regprocedure, p_role);
-        EXCEPTION WHEN insufficient_privilege THEN
-            NULL;
-        END;
-    END LOOP;
-
-    EXECUTE format('REVOKE USAGE ON SCHEMA df FROM %I CASCADE', p_role);
+    -- Schema access — the access gate for all ordinary df.* functions.
+    EXECUTE pg_catalog.format('REVOKE USAGE ON SCHEMA df FROM %I CASCADE', p_role);
 
     RAISE NOTICE 'pg_durable: revoked df usage privileges granted by "%" from "%"', current_user, p_role;
 END;
@@ -543,17 +455,10 @@ BEGIN
     END IF;
 END $$;
 
--- df.http() carries network-access implications and must be opt-in.
--- PostgreSQL grants EXECUTE to PUBLIC by default when functions are created;
--- revoke that so only roles explicitly granted access (via
--- df.grant_usage(role, include_http => true) or a direct GRANT) can make
--- HTTP requests.
+-- df.http(), df.grant_usage() and df.revoke_usage() are sensitive (network
+-- access / privilege management), so revoke PostgreSQL's default PUBLIC
+-- EXECUTE. df.grant_usage() re-grants them explicitly to authorized roles.
 REVOKE EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) FROM PUBLIC;
-
--- df.grant_usage() and df.revoke_usage() are admin-only helpers.
--- Revoke PUBLIC's default EXECUTE privilege so that only roles explicitly
--- granted access (via with_grant => true or a direct superuser GRANT) can
--- manage other roles' df privileges.
 REVOKE EXECUTE ON FUNCTION df.grant_usage(text, boolean, boolean) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION df.revoke_usage(text) FROM PUBLIC;
 "#,

--- a/tests/e2e/sql/18_delegated_grants.sql
+++ b/tests/e2e/sql/18_delegated_grants.sql
@@ -12,11 +12,15 @@
 --   3. Non-superuser admin CAN set with_grant => true (delegated admin can create sub-admins)
 --   4. Non-superuser admin CANNOT set include_http => true without HTTP grant permission
 --   5. admin_role can call df.grant_usage() to grant app_role access
+--   5b. granted app_role reaches ordinary df.* functions via schema USAGE
+--       (no per-function EXECUTE grant) and is NOT granted df.http()
 --   6. app_role can use pg_durable (start + complete a workflow)
 --   7. app_role CANNOT call df.grant_usage() (no EXECUTE privilege)
 --   8. admin_role can revoke app_role access
 --   9. app_role can no longer use pg_durable
---   10. Self-revoke protection: admin_role cannot revoke its own access
+--   10. Self-revoke is harmless: PostgreSQL's REVOKE only removes grants the
+--       current role made, so admin_role cannot revoke its own postgres-granted
+--       access (no explicit guard needed)
 --
 -- Note: cross-admin revoke is intentionally not tested here. These helper
 -- functions are SECURITY INVOKER, and PostgreSQL revoke semantics are scoped
@@ -222,6 +226,37 @@ BEGIN
     RAISE NOTICE 'TEST 5 verification PASSED: app role does not have admin helper access';
 END $$;
 
+-- === Test 5b: granted app_role reaches ordinary functions via schema USAGE,
+-- and a plain grant (no include_http) does NOT expose df.http() ===
+-- This pins the access model after dropping the explicit func_sigs allowlist
+-- from df.grant_usage(): schema USAGE is the gate for ordinary df.* functions
+-- (which retain PostgreSQL's default PUBLIC EXECUTE), while df.http() stays
+-- opt-in because its PUBLIC EXECUTE is revoked at install time.
+DO $$
+DECLARE
+    has_usage BOOLEAN;
+    can_start BOOLEAN;
+    can_http BOOLEAN;
+BEGIN
+    SELECT has_schema_privilege('dg_app', 'df', 'USAGE') INTO has_usage;
+    SELECT has_function_privilege('dg_app', 'df.start(text, text, text)', 'EXECUTE') INTO can_start;
+    SELECT has_function_privilege('dg_app', 'df.http(text, text, text, jsonb, integer)', 'EXECUTE') INTO can_http;
+
+    IF NOT has_usage THEN
+        RAISE EXCEPTION 'TEST 5b FAILED: dg_app should have USAGE on schema df after grant_usage';
+    END IF;
+
+    IF NOT can_start THEN
+        RAISE EXCEPTION 'TEST 5b FAILED: dg_app should reach df.start via schema USAGE + default PUBLIC EXECUTE';
+    END IF;
+
+    IF can_http THEN
+        RAISE EXCEPTION 'SECURITY FAILURE: dg_app granted without include_http should NOT have EXECUTE on df.http';
+    END IF;
+
+    RAISE NOTICE 'TEST 5b PASSED: USAGE gates ordinary functions; df.http remains opt-in for a plain grant';
+END $$;
+
 -- === Test 6: app_role can use pg_durable ===
 SET SESSION AUTHORIZATION dg_app;
 
@@ -268,9 +303,18 @@ RESET SESSION AUTHORIZATION;
 SET SESSION AUTHORIZATION dg_admin;
 
 DO $$
+DECLARE
+    still_has_usage BOOLEAN;
 BEGIN
     PERFORM df.revoke_usage('dg_app');
     RAISE NOTICE 'TEST 8 PASSED: admin role successfully called df.revoke_usage for app role';
+
+    -- Schema USAGE is the access gate; revoke_usage() must remove it.
+    SELECT has_schema_privilege('dg_app', 'df', 'USAGE') INTO still_has_usage;
+    IF still_has_usage THEN
+        RAISE EXCEPTION 'TEST 8 FAILED: dg_app still has USAGE on schema df after revoke_usage';
+    END IF;
+    RAISE NOTICE 'TEST 8 PASSED: dg_app lost USAGE on schema df (access gate closed)';
 END $$;
 
 RESET SESSION AUTHORIZATION;
@@ -297,22 +341,25 @@ END $$;
 
 RESET SESSION AUTHORIZATION;
 
--- === Test 10: Self-revoke protection ===
+-- === Test 10: Self-revoke is harmless (PostgreSQL built-in protection) ===
+-- We don't have an explicit self-revoke guard. None is needed: PostgreSQL's
+-- REVOKE only removes grants made by the current role, and dg_admin's
+-- privileges were granted by postgres (not by dg_admin itself). So a
+-- self-revoke attempt is a no-op and dg_admin retains its access.
 SET SESSION AUTHORIZATION dg_admin;
 
 DO $$
+DECLARE
+    still_has_usage BOOLEAN;
 BEGIN
-    BEGIN
-        PERFORM df.revoke_usage('dg_admin');
-        RAISE EXCEPTION 'SECURITY FAILURE: admin was able to revoke its own access';
-    EXCEPTION
-        WHEN OTHERS THEN
-            IF SQLERRM ILIKE '%cannot revoke df privileges%' AND SQLERRM ILIKE '%member of it%' THEN
-                RAISE NOTICE 'TEST 10 PASSED: self-revoke prevented with clear error';
-            ELSE
-                RAISE EXCEPTION 'TEST 10 UNEXPECTED ERROR: %', SQLERRM;
-            END IF;
-    END;
+    -- Attempt to revoke own access; PostgreSQL leaves it intact.
+    PERFORM df.revoke_usage('dg_admin');
+
+    SELECT has_schema_privilege('dg_admin', 'df', 'USAGE') INTO still_has_usage;
+    IF NOT still_has_usage THEN
+        RAISE EXCEPTION 'TEST 10 FAILED: dg_admin lost USAGE after self-revoke (expected PostgreSQL to keep it)';
+    END IF;
+    RAISE NOTICE 'TEST 10 PASSED: self-revoke is a no-op; dg_admin retains access (built into PostgreSQL)';
 END $$;
 
 RESET SESSION AUTHORIZATION;


### PR DESCRIPTION
## Summary

Rationalizes the `df.grant_usage()` / `df.revoke_usage()` privilege helpers for the unreleased v0.2.3, removing defensive code that PostgreSQL already handles and making the two functions symmetric.

## Changes

- **`grant_usage`**
  - Drops the per-function `GRANT EXECUTE` allowlist. Ordinary `df.*` functions keep PostgreSQL's default `PUBLIC EXECUTE`, so `USAGE ON SCHEMA df` is the single access gate. Only the sensitive functions (`df.http`, `df.grant_usage`, `df.revoke_usage`) — which have `PUBLIC EXECUTE` revoked at install time — are granted explicitly.
  - Drops the redundant role-existence check (a named role that doesn't exist fails naturally on the first `GRANT`; granting to `PUBLIC` is a deliberate admin choice).
- **`revoke_usage`**
  - Mirror of `grant_usage` (Option A): undoes only what `grant_usage` grants.
  - Drops the role-existence and self-revoke guards — PostgreSQL's grantor rules already prevent a non-superuser from removing another role's grants, so self-revoke is a harmless no-op.
- **Upgrade script** (`sql/pg_durable--0.2.2--0.2.3.sql`): same `CREATE OR REPLACE` bodies as `src/lib.rs`.
- **E2E test 18 (`18_delegated_grants.sql`)**: adds schema/HTTP assertions (5b), asserts loss of schema `USAGE` after revoke (8), and verifies self-revoke is a harmless no-op (10).
- **Docs**: `USER_GUIDE.md` — fixes the inaccurate self-revoke "safety measure" claim, notes that `df.grant_usage('public')` grants cluster-wide, and trims the stale per-function manual-grants list. `docs/upgrade-testing.md` — documents both simplifications.

## pgspot gate

The 0.2.2 → 0.2.3 upgrade script is the first non-excluded upgrade script that defines functions. Scanned standalone (without the `CREATE SCHEMA df` that the install SQL emits, so pgspot can't prove `df` is extension-owned), the helper bodies tripped PS001/PS005/PS016.

- Schema-qualified the `grant_usage`/`revoke_usage` bodies — `pg_catalog.format(...)`, `OPERATOR(pg_catalog.||)`, and `SET search_path = pg_catalog, pg_temp` — applied byte-identically in `src/lib.rs` and the upgrade script. The install SQL stays clean because pgspot suppresses those findings via the emitted `CREATE SCHEMA df`.
- Allowlisted PS002 (unsafe `CREATE OR REPLACE`) for the two exact function signatures in `scripts/run-pgspot.sh`. PostgreSQL 14.5+ blocks the `CREATE OR REPLACE` attack inside extension scripts, so this is safe.

## Upgrade & Migration

- **B1 (binary backward compat):** Function signatures are unchanged; only bodies are simplified. Legacy installs may retain inert per-function EXECUTE grants, which are harmless.
- All changes fold into the existing 0.2.2 → 0.2.3 upgrade script; no new SQL fixtures needed.

## Testing

- `cargo fmt -p pg_durable -- --check` ✅
- `cargo build --features pg17` ✅ (only the pre-existing `extract_host` dead-code warning)
- `./scripts/test-e2e-local.sh 18_delegated_grants --verbose` ✅ (1 passed, 0 failed)
- `scripts/run-pgspot.sh sql/pg_durable--0.2.2--0.2.3.sql` ✅ (gate passes; only the two allowlisted PS002 findings)
