### PR TITLE
chore: start 0.2.4 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file. The format is b
 
 Pre-1.0 note: while `pg_durable` is in major version `0`, minor releases may include breaking changes.
 
+## [0.2.4] - Unreleased
+
 ## [0.2.3] - 2026-06-17
 
 Provider-line note: v0.2.3 stays in the `duroxide-pg` provider compatibility line started in v0.2.2, so the upgrade source is v0.2.2 (`sql/pg_durable--0.2.2--0.2.3.sql`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "pg_durable"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_durable"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "PostgreSQL"
 repository = "https://github.com/microsoft/pg_durable"

--- a/sql/pg_durable--0.2.3--0.2.4.sql
+++ b/sql/pg_durable--0.2.3--0.2.4.sql
@@ -1,0 +1,9 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the PostgreSQL License.
+
+-- pg_durable upgrade: 0.2.3 → 0.2.4
+--
+-- No schema changes yet in this release.
+-- Add DDL here for any df-schema changes that land in 0.2.4. See
+-- docs/upgrade-testing.md for the upgrade-script and backward-compatibility
+-- requirements (Scenario A / B1 / B2).


### PR DESCRIPTION
Opens the next development cycle now that **v0.2.3** is released (tag `v0.2.3`, GitHub Release published, GHCR images `0.2.3-pg17/18` + floating `pg17`/`pg18`/`latest`).

### Changes
- Bump version `0.2.3` → `0.2.4` (`Cargo.toml`, `Cargo.lock`).
- Add empty upgrade script `sql/pg_durable--0.2.3--0.2.4.sql` (license header + "no schema changes yet" stub; add DDL here as schema-changing PRs land).
- Add a `## [0.2.4] - Unreleased` placeholder to `CHANGELOG.md`.

No `docs/upgrade-testing.md` "Version-Specific Changes" entry — that's added per schema-changing PR, and 0.2.4 has none yet.

Part of #243.