### PR TITLE
fix: wrap std::env::set_var in unsafe block for Rust 2024 edition

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -104,7 +104,13 @@ where
         let client = rt.block_on(async {
             // Limit backend provider to 1 connection — backends need minimal
             // duroxide access (start/cancel/signal only).
-            std::env::set_var("DUROXIDE_PG_POOL_MAX", "1");
+            //
+            // SAFETY: Each PostgreSQL backend is a separate process (fork model).
+            // This code runs in a single-threaded tokio runtime with no worker
+            // threads. No concurrent thread can be reading env simultaneously.
+            unsafe {
+                std::env::set_var("DUROXIDE_PG_POOL_MAX", "1");
+            }
 
             let store = new_backend_provider(&pg_conn_str, schema).await?;
             Ok::<Client, String>(Client::new(store))

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -456,12 +456,17 @@ async fn initialize_duroxide_runtime(
     log!("pg_durable: initializing duroxide runtime...");
 
     // Control duroxide provider pool size via env var (the only mechanism
-    // without modifying duroxide-pg). BGW is single-threaded so no
-    // concurrent readers. Note: std::env::set_var becomes unsafe in Rust 2024 edition.
-    std::env::set_var(
-        "DUROXIDE_PG_POOL_MAX",
-        get_max_duroxide_connections().to_string(),
-    );
+    // without modifying duroxide-pg).
+    //
+    // SAFETY: The BGW tokio runtime uses new_current_thread() — no additional
+    // OS threads are spawned. PostgreSQL's fork model means this process has no
+    // other threads that could be reading the environment concurrently.
+    unsafe {
+        std::env::set_var(
+            "DUROXIDE_PG_POOL_MAX",
+            get_max_duroxide_connections().to_string(),
+        );
+    }
 
     // Create the user-execution semaphore once — the GUC is Postmaster-context
     // so the value never changes within a worker lifetime.


### PR DESCRIPTION
Split from #221 to ease review.

`std::env::set_var` becomes unsafe in the Rust 2024 edition because it can cause undefined behavior when other threads read the environment concurrently.

Add `SAFETY` documentation explaining why `set_var` is acceptable here: PostgreSQL backends are forked single-process, and the BGW tokio runtime uses `new_current_thread()` with no additional OS threads spawned.

**Files:** `src/worker.rs`, `src/client.rs`
**Tests:** Purely mechanical annotation — zero behavioral change.