### PR TITLE
Fix pg_durable documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The model is intentionally SQL-shaped. If a step needs arbitrary code, a non-HTT
 -- A durable function that processes data in steps
 SELECT df.start(
     'SELECT id FROM documents WHERE processed = false LIMIT 100' |=> 'batch'
-    ~> 'UPDATE documents SET processed = true WHERE id = ANY($batch)'
+    ~> 'UPDATE documents SET processed = true WHERE id IN (SELECT id FROM $batch.*)'
 );
 ```
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -251,7 +251,7 @@ Access specific columns by name instead of just the first column:
 ```sql
 SELECT df.start(
     $$SELECT 42 AS id, 'Alice' AS name$$ |=> 'user'
-    ~> $$SELECT $user.id, $user.name$$          -- access specific columns
+    ~> $$SELECT $user.id AS id, $user.name AS name$$  -- access specific columns
 );
 ```
 
@@ -557,11 +557,11 @@ Use `df.if_rows()` to branch based on whether a named result has rows — withou
 
 ```sql
 SELECT df.start(
-    $$SELECT id FROM orders WHERE status = 'pending'$$ |=> 'pending'
+    $$SELECT id FROM playground.orders WHERE status = 'pending'$$ |=> 'pending'
     ~> df.if_rows(
         'pending',                                               -- result name
-        $$UPDATE orders SET status = 'processing' WHERE id = $pending.id$$,  -- then
-        $$INSERT INTO logs (msg) VALUES ('No pending orders')$$               -- else
+        $$UPDATE playground.orders SET status = 'processing' WHERE id = $pending.id$$,  -- then
+        $$INSERT INTO playground.logs (msg) VALUES ('No pending orders')$$               -- else
     ),
     'check-pending'
 );
@@ -877,7 +877,7 @@ SELECT df.setvar('batch_size', '100');
 -- Start the pipeline
 SELECT df.start(
     'SELECT * FROM {source_table} LIMIT {batch_size}::int' |=> 'batch'
-    ~> 'INSERT INTO {target_table} SELECT * FROM ($batch) AS source',
+    ~> 'INSERT INTO {target_table} SELECT * FROM $batch.*',
     'etl-pipeline'
 );
 ```
@@ -1136,13 +1136,13 @@ If the signal times out:
 
 ```sql
 SELECT df.start(
-    'SELECT order_id, total FROM orders WHERE id = 1' |=> 'order'
+    'SELECT id, total FROM orders WHERE id = 1' |=> 'order'
     ~> df.wait_for_signal('approval', 86400) |=> 'sig'  -- 24h timeout
     ~> df.if(
         'SELECT NOT ($sig::jsonb->>''timed_out'')::boolean 
             AND ($sig::jsonb->''data''->>''approved'')::boolean',
-        'UPDATE orders SET status = ''approved'' WHERE id = $order_id',
-        'UPDATE orders SET status = ''rejected'' WHERE id = $order_id'
+        'UPDATE orders SET status = ''approved'' WHERE id = $order.id',
+        'UPDATE orders SET status = ''rejected'' WHERE id = $order.id'
     ),
     'order-approval'
 );
@@ -1157,13 +1157,13 @@ Wait for multiple approvals using `df.join3()`:
 
 ```sql
 SELECT df.start(
-    'SELECT doc_id FROM documents WHERE id = 1' |=> 'doc'
+    'SELECT id FROM documents WHERE id = 1' |=> 'doc'
     ~> df.join3(
         df.wait_for_signal('legal_approval'),
         df.wait_for_signal('tech_approval'),
         df.wait_for_signal('mgmt_approval')
     ) |=> 'approvals'
-    ~> 'UPDATE documents SET status = ''approved'' WHERE id = $doc_id',
+    ~> 'UPDATE documents SET status = ''approved'' WHERE id = $doc.id',
     'multi-approval'
 );
 

--- a/docs/spec-signals.md
+++ b/docs/spec-signals.md
@@ -68,9 +68,9 @@ The `df.wait_for_signal()` function returns a JSON object:
 
 ```sql
 SELECT df.start(
-    'SELECT order_id FROM orders WHERE id = 1' |=> 'order'
+    'SELECT id FROM orders WHERE id = 1' |=> 'order'
     ~> df.wait_for_signal('approval') |=> 'sig'
-    ~> 'INSERT INTO audit_log VALUES ($order_id, $sig::jsonb->''data''->>''approver'')',
+    ~> 'INSERT INTO audit_log VALUES ($order.id, $sig::jsonb->''data''->>''approver'')',
     'order-approval'
 );
 
@@ -82,18 +82,18 @@ SELECT df.signal('a1b2c3d4', 'approval', '{"approved": true, "approver": "jane"}
 
 ```sql
 SELECT df.start(
-    'SELECT order_id FROM orders WHERE id = 1' |=> 'order'
+    'SELECT id FROM orders WHERE id = 1' |=> 'order'
     ~> df.wait_for_signal('approval', 86400) |=> 'sig'  -- 24 hour timeout
     ~> df.if(
         'SELECT NOT ($sig::jsonb->>''timed_out'')::boolean',
         -- Signal received
         df.if(
             'SELECT ($sig::jsonb->''data''->>''approved'')::boolean',
-            'UPDATE orders SET status = ''approved'' WHERE id = $order_id',
-            'UPDATE orders SET status = ''rejected'' WHERE id = $order_id'
+            'UPDATE orders SET status = ''approved'' WHERE id = $order.id',
+            'UPDATE orders SET status = ''rejected'' WHERE id = $order.id'
         ),
         -- Timed out
-        'UPDATE orders SET status = ''expired'' WHERE id = $order_id'
+        'UPDATE orders SET status = ''expired'' WHERE id = $order.id'
     ),
     'order-with-timeout'
 );
@@ -103,13 +103,13 @@ SELECT df.start(
 
 ```sql
 SELECT df.start(
-    'SELECT doc_id FROM documents WHERE id = 1' |=> 'doc'
+    'SELECT id FROM documents WHERE id = 1' |=> 'doc'
     ~> df.join3(
         df.wait_for_signal('legal_approval'),
         df.wait_for_signal('tech_approval'),
         df.wait_for_signal('mgmt_approval')
     ) |=> 'approvals'
-    ~> 'UPDATE documents SET status = ''approved'' WHERE id = $doc_id',
+    ~> 'UPDATE documents SET status = ''approved'' WHERE id = $doc.id',
     'multi-approval'
 );
 
@@ -635,13 +635,13 @@ SELECT df.signal('instance_id', 'signal_name', '{"data": "value"}');
 
 ```sql
 SELECT df.start(
-    'SELECT order_id, total FROM orders WHERE id = 1' |=> 'order'
+    'SELECT id, total FROM orders WHERE id = 1' |=> 'order'
     ~> df.wait_for_signal('approval', 86400) |=> 'sig'
     ~> df.if(
         'SELECT NOT ($sig::jsonb->>''timed_out'')::boolean 
             AND ($sig::jsonb->''data''->>''approved'')::boolean',
-        'UPDATE orders SET status = ''approved'' WHERE id = $order_id',
-        'UPDATE orders SET status = ''rejected'' WHERE id = $order_id'
+        'UPDATE orders SET status = ''approved'' WHERE id = $order.id',
+        'UPDATE orders SET status = ''rejected'' WHERE id = $order.id'
     ),
     'order-approval'
 );
@@ -675,4 +675,3 @@ SELECT df.signal('a1b2c3d4', 'approval', '{"approved": true}');
 - [x] Add to Quick Reference Card
 
 **Implementation completed: December 2024**
-

--- a/examples/azure-http-domains/scripts/smoke_check.sh
+++ b/examples/azure-http-domains/scripts/smoke_check.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the PostgreSQL License.
 
-# Offline syntax validation for all scripts and SQL in this example.
+# Offline validation for shell syntax and required service files in this example.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Problem

Testing the README and user-facing documentation examples found several result-substitution issues:

- The README quick example used a captured multi-row result as a scalar in an array context. A bare `$var` capture substitutes only the first column of the first row, so the generated SQL was invalid.
- `USER_GUIDE.md` had additional examples with the same scalar-vs-row-set issue, unqualified playground tables, duplicate unnamed substituted columns, and signal workflows that captured `order`/`doc` but referenced undefined `$order_id`/`$doc_id`.
- `docs/spec-signals.md` duplicated the signal capture-reference mistakes.
- The Azure HTTP domains smoke check comment claimed broader SQL validation than the script performs.

## Fix

- Use `$batch.*` row-set expansion where examples pass captured row sets between steps.
- Keep runnable User Guide examples aligned with the `playground` schema from the appendix.
- Alias substituted dot-notation columns in the dot-notation example.
- Reference captured result columns with `$order.id` and `$doc.id` in signal examples.
- Narrow the smoke-check comment to match its actual offline validation.

## Verification

Tested against pgrx-managed PostgreSQL 17 and 18 instances built from this PR branch:

- README quick example completed and updated all expected rows.
- Corrected finite User Guide examples completed, including dot notation, `df.if_rows()`, configurable ETL, row-set expansion, and signal timeout flows.
- `docs/SCENARIOS.md` copy-paste scenarios completed; the scheduled HTTP scenario was started, observed through its first insert, then cancelled.
- Example smoke checks passed for `azure-functions`, `azure-http-domains`, and `invoice-approval`.
- Local non-cloud portions of the Azure example SQL scripts ran successfully.
- Patched signal snippets in `docs/spec-signals.md` completed with expected state changes.
