### PR TITLE
Compare constraint definitions in upgrade schema snapshots

### DIFF
--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -531,19 +531,17 @@ ORDER BY t.typname;
 
 -- Constraints
 SELECT 'constraint' AS obj_type,
-       tc.table_name,
-       tc.constraint_name,
-       tc.constraint_type,
-       string_agg(kcu.column_name, ', ' ORDER BY kcu.ordinal_position) AS columns,
-       '' AS extra1,
+       rel.relname AS table_name,
+       con.conname AS constraint_name,
+       con.contype::text AS constraint_type,
+       pg_get_constraintdef(con.oid) AS definition,
+       con.convalidated::text AS validated,
        '' AS extra2
-FROM information_schema.table_constraints tc
-JOIN information_schema.key_column_usage kcu
-  ON tc.constraint_name = kcu.constraint_name
-  AND tc.table_schema = kcu.table_schema
-WHERE tc.table_schema = 'df'
-GROUP BY tc.table_name, tc.constraint_name, tc.constraint_type
-ORDER BY tc.table_name, tc.constraint_name;
+FROM pg_constraint con
+JOIN pg_class rel ON rel.oid = con.conrelid
+JOIN pg_namespace n ON n.oid = rel.relnamespace
+WHERE n.nspname = 'df'
+ORDER BY rel.relname, con.conname;
 
 -- RLS policies
 SELECT 'policy' AS obj_type,

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -530,6 +530,16 @@ GROUP BY t.typname, t.typtype, t.typbasetype, t.typtypmod
 ORDER BY t.typname;
 
 -- Constraints
+--
+-- Read from pg_constraint so CHECK bodies (pg_get_constraintdef) and the
+-- validated/NOT VALID state (convalidated) are compared, not just key columns.
+--
+-- Exclude NOT NULL constraints (contype = 'n'): on PG18+ these are first-class
+-- pg_constraint rows, but on PG17 they are not (they live in
+-- pg_attribute.attnotnull), so including them would make this snapshot
+-- PG-version-dependent. Per-column nullability is already captured by the
+-- 'column' section above via is_nullable, and the auto-generated NOT NULL
+-- constraint names add noise without extra coverage.
 SELECT 'constraint' AS obj_type,
        rel.relname AS table_name,
        con.conname AS constraint_name,
@@ -541,6 +551,7 @@ FROM pg_constraint con
 JOIN pg_class rel ON rel.oid = con.conrelid
 JOIN pg_namespace n ON n.oid = rel.relnamespace
 WHERE n.nspname = 'df'
+  AND con.contype <> 'n'
 ORDER BY rel.relname, con.conname;
 
 -- RLS policies


### PR DESCRIPTION
Fixes #241.

## Summary
- switch the upgrade-test schema snapshot constraint section to read from `pg_constraint`
- include `pg_get_constraintdef(con.oid)` so CHECK bodies and full constraint definitions are compared
- include `con.convalidated` so validated vs `NOT VALID` drift is caught
- keep deterministic ordering and the existing seven-column snapshot shape

## Testing
- `bash -n scripts/test-upgrade.sh`
- `cargo fmt -p pg_durable -- --check`
- `git diff --check`

Not run: `./scripts/test-upgrade.sh` because this local environment does not have pgrx PostgreSQL 17 installed (`Error: pgrx PostgreSQL 17 not installed`).