### PR TITLE
Node state-transition model: execution_id stamping + derived statuses

### DIFF
--- a/.agents/skills/pg-durable-sql/SKILL.md
+++ b/.agents/skills/pg-durable-sql/SKILL.md
@@ -153,8 +153,9 @@ df.list_instances(status_filter TEXT DEFAULT NULL, limit_count INT DEFAULT 100)
 df.instance_info(instance_id TEXT)
 -- Columns: instance_id, label, function_name, function_version, current_execution_id, status, output
 
-df.instance_nodes(instance_id TEXT, last_n_executions INT DEFAULT 5)
--- Columns: execution_id, node_id, node_type, query, result_name, left_node, right_node, status, result, updated_at
+df.instance_nodes(instance_id TEXT)
+-- Columns: node_id, node_type, query, result_name, left_node, right_node, status, result, status_details, inferred_status, inferred_status_from_ancestor_id, updated_at
+-- inferred_status reinterprets status with a derived 'skipped' (untaken if/then/race branch) and loop re-entry as 'pending'
 
 df.instance_executions(instance_id TEXT, limit_count INT DEFAULT 5)
 -- Columns: execution_id, status, event_count, duration_ms, output

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1459,17 +1459,70 @@ SELECT * FROM df.instance_executions('a1b2c3d4', 20);
 
 ### Function Nodes
 
-See the function graph structure:
+See the function graph structure, one row per node, with both the stored status
+and a derived status that interprets the durable-execution state model:
 
 ```sql
--- Last 5 executions (default)
 SELECT * FROM df.instance_nodes('a1b2c3d4');
-
--- Last 10 executions
-SELECT * FROM df.instance_nodes('a1b2c3d4', 10);
 ```
 
-**Columns:** `execution_id`, `node_id`, `node_type`, `query`, `result_name`, `left_node`, `right_node`, `status`, `result`
+**Columns:** `node_id`, `node_type`, `query`, `result_name`, `left_node`, `right_node`, `status`, `result`, `status_details`, `inferred_status`, `inferred_status_from_ancestor_id`, `updated_at`
+
+- **`status`** — the status physically stored on the node: `pending`, `running`,
+  `completed`, or `failed`.
+- **`status_details`** — JSON execution metadata written by the worker (the
+  `execution_id` generation stamp). You normally do not read this directly; it is
+  what `inferred_status` is derived from.
+- **`inferred_status`** — the stored status reinterpreted top-down from the root
+  node. It adds one derived value, **`skipped`**, and reconciles loop re-entry:
+  - `skipped` — a node on a branch that was decided against and will not (further)
+    run: the untaken arm of a completed `df.if()`, the right side of a failed
+    `df.then()`, or the abandoned arm of a resolved `df.race()`.
+  - a node from a previous loop iteration reads back as `pending` (it will re-run),
+    rather than showing the old iteration's terminal status.
+  - a node that physically ran keeps its stored `completed`/`failed`/`running`.
+- **`inferred_status_from_ancestor_id`** — when `inferred_status` was *derived*
+  from an ancestor (a `skipped` branch, or a superseded loop node), this names the
+  ancestor node that drove the inference; otherwise `NULL`.
+
+> This is read-time interpretation only — it does not change how the graph
+> executes. `df.race()` still abandons the losing branch and `df.join()` still
+> waits for every branch; `inferred_status` only changes how those outcomes are
+> *reported*.
+
+#### Node state transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending
+    pending --> running: scheduled (written)
+    running --> completed: success (written)
+    running --> failed: error (written)
+
+    pending --> skipped: ancestor failed / not taken / race lost (derived)
+    running --> skipped: ancestor failed / not taken / race lost (derived)
+    completed --> pending: superseded by newer execution (derived)
+    failed --> pending: superseded by newer execution (derived)
+
+    classDef physical fill:#dfd,stroke:#080;
+    classDef derived stroke-dasharray: 5 5,fill:#eee;
+    classDef hybrid fill:#dfd,stroke:#080,stroke-dasharray: 5 5;
+    class running,completed,failed physical
+    class skipped derived
+    class pending hybrid
+```
+
+Solid edges are **physical**: the worker writes them and they persist in
+`df.nodes.status` (the `status` column). Dashed edges are **derived**: nothing
+writes them — they are how `df.instance_nodes()` *reinterprets* a stored status
+(via `inferred_status`) when a node's `execution_id` no longer matches its live
+lineage. `pending` (drawn with a dashed border) is **both**: it is written once by
+`df.start()`, and it is *also* what the read path reports for a node superseded by a
+newer loop iteration. That terminal → `pending` edge is therefore not a write — it
+is what a previous iteration's stored `completed`/`failed` (or an in-flight
+`running`) *looks like* once a newer iteration supersedes it and has not yet
+re-reached the node.
+
 
 ### System Metrics (Explicit Grant Required)
 
@@ -2118,14 +2171,17 @@ This shows the graph structure with status markers on each node:
 - `✓ Completed` — node finished successfully
 - `✗ Failed` — node encountered an error
 - `⏳ Running` — node was in progress when the instance failed or was inspected
+- `⊘ Skipped` — branch was decided away (untaken `if` arm, right side of a failed `then`, or race loser) so the node will never run
 - `○ Pending` — node never started
+
+The markers reflect the same derived status as the `inferred_status` column of `df.instance_nodes()`, so the tree view and the node table always agree.
 
 `df.explain()` tells you **where** in the graph execution stopped, but not **why**. For that, inspect individual nodes.
 
 #### Step 4: Inspect Individual Nodes
 
 ```sql
-SELECT node_id, node_type, result_name, status, 
+SELECT node_id, node_type, result_name, status, inferred_status,
        left(query, 80) AS query,
        left(result, 120) AS result
 FROM df.instance_nodes('a1b2c3d4');
@@ -2137,6 +2193,8 @@ This shows every node in the graph with its status and result. Key things to loo
 |---------------|---------------|
 | A node with `status = 'failed'` | This is the node that caused the failure |
 | A node with `result = NULL` and `status = 'completed'` | The SQL returned no rows |
+| A node with `inferred_status = 'skipped'` | The node was on a branch that was decided against (untaken `df.if()` arm, right side of a failed `df.then()`, or losing `df.race()` arm) and never (further) ran |
+| `inferred_status = 'pending'` on a node that previously completed | The node belongs to an earlier loop iteration and will re-run |
 | Result contains `{"jsonb": null}` | Possible type extraction issue — see "Known Limitations" below |
 | A `running` node with no result | Execution was interrupted at this node |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -351,6 +351,68 @@ SELECT df.result('a1b2c3d4');
 
 ---
 
+### df.instance_nodes(instance_id)
+
+Returns one row per node in an instance's graph, with each node's stored physical
+status alongside a read-time **derived** status. This is the primary tool for
+inspecting *where* an instance is and *why* a branch did or did not run.
+
+| Parameter | Type | Auto-wrap | Description |
+|-----------|------|-----------|-------------|
+| `instance_id` | TEXT | ❌ Literal | Target instance ID |
+
+Return columns:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `node_id` | TEXT | Node id (unique within the instance) |
+| `node_type` | TEXT | `SQL`, `THEN`, `IF`, `JOIN`, `RACE`, `LOOP`, `SLEEP`, `SIGNAL`, `HTTP`, … |
+| `query` | TEXT | SQL text for `SQL` nodes; a JSON config for compound/leaf nodes |
+| `result_name` | TEXT | Capture name (`\|=>`), or `NULL` |
+| `left_node` | TEXT | First child node id, or `NULL` |
+| `right_node` | TEXT | Second child node id, or `NULL` |
+| `status` | TEXT | **Physical** stored status: `pending`, `running`, `completed`, `failed` |
+| `result` | JSONB | Result/error payload for `completed`/`failed` nodes, else `NULL` |
+| `status_details` | JSONB | Worker-written node metadata (see below), or `NULL` if never transitioned |
+| `inferred_status` | TEXT | **Derived** status: physical status plus `skipped`, and loop re-entry surfaced as `pending` |
+| `inferred_status_from_ancestor_id` | TEXT | Ancestor node id that drove a derived `skipped`/`pending`, or `NULL` |
+| `updated_at` | TIMESTAMPTZ | Last physical status change |
+
+**`status_details` JSON contract.** Written by the worker through the
+`update-node-status` activity and stored verbatim in `df.nodes.status_details`:
+
+- `execution_id` — the node's full segmented execution path, e.g.
+  `a1b2c3d4::1::7f9a0012::1`. Parse it positionally: the second `::`-token is the
+  root loop generation (used to detect superseded loop iterations), and the
+  trailing segments encode `JOIN`/`RACE` sub-orchestration lineage.
+
+`inferred_status` and `inferred_status_from_ancestor_id` are **computed at read
+time** and are not stored in `df.nodes.status_details`.
+
+**Derived statuses.** `skipped` is never written to `df.nodes.status` (it is not a
+member of the `nodes_status_chk` constraint) — it exists only in `inferred_status`:
+
+- `skipped` — a non-terminal node whose nearest terminal ancestor already decided
+  the branch will not run: the untaken arm of a completed `df.if()`, the right side
+  of a failed `df.then()`/`~>`, or the abandoned (still-running) loser of a resolved
+  `df.race()`. A loser that already reached `completed`/`failed` keeps its physical
+  status.
+- `pending` (derived) — a node from an older loop generation that a newer ancestor
+  generation has superseded; it will re-run, so it reads back as `pending` rather
+  than showing the previous iteration's terminal status.
+
+`df.explain()` renders the same derived status for each node, so the two views
+always agree.
+
+```sql
+SELECT node_id, node_type, status AS physical, inferred_status,
+       status_details->>'execution_id' AS execution_id
+FROM df.instance_nodes('a1b2c3d4')
+ORDER BY node_id;
+```
+
+---
+
 ## Variable Functions
 
 ### df.setvar(name, value)

--- a/sql/pg_durable--0.2.3--0.2.4.sql
+++ b/sql/pg_durable--0.2.3--0.2.4.sql
@@ -256,3 +256,87 @@ DROP INDEX IF EXISTS df.idx_instances_status;
 CREATE INDEX idx_instances_status ON df.instances(status, created_at DESC, id);
 DROP INDEX IF EXISTS df.idx_instances_created_at;
 CREATE INDEX idx_instances_created_at ON df.instances(created_at DESC, id);
+
+-- ============================================================================
+-- Node state-transition model: add df.nodes.status_details (PR #263).
+--
+-- The background worker stamps every node transition with the orchestration
+-- generation "{instance_id}::{execution_id}" in status_details->>'execution_id'.
+-- df.instance_nodes() parses that stamp to derive the pending/skipped statuses
+-- and to reconcile loop re-entry, and update_node_status() uses it to fence stale
+-- writes. The column is nullable and is deliberately NOT added to any user INSERT
+-- grant on df.nodes -- only the background worker writes it.
+--
+-- Backward compatibility (Scenario B1): the new .so probes for this column at
+-- runtime (update_node_status) and degrades to the plain status/result write when
+-- it is absent, so a pre-0.2.4 schema keeps running until this upgrade applies.
+--
+-- Upgrade ordering (in-flight instances): the worker's orchestration history
+-- changed shape in this release -- update_node_status activity inputs gained an
+-- execution_id field, and JOIN/RACE branch sub-orchestrations now use
+-- deterministic composed instance ids instead of auto-generated ones. duroxide
+-- replays by exact equality on recorded inputs/ids, so instances in flight across
+-- the upgrade cannot resume; drain or recreate them before upgrading (the same
+-- constraint documented for issue #129).
+-- ============================================================================
+ALTER TABLE df.nodes ADD COLUMN status_details JSONB;
+
+COMMENT ON COLUMN df.nodes.status_details IS
+    'Execution metadata written by the worker (never inserted by users). JSON object with key '
+    '"execution_id": the orchestration instance_id::execution_id stamp recorded when the node last '
+    'transitioned. df.instance_nodes() parses it to derive pending/skipped statuses; see USER_GUIDE.md.';
+
+-- ============================================================================
+-- df.instance_nodes(): one row per node with derived status (PR #263).
+--
+-- The return shape changed: the per-execution fan-out is gone, replaced by a
+-- single row per node carrying the stored status plus the derived status_details,
+-- inferred_status and inferred_status_from_ancestor_id columns. Keep the old
+-- two-argument overload callable for binary/schema compatibility, but implement
+-- it as a one-row-per-node adapter that ignores last_n_executions and returns a
+-- dummy execution_id of 1. Remove its default argument so one-argument calls
+-- resolve to the new API after the schema upgrade. The definitions below are the
+-- pgrx-generated fresh-install DDL (src/monitoring.rs) verbatim, so the Scenario
+-- A schema snapshot (function arguments + result type) matches a fresh 0.2.4
+-- install.
+-- ============================================================================
+DROP FUNCTION IF EXISTS df.instance_nodes(text, integer);
+
+CREATE  FUNCTION df."instance_nodes"(
+    "instance_id_param" TEXT, /* &str */
+    "_last_n_executions" INT /* i32 */
+) RETURNS TABLE (
+    "execution_id" bigint,  /* i64 */
+    "node_id" TEXT,  /* alloc::string::String */
+    "node_type" TEXT,  /* alloc::string::String */
+    "query" TEXT,  /* core::option::Option<alloc::string::String> */
+    "result_name" TEXT,  /* core::option::Option<alloc::string::String> */
+    "left_node" TEXT,  /* core::option::Option<alloc::string::String> */
+    "right_node" TEXT,  /* core::option::Option<alloc::string::String> */
+    "status" TEXT,  /* core::option::Option<alloc::string::String> */
+    "result" TEXT,  /* core::option::Option<alloc::string::String> */
+    "updated_at" timestamp with time zone  /* core::option::Option<pgrx::datum::time_stamp_with_timezone::TimestampWithTimeZone> */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'instance_nodes_wrapper';
+
+CREATE  FUNCTION df."instance_nodes"(
+	"instance_id_param" TEXT /* &str */
+) RETURNS TABLE (
+	"node_id" TEXT,  /* alloc::string::String */
+	"node_type" TEXT,  /* alloc::string::String */
+	"query" TEXT,  /* core::option::Option<alloc::string::String> */
+	"result_name" TEXT,  /* core::option::Option<alloc::string::String> */
+	"left_node" TEXT,  /* core::option::Option<alloc::string::String> */
+	"right_node" TEXT,  /* core::option::Option<alloc::string::String> */
+	"status" TEXT,  /* core::option::Option<alloc::string::String> */
+	"result" TEXT,  /* core::option::Option<alloc::string::String> */
+	"status_details" TEXT,  /* core::option::Option<alloc::string::String> */
+	"inferred_status" TEXT,  /* alloc::string::String */
+	"inferred_status_from_ancestor_id" TEXT,  /* core::option::Option<alloc::string::String> */
+	"updated_at" timestamp with time zone  /* core::option::Option<pgrx::datum::time_stamp_with_timezone::TimestampWithTimeZone> */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'instance_nodes_v2_wrapper';

--- a/src/activities/update_node_status.rs
+++ b/src/activities/update_node_status.rs
@@ -1,16 +1,42 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the PostgreSQL License.
 
-//! UpdateNodeStatus activity - updates df.nodes status and result
+//! UpdateNodeStatus activity - updates df.nodes status, result, and status_details
 
 use duroxide::ActivityContext;
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, QueryBuilder};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
 /// Activity name for registration and scheduling
 pub const NAME: &str = "pg_durable::activity::update-node-status";
 
-/// Update the status and optionally the result of a node in df.nodes
+/// Process-global cache for whether df.nodes.status_details exists.
+///
+/// 0 = unknown, 1 = present, 2 = absent. The column is added by the
+/// 0.2.3 → 0.2.4 upgrade; a binary newer than the schema (Scenario B1) must run
+/// against an older schema that lacks it. We cache "present" permanently once
+/// seen, but re-probe on "unknown"/"absent" so an in-place ALTER EXTENSION
+/// UPDATE that adds the column is picked up without a worker restart.
+static STATUS_DETAILS_COL: AtomicU8 = AtomicU8::new(0);
+
+async fn status_details_present(pool: &PgPool) -> bool {
+    if STATUS_DETAILS_COL.load(Ordering::Relaxed) == 1 {
+        return true;
+    }
+    let present = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.columns \
+         WHERE table_schema = 'df' AND table_name = 'nodes' \
+         AND column_name = 'status_details')",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap_or(false);
+    STATUS_DETAILS_COL.store(if present { 1 } else { 2 }, Ordering::Relaxed);
+    present
+}
+
+/// Update the status and optionally the result of a node in df.nodes.
 pub async fn execute(
     ctx: ActivityContext,
     pool: Arc<PgPool>,
@@ -32,55 +58,108 @@ pub async fn execute(
     // here. The serialized graph carried in the input preserves the df id.
     //
     // Upgrade note: duroxide compares activity inputs by exact equality during
-    // replay, so adding instance_id changes the recorded input shape. Instances
-    // in flight across the binary upgrade recorded the old shape and cannot be
+    // replay, so adding fields changes the recorded input shape. Instances in
+    // flight across the binary upgrade recorded the old shape and cannot be
     // replayed -- they must be drained/recreated before upgrading (see
-    // docs/upgrade-testing.md, issue #129 section). Every post-upgrade instance
-    // carries instance_id from the start, so requiring it here is safe and there
-    // is deliberately no node_id-only fallback (it would be dead code that only
-    // re-opened the corruption path above).
+    // docs/upgrade-testing.md, issue #129 section).
     let instance_id = input["instance_id"].as_str().ok_or("Missing instance_id")?;
 
-    // The UPDATE is always scoped by (id, instance_id), which the composite
-    // primary key makes unique, so it can affect at most one row. Positional
-    // placeholders match the bind order below.
-    let sql: &str = if result.is_some() {
-        "UPDATE df.nodes
-             SET status = $1, result = $2::jsonb, updated_at = now()
-             WHERE id = $3 AND instance_id = $4"
-    } else if status == "running" {
-        // When marking as running, clear any stale result from a previous
-        // loop iteration to satisfy the constraint:
-        // (result IS NULL OR status IN ('completed', 'failed'))
-        "UPDATE df.nodes
-             SET status = $1, result = NULL, updated_at = now()
-             WHERE id = $2 AND instance_id = $3"
-    } else {
-        "UPDATE df.nodes
-             SET status = $1, updated_at = now()
-             WHERE id = $2 AND instance_id = $3"
-    };
+    // execution_id is the "{orchestration_instance_id}::{execution_id}" stamp
+    // identifying which orchestration generation last transitioned this node. It
+    // is optional: a pre-execution-id binary recorded inputs without it, so when
+    // absent we fall back to the unfenced write. df.instance_nodes() parses the
+    // stamp's second token (the root loop generation) to derive pending/skipped.
+    let execution_id = input.get("execution_id").and_then(|v| v.as_str());
 
-    let mut query = sqlx::query(sql).bind(status);
+    // Only write status_details when the binary supplies a stamp AND the running
+    // schema actually has the column (Scenario B1: a newer .so may run against a
+    // pre-0.2.4 schema lacking it -- degrade to the plain status/result write).
+    let write_details = execution_id.is_some() && status_details_present(pool.as_ref()).await;
+
+    // Fence value: the incoming root generation (second "::"-token of the stamp).
+    // When the stamp can't be parsed we pass i64::MAX so the fence always
+    // accepts (i.e. behaves as no fence) rather than silently dropping writes.
+    let incoming_gen: i64 = execution_id
+        .and_then(|s| s.split("::").nth(1))
+        .and_then(|tok| tok.parse::<i64>().ok())
+        .unwrap_or(i64::MAX);
+
+    let mut update = QueryBuilder::<Postgres>::new("UPDATE df.nodes SET status = ");
+    update.push_bind(status);
+
     if let Some(res) = result {
-        // The result column is JSONB, so normalize invalid JSON payloads into
-        // a JSON string before binding.
         let json_result = serde_json::from_str::<serde_json::Value>(res)
             .unwrap_or_else(|_| serde_json::Value::String(res.to_string()));
-        query = query.bind(json_result);
+        update
+            .push(", result = ")
+            .push_bind(json_result)
+            .push("::jsonb");
+    } else if status == "running" {
+        // When marking as running, clear any stale result from a previous loop
+        // iteration to satisfy nodes_result_status_chk
+        // (result IS NULL OR status IN ('completed', 'failed')).
+        update.push(", result = NULL");
     }
-    query = query.bind(node_id).bind(instance_id);
 
-    match query.execute(pool.as_ref()).await {
+    if write_details {
+        let details = serde_json::json!({ "execution_id": execution_id });
+        update
+            .push(", status_details = ")
+            .push_bind(details)
+            .push("::jsonb");
+    }
+
+    // Monotonic write fence: reject a write carrying an OLDER root generation than
+    // the one already stamped on the row, so a stale loser/iteration drain can't
+    // clobber a newer generation's status. Equal-or-newer generations (including
+    // running -> terminal within the same generation) are accepted.
+    update
+        .push(", updated_at = now() WHERE id = ")
+        .push_bind(node_id)
+        .push(" AND instance_id = ")
+        .push_bind(instance_id);
+    if write_details {
+        update
+            .push(
+                " AND (status_details IS NULL OR \
+                 COALESCE(NULLIF(split_part(status_details->>'execution_id', '::', 2), '')::bigint, 0) <= ",
+            )
+            .push_bind(incoming_gen)
+            .push(")");
+    }
+
+    match update.build().execute(pool.as_ref()).await {
         Ok(done) => {
             let rows = done.rows_affected();
             if rows == 1 {
                 Ok("Node status updated".to_string())
+            } else if write_details {
+                // Zero rows under an active fence is ambiguous: the row may exist
+                // but carry a NEWER generation (a legitimate fenced-out stale
+                // write), or the node may genuinely be missing. Distinguish the
+                // two so a fence rejection is not surfaced as a correctness error.
+                let exists = sqlx::query_scalar::<_, bool>(
+                    "SELECT EXISTS (SELECT 1 FROM df.nodes WHERE id = $1 AND instance_id = $2)",
+                )
+                .bind(node_id)
+                .bind(instance_id)
+                .fetch_one(pool.as_ref())
+                .await
+                .unwrap_or(false);
+                if exists {
+                    Ok("Node status write fenced (superseded by newer generation)".to_string())
+                } else {
+                    let err_msg = format!(
+                        "update_node_status affected 0 rows: node {node_id} \
+                         not found in instance {instance_id}"
+                    );
+                    ctx.trace_info(&err_msg);
+                    Err(err_msg)
+                }
             } else {
-                // Exactly one row must match (instance_id, id). Anything else
-                // (typically zero rows: a missing node or a mismatched
-                // instance_id) is a correctness violation we must surface rather
-                // than silently swallow.
+                // No fence in play: exactly one row must match (instance_id, id).
+                // Anything else (typically zero rows: a missing node or a
+                // mismatched instance_id) is a correctness violation.
                 let err_msg = format!(
                     "update_node_status affected {rows} row(s) for node {node_id} \
                      in instance {instance_id} (expected exactly 1)"

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -19,6 +19,28 @@ struct ExplainNode {
     status: Option<String>,
     #[allow(dead_code)]
     result: Option<String>,
+    status_details: Option<String>,
+}
+
+impl crate::node_status::NodeFacts for ExplainNode {
+    fn node_type(&self) -> &str {
+        &self.node_type
+    }
+    fn query(&self) -> Option<&str> {
+        self.query.as_deref()
+    }
+    fn left_node(&self) -> Option<&str> {
+        self.left_node.as_deref()
+    }
+    fn right_node(&self) -> Option<&str> {
+        self.right_node.as_deref()
+    }
+    fn status(&self) -> Option<&str> {
+        self.status.as_deref()
+    }
+    fn status_details(&self) -> Option<&str> {
+        self.status_details.as_deref()
+    }
 }
 
 /// Explain a durable function - either an existing instance or a DSL expression
@@ -74,7 +96,16 @@ fn explain_instance(instance_id: &str) -> String {
     let (duroxide_status, output) = get_duroxide_instance_info(instance_id);
 
     // Load all nodes for this instance
-    let nodes = load_nodes_from_table("df.nodes", Some(instance_id));
+    let mut nodes = load_nodes_from_table("df.nodes", Some(instance_id));
+
+    // Overwrite each node's status with the derived status so the tree shows the
+    // same `skipped`/`pending` interpretation as df.instance_nodes() (shared walk).
+    let inferred = crate::node_status::infer_statuses(Some(&root_id), &nodes);
+    for (id, node) in nodes.iter_mut() {
+        if let Some(inf) = inferred.get(id) {
+            node.status = Some(inf.status.clone());
+        }
+    }
 
     if nodes.is_empty() {
         return format!("No nodes found for instance '{instance_id}'");
@@ -292,6 +323,7 @@ fn collect_nodes(
             right_node: right_id,
             status: None,
             result: None,
+            status_details: None,
         },
     );
 
@@ -305,10 +337,11 @@ fn load_nodes_from_table(table: &str, instance_id: Option<&str>) -> HashMap<Stri
     let mut nodes = HashMap::new();
 
     Spi::connect(|client| {
+        let status_details_expr = crate::node_status::status_details_select_expr(client);
         let (sql, args): (String, Vec<pgrx::datum::DatumWithOid>) = if let Some(id) = instance_id {
             (
                 format!(
-                    "SELECT id, node_type, query, result_name, left_node, right_node, status, result::text FROM {} WHERE instance_id = $1",
+                    "SELECT id, node_type, query, result_name, left_node, right_node, status, result::text, {status_details_expr} FROM {} WHERE instance_id = $1",
                     table
                 ),
                 vec![id.into()],
@@ -316,7 +349,7 @@ fn load_nodes_from_table(table: &str, instance_id: Option<&str>) -> HashMap<Stri
         } else {
             (
                 format!(
-                    "SELECT id, node_type, query, result_name, left_node, right_node, status, result::text FROM {table}"
+                    "SELECT id, node_type, query, result_name, left_node, right_node, status, result::text, {status_details_expr} FROM {table}"
                 ),
                 vec![],
             )
@@ -333,6 +366,7 @@ fn load_nodes_from_table(table: &str, instance_id: Option<&str>) -> HashMap<Stri
                         right_node: row.get(6).ok().flatten(),
                         status: row.get(7).ok().flatten(),
                         result: row.get(8).ok().flatten(),
+                        status_details: row.get(9).ok().flatten(),
                     };
                     nodes.insert(id, node);
                 }
@@ -394,6 +428,7 @@ fn build_tree_recursive(
             Some("failed") => " ✗",
             Some("running") => " ⏳",
             Some("pending") => " ○",
+            Some("skipped") => " ⊘",
             _ => "",
         }
     } else {
@@ -423,6 +458,7 @@ fn build_tree_recursive(
                         Some("failed") => " ✗",
                         Some("running") => " ⏳",
                         Some("pending") => " ○",
+                        Some("skipped") => " ⊘",
                         _ => "",
                     }
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod client;
 pub mod dsl;
 pub mod explain;
 pub mod monitoring;
+pub mod node_status;
 pub mod orchestrations;
 pub mod registry;
 pub mod ssrf;
@@ -195,11 +196,19 @@ CREATE TABLE df.nodes (
     submitted_by REGROLE,
     database TEXT,
     created_at TIMESTAMPTZ DEFAULT pg_catalog.now(),
-    updated_at TIMESTAMPTZ DEFAULT pg_catalog.now()
+    updated_at TIMESTAMPTZ DEFAULT pg_catalog.now(),
+    -- Appended last so the fresh-install column order matches the upgrade path,
+    -- where ALTER TABLE ADD COLUMN can only append (see pg_durable--0.2.3--0.2.4.sql).
+    status_details JSONB
 );
 
 COMMENT ON COLUMN df.nodes.submitted_by IS
     'Effective role (current_user) at df.start() time - used for connection authentication and SQL execution';
+
+COMMENT ON COLUMN df.nodes.status_details IS
+    'Execution metadata written by the worker (never inserted by users). JSON object with key '
+    '"execution_id": the orchestration instance_id::execution_id stamp recorded when the node last '
+    'transitioned. df.instance_nodes() parses it to derive pending/skipped statuses; see USER_GUIDE.md.';
 
 -- Table to store function instances
 CREATE TABLE df.instances (

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -6,7 +6,9 @@
 #![allow(clippy::type_complexity)] // Required for pgrx TableIterator return types
 
 use duroxide::Client;
+use pgrx::datum::TimestampWithTimeZone;
 use pgrx::prelude::*;
+use std::collections::HashMap;
 
 use crate::types::{backend_duroxide_schema, new_backend_provider, postgres_connection_string};
 
@@ -343,11 +345,165 @@ pub fn metrics() -> TableIterator<
     TableIterator::new(results)
 }
 
-/// Get function nodes for an instance with execution history.
+struct NodeRow {
+    id: String,
+    node_type: String,
+    query: Option<String>,
+    result_name: Option<String>,
+    left_node: Option<String>,
+    right_node: Option<String>,
+    status: Option<String>,
+    result: Option<String>,
+    status_details: Option<String>,
+    updated_at: Option<TimestampWithTimeZone>,
+}
+
+impl crate::node_status::NodeFacts for NodeRow {
+    fn node_type(&self) -> &str {
+        &self.node_type
+    }
+    fn query(&self) -> Option<&str> {
+        self.query.as_deref()
+    }
+    fn left_node(&self) -> Option<&str> {
+        self.left_node.as_deref()
+    }
+    fn right_node(&self) -> Option<&str> {
+        self.right_node.as_deref()
+    }
+    fn status(&self) -> Option<&str> {
+        self.status.as_deref()
+    }
+    fn status_details(&self) -> Option<&str> {
+        self.status_details.as_deref()
+    }
+}
+
+fn load_instance_nodes(instance_id: &str) -> (Option<String>, Vec<NodeRow>) {
+    Spi::connect(|client| {
+        let status_details_expr = crate::node_status::status_details_select_expr(client);
+        let node_sql = format!(
+            "SELECT id, node_type, query, result_name, left_node, right_node,
+                    status, result::text, {status_details_expr}, updated_at
+             FROM df.nodes WHERE instance_id = $1"
+        );
+        let mut nodes = Vec::new();
+        if let Ok(table) = client.select(&node_sql, None, &[instance_id.into()]) {
+            for row in table {
+                if let Ok(Some(id)) = row.get::<String>(1) {
+                    nodes.push(NodeRow {
+                        id,
+                        node_type: row.get::<String>(2).ok().flatten().unwrap_or_default(),
+                        query: row.get(3).ok().flatten(),
+                        result_name: row.get(4).ok().flatten(),
+                        left_node: row.get(5).ok().flatten(),
+                        right_node: row.get(6).ok().flatten(),
+                        status: row.get(7).ok().flatten(),
+                        result: row.get(8).ok().flatten(),
+                        status_details: row.get(9).ok().flatten(),
+                        updated_at: row.get(10).ok().flatten(),
+                    });
+                }
+            }
+        }
+
+        let mut root: Option<String> = None;
+        if let Ok(table) = client.select(
+            "SELECT root_node FROM df.instances WHERE id = $1",
+            None,
+            &[instance_id.into()],
+        ) {
+            if let Some(row) = table.into_iter().next() {
+                root = row.get::<String>(1).ok().flatten();
+            }
+        }
+
+        (root, nodes)
+    })
+}
+
+/// Get one row per node, with stored status plus read-time inferred status.
+#[pg_extern(name = "instance_nodes", schema = "df")]
+pub fn instance_nodes_v2(
+    instance_id_param: &str,
+) -> TableIterator<
+    'static,
+    (
+        name!(node_id, String),
+        name!(node_type, String),
+        name!(query, Option<String>),
+        name!(result_name, Option<String>),
+        name!(left_node, Option<String>),
+        name!(right_node, Option<String>),
+        name!(status, Option<String>),
+        name!(result, Option<String>),
+        name!(status_details, Option<String>),
+        name!(inferred_status, String),
+        name!(inferred_status_from_ancestor_id, Option<String>),
+        name!(updated_at, Option<pgrx::datum::TimestampWithTimeZone>),
+    ),
+> {
+    use crate::node_status::infer_statuses;
+
+    let (root_node, node_rows) = load_instance_nodes(instance_id_param);
+    let nodes: HashMap<String, NodeRow> =
+        node_rows.into_iter().map(|n| (n.id.clone(), n)).collect();
+
+    // Shared with df.explain() so both views agree on skipped/superseded nodes.
+    let inferred = infer_statuses(root_node.as_deref(), &nodes);
+
+    type Row = (
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        String,
+        Option<String>,
+        Option<TimestampWithTimeZone>,
+    );
+
+    let mut rows: Vec<Row> = Vec::with_capacity(nodes.len());
+    for (id, n) in &nodes {
+        let inf = inferred.get(id);
+        let inferred_status = inf
+            .map(|i| i.status.clone())
+            .unwrap_or_else(|| n.status.clone().unwrap_or_else(|| "pending".to_string()));
+        let from_anc = inf.and_then(|i| i.from_ancestor_id.clone());
+        rows.push((
+            id.clone(),
+            n.node_type.clone(),
+            n.query.clone(),
+            n.result_name.clone(),
+            n.left_node.clone(),
+            n.right_node.clone(),
+            n.status.clone(),
+            n.result.clone(),
+            n.status_details.clone(),
+            inferred_status,
+            from_anc,
+            n.updated_at,
+        ));
+    }
+
+    TableIterator::new(rows)
+}
+
+/// Compatibility wrapper for df.instance_nodes(text, integer).
+///
+/// A pure projection of df.nodes in the pre-0.2.4 result shape: no inference, no
+/// execution-history fan-out, and a constant execution_id of 1. It selects only
+/// columns present in every 0.2.x schema, so it behaves identically whether the
+/// running schema has df.nodes.status_details (0.2.4) or not (0.2.3 under a newer
+/// .so) — no column probe required. last_n_executions is ignored.
 #[pg_extern(schema = "df")]
 pub fn instance_nodes(
     instance_id_param: &str,
-    last_n_executions: default!(i32, "5"),
+    _last_n_executions: i32,
 ) -> TableIterator<
     'static,
     (
@@ -363,14 +519,8 @@ pub fn instance_nodes(
         name!(updated_at, Option<pgrx::datum::TimestampWithTimeZone>),
     ),
 > {
-    use pgrx::datum::TimestampWithTimeZone;
-
-    let instance_id = instance_id_param.to_string();
-    let pg_conn_str = postgres_connection_string();
-    let provider_schema = backend_duroxide_schema();
-
-    // Get node definitions from PostgreSQL (including status, result and updated_at)
-    let node_defs: Vec<(
+    type CompatRow = (
+        i64,
         String,
         String,
         Option<String>,
@@ -380,127 +530,34 @@ pub fn instance_nodes(
         Option<String>,
         Option<String>,
         Option<TimestampWithTimeZone>,
-    )> = Spi::connect(|client| {
-        let sql = r#"SELECT id, node_type, query, result_name, left_node, right_node, status, result::text, updated_at
-                   FROM df.nodes WHERE instance_id = $1"#;
-        let mut nodes = Vec::new();
+    );
+
+    let instance_id = instance_id_param.to_string();
+    let rows: Vec<CompatRow> = Spi::connect(|client| {
+        let sql = "SELECT id, node_type, query, result_name, left_node, right_node,
+                          status, result::text, updated_at
+                   FROM df.nodes WHERE instance_id = $1";
+        let mut rows = Vec::new();
         if let Ok(table) = client.select(sql, None, &[instance_id.as_str().into()]) {
             for row in table {
                 if let Ok(Some(id)) = row.get::<String>(1) {
-                    let node_type: String = row.get(2).ok().flatten().unwrap_or_default();
-                    let query: Option<String> = row.get(3).ok().flatten();
-                    let result_name: Option<String> = row.get(4).ok().flatten();
-                    let left_node: Option<String> = row.get(5).ok().flatten();
-                    let right_node: Option<String> = row.get(6).ok().flatten();
-                    let node_status: Option<String> = row.get(7).ok().flatten();
-                    let node_result: Option<String> = row.get(8).ok().flatten();
-                    let updated_at: Option<TimestampWithTimeZone> = row.get(9).ok().flatten();
-                    nodes.push((
+                    rows.push((
+                        1i64,
                         id,
-                        node_type,
-                        query,
-                        result_name,
-                        left_node,
-                        right_node,
-                        node_status,
-                        node_result,
-                        updated_at,
+                        row.get::<String>(2).ok().flatten().unwrap_or_default(),
+                        row.get(3).ok().flatten(),
+                        row.get(4).ok().flatten(),
+                        row.get(5).ok().flatten(),
+                        row.get(6).ok().flatten(),
+                        row.get(7).ok().flatten(),
+                        row.get(8).ok().flatten(),
+                        row.get(9).ok().flatten(),
                     ));
                 }
             }
         }
-        nodes
-    });
-
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(_) => return TableIterator::new(vec![]),
-    };
-
-    let results = rt.block_on(async {
-        let store = match new_backend_provider(&pg_conn_str, provider_schema).await {
-            Ok(s) => s,
-            Err(_) => return vec![],
-        };
-
-        let client = Client::new(store);
-
-        let execution_ids = match client.list_executions(&instance_id).await {
-            Ok(ids) => ids,
-            Err(_) => return vec![],
-        };
-
-        let mut sorted_ids: Vec<_> = execution_ids.into_iter().collect();
-        sorted_ids.sort_by(|a, b| b.cmp(a));
-        let limited: Vec<_> = sorted_ids
-            .into_iter()
-            .take(last_n_executions as usize)
-            .collect();
-
-        let mut rows = Vec::new();
-
-        for exec_id in limited {
-            for (
-                node_id,
-                node_type,
-                query,
-                result_name,
-                left_node,
-                right_node,
-                node_status,
-                node_result,
-                updated_at,
-            ) in &node_defs
-            {
-                rows.push((
-                    exec_id as i64,
-                    node_id.clone(),
-                    node_type.clone(),
-                    query.clone(),
-                    result_name.clone(),
-                    left_node.clone(),
-                    right_node.clone(),
-                    node_status.clone(),
-                    node_result.clone(),
-                    *updated_at,
-                ));
-            }
-        }
-
-        // If no executions found, return static node definitions
-        if rows.is_empty() {
-            for (
-                node_id,
-                node_type,
-                query,
-                result_name,
-                left_node,
-                right_node,
-                node_status,
-                node_result,
-                updated_at,
-            ) in node_defs
-            {
-                rows.push((
-                    0i64,
-                    node_id,
-                    node_type,
-                    query,
-                    result_name,
-                    left_node,
-                    right_node,
-                    node_status,
-                    node_result,
-                    updated_at,
-                ));
-            }
-        }
-
         rows
     });
 
-    TableIterator::new(results)
+    TableIterator::new(rows)
 }

--- a/src/node_status.rs
+++ b/src/node_status.rs
@@ -1,0 +1,515 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the PostgreSQL License.
+
+//! Shared read-time node-status inference for `df.instance_nodes()` and
+//! `df.explain()`.
+
+use std::collections::{HashMap, HashSet};
+
+pub(crate) fn status_details_select_expr(client: &pgrx::spi::SpiClient) -> &'static str {
+    let present = client
+        .select(
+            "SELECT EXISTS (
+                 SELECT 1
+                 FROM information_schema.columns
+                 WHERE table_schema = 'df'
+                   AND table_name = 'nodes'
+                   AND column_name = 'status_details'
+             )",
+            None,
+            &[],
+        )
+        .ok()
+        .and_then(|table| table.into_iter().next())
+        .and_then(|row| row.get::<bool>(1).ok().flatten())
+        .unwrap_or(false);
+
+    if present {
+        "status_details::text"
+    } else {
+        "NULL::text"
+    }
+}
+
+/// Structural facts needed to infer a node's status.
+pub trait NodeFacts {
+    fn node_type(&self) -> &str;
+    fn query(&self) -> Option<&str>;
+    fn left_node(&self) -> Option<&str>;
+    fn right_node(&self) -> Option<&str>;
+    fn status(&self) -> Option<&str>;
+    fn status_details(&self) -> Option<&str>;
+}
+
+/// Result of inference for a single node.
+#[derive(Debug, Clone)]
+pub struct Inferred {
+    /// The derived status: `pending` / `running` / `completed` / `failed` /
+    /// `skipped`.
+    pub status: String,
+    /// When the status was *derived* from an ancestor (a `skipped` branch or a
+    /// superseded loop node), the ancestor node id that drove it; otherwise None.
+    pub from_ancestor_id: Option<String>,
+}
+
+/// Parse the loop generation (the second "::"-token) from a node's
+/// status_details `execution_id` stamp. None when never stamped / unparseable.
+fn gen_of(status_details: Option<&str>) -> Option<i64> {
+    let sd = status_details?;
+    let v: serde_json::Value = serde_json::from_str(sd).ok()?;
+    v.get("execution_id")?
+        .as_str()?
+        .split("::")
+        .nth(1)?
+        .parse::<i64>()
+        .ok()
+}
+
+fn is_terminal(status: Option<&str>) -> bool {
+    matches!(status, Some("completed") | Some("failed"))
+}
+
+/// Enumerate child node ids referenced by compound nodes.
+fn children_of<N: NodeFacts>(n: &N) -> Vec<String> {
+    fn config_node(query: Option<&str>, key: &str, out: &mut Vec<String>) {
+        if let Some(cfg) = query {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(cfg) {
+                if let Some(s) = v.get(key).and_then(|c| c.as_str()) {
+                    out.push(s.to_string());
+                }
+            }
+        }
+    }
+    let mut kids: Vec<String> = Vec::new();
+    match n.node_type().to_uppercase().as_str() {
+        "THEN" | "RACE" => {
+            kids.extend(n.left_node().map(String::from));
+            kids.extend(n.right_node().map(String::from));
+        }
+        "JOIN" => {
+            kids.extend(n.left_node().map(String::from));
+            kids.extend(n.right_node().map(String::from));
+            if let Some(cfg) = n.query() {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(cfg) {
+                    if let Some(extra) = v.get("extra_nodes").and_then(|e| e.as_array()) {
+                        for x in extra {
+                            if let Some(s) = x.as_str() {
+                                kids.push(s.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        "IF" => {
+            config_node(n.query(), "condition_node", &mut kids);
+            kids.extend(n.left_node().map(String::from));
+            kids.extend(n.right_node().map(String::from));
+        }
+        "LOOP" => {
+            kids.extend(n.left_node().map(String::from));
+            config_node(n.query(), "condition_node", &mut kids);
+        }
+        _ => {}
+    }
+    kids
+}
+
+/// Compute the inferred status for every node in `nodes`, walking top-down from
+/// `root_node`. The returned map has one entry per node id present in `nodes`.
+pub fn infer_statuses<N: NodeFacts>(
+    root_node: Option<&str>,
+    nodes: &HashMap<String, N>,
+) -> HashMap<String, Inferred> {
+    // A walk frame: (node id, nearest terminal ancestor id, highest-generation
+    // ancestor as (generation, node id)).
+    type Frame = (String, Option<String>, Option<(i64, String)>);
+
+    let mut out: HashMap<String, Inferred> = HashMap::new();
+    let mut visited: HashSet<String> = HashSet::new();
+
+    // Top-down walk from the root, carrying the nearest terminal ancestor and
+    // highest-generation ancestor seen so far.
+    if let Some(root) = root_node {
+        let mut stack: Vec<Frame> = vec![(root.to_string(), None, None)];
+        while let Some((node_id, nta, max_gen_anc)) = stack.pop() {
+            if !visited.insert(node_id.clone()) {
+                continue;
+            }
+            let n = match nodes.get(&node_id) {
+                Some(n) => n,
+                None => continue, // dangling reference (should not happen)
+            };
+
+            let gen_n = gen_of(n.status_details());
+            let terminal = is_terminal(n.status());
+            let superseded = match (gen_n, &max_gen_anc) {
+                (Some(g), Some((ag, _))) => *ag > g,
+                _ => false,
+            };
+
+            let (inferred, from_anc): (String, Option<String>) = if terminal {
+                if superseded {
+                    // Terminal in an older generation: a newer iteration exists. If a
+                    // terminal ancestor decided against this branch it is `skipped`;
+                    // otherwise it will re-run, so it reads back as `pending`.
+                    match &nta {
+                        Some(a) => ("skipped".to_string(), Some(a.clone())),
+                        None => (
+                            "pending".to_string(),
+                            max_gen_anc.as_ref().map(|(_, id)| id.clone()),
+                        ),
+                    }
+                } else {
+                    // Physically ran in the current generation: keep its stored status.
+                    (n.status().unwrap_or("pending").to_string(), None)
+                }
+            } else {
+                // Non-terminal: a terminal ancestor means this branch was abandoned
+                // (untaken IF arm / right of a failed THEN / RACE loser) -> `skipped`.
+                match &nta {
+                    Some(a) => ("skipped".to_string(), Some(a.clone())),
+                    None => match n.status() {
+                        Some("running") => ("running".to_string(), None),
+                        _ => ("pending".to_string(), None),
+                    },
+                }
+            };
+
+            out.insert(
+                node_id.clone(),
+                Inferred {
+                    status: inferred,
+                    from_ancestor_id: from_anc,
+                },
+            );
+
+            // A terminal node decides its descendants are `skipped` only when it ran in
+            // the CURRENT generation. A *superseded* terminal node belongs to an older loop
+            // generation and is about to re-run together with its whole subtree, so it must
+            // not mask its descendants as skipped — they keep the existing decision (usually
+            // none, so they read back as `pending` like the superseded node itself).
+            let child_nta = if terminal && !superseded {
+                Some(node_id.clone())
+            } else {
+                nta.clone()
+            };
+            let child_max_gen_anc = match (gen_n, max_gen_anc.clone()) {
+                (Some(g), Some((ag, aid))) => {
+                    if g >= ag {
+                        Some((g, node_id.clone()))
+                    } else {
+                        Some((ag, aid))
+                    }
+                }
+                (Some(g), None) => Some((g, node_id.clone())),
+                (None, prev) => prev,
+            };
+
+            for child in children_of(n) {
+                stack.push((child, child_nta.clone(), child_max_gen_anc.clone()));
+            }
+        }
+    }
+
+    // Defensive: surface any node not reachable from the root (orphaned or
+    // referenced only through configs we do not traverse) with its stored status
+    // and no derived inference, so the result map stays complete.
+    for (id, n) in nodes {
+        if visited.contains(id) {
+            continue;
+        }
+        out.insert(
+            id.clone(),
+            Inferred {
+                status: n.status().unwrap_or("pending").to_string(),
+                from_ancestor_id: None,
+            },
+        );
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal in-memory node used to drive pure inference tests.
+    struct TestNode {
+        node_type: &'static str,
+        query: Option<String>,
+        left: Option<&'static str>,
+        right: Option<&'static str>,
+        status: Option<&'static str>,
+        status_details: Option<String>,
+    }
+
+    impl TestNode {
+        fn new(node_type: &'static str) -> Self {
+            TestNode {
+                node_type,
+                query: None,
+                left: None,
+                right: None,
+                status: None,
+                status_details: None,
+            }
+        }
+        fn status(mut self, s: &'static str) -> Self {
+            self.status = Some(s);
+            self
+        }
+        fn left(mut self, n: &'static str) -> Self {
+            self.left = Some(n);
+            self
+        }
+        fn right(mut self, n: &'static str) -> Self {
+            self.right = Some(n);
+            self
+        }
+        fn query(mut self, q: &str) -> Self {
+            self.query = Some(q.to_string());
+            self
+        }
+        /// Stamp the node with an `execution_id` whose second "::"-token is `gen`.
+        fn gen(mut self, exec_id: &str) -> Self {
+            self.status_details = Some(format!(r#"{{"execution_id":"{exec_id}"}}"#));
+            self
+        }
+    }
+
+    impl NodeFacts for TestNode {
+        fn node_type(&self) -> &str {
+            self.node_type
+        }
+        fn query(&self) -> Option<&str> {
+            self.query.as_deref()
+        }
+        fn left_node(&self) -> Option<&str> {
+            self.left
+        }
+        fn right_node(&self) -> Option<&str> {
+            self.right
+        }
+        fn status(&self) -> Option<&str> {
+            self.status
+        }
+        fn status_details(&self) -> Option<&str> {
+            self.status_details.as_deref()
+        }
+    }
+
+    fn graph(nodes: Vec<(&'static str, TestNode)>) -> HashMap<String, TestNode> {
+        nodes
+            .into_iter()
+            .map(|(id, n)| (id.to_string(), n))
+            .collect()
+    }
+
+    fn status_of<'a>(out: &'a HashMap<String, Inferred>, id: &str) -> &'a str {
+        out.get(id)
+            .map(|i| i.status.as_str())
+            .unwrap_or("<missing>")
+    }
+
+    #[test]
+    fn untaken_if_arm_is_skipped() {
+        // if(true): then-arm runs, else-arm is never taken -> skipped, decided by IF.
+        let g = graph(vec![
+            (
+                "if",
+                TestNode::new("IF")
+                    .query(r#"{"condition_node":"cond"}"#)
+                    .left("then")
+                    .right("else")
+                    .status("completed")
+                    .gen("i::1"),
+            ),
+            ("cond", TestNode::new("SQL").status("completed").gen("i::1")),
+            ("then", TestNode::new("SQL").status("completed").gen("i::1")),
+            ("else", TestNode::new("SQL").status("pending")),
+        ]);
+
+        let out = infer_statuses(Some("if"), &g);
+
+        assert_eq!(status_of(&out, "then"), "completed");
+        assert_eq!(status_of(&out, "else"), "skipped");
+        assert_eq!(
+            out.get("else").unwrap().from_ancestor_id.as_deref(),
+            Some("if")
+        );
+    }
+
+    #[test]
+    fn right_of_failed_then_is_skipped() {
+        // left of a THEN fails -> the THEN fails and the right side never runs -> skipped.
+        let g = graph(vec![
+            (
+                "then",
+                TestNode::new("THEN")
+                    .left("a")
+                    .right("b")
+                    .status("failed")
+                    .gen("i::1"),
+            ),
+            ("a", TestNode::new("SQL").status("failed").gen("i::1")),
+            ("b", TestNode::new("SQL").status("pending")),
+        ]);
+
+        let out = infer_statuses(Some("then"), &g);
+
+        assert_eq!(status_of(&out, "a"), "failed");
+        assert_eq!(status_of(&out, "b"), "skipped");
+        assert_eq!(
+            out.get("b").unwrap().from_ancestor_id.as_deref(),
+            Some("then")
+        );
+    }
+
+    #[test]
+    fn race_loser_is_skipped() {
+        // RACE resolves: the winner completes, the still-running loser -> skipped.
+        let g = graph(vec![
+            (
+                "race",
+                TestNode::new("RACE")
+                    .left("win")
+                    .right("lose")
+                    .status("completed")
+                    .gen("i::1"),
+            ),
+            ("win", TestNode::new("SQL").status("completed").gen("i::1")),
+            ("lose", TestNode::new("SLEEP").status("running").gen("i::1")),
+        ]);
+
+        let out = infer_statuses(Some("race"), &g);
+
+        assert_eq!(status_of(&out, "win"), "completed");
+        assert_eq!(status_of(&out, "lose"), "skipped");
+        assert_eq!(
+            out.get("lose").unwrap().from_ancestor_id.as_deref(),
+            Some("race")
+        );
+    }
+
+    #[test]
+    fn clean_sequence_inferred_matches_physical() {
+        // A fully-completed sequence: nothing is skipped, inferred == physical.
+        let g = graph(vec![
+            (
+                "then",
+                TestNode::new("THEN")
+                    .left("a")
+                    .right("b")
+                    .status("completed")
+                    .gen("i::1"),
+            ),
+            ("a", TestNode::new("SQL").status("completed").gen("i::1")),
+            ("b", TestNode::new("SQL").status("completed").gen("i::1")),
+        ]);
+
+        let out = infer_statuses(Some("then"), &g);
+
+        for id in ["then", "a", "b"] {
+            assert_eq!(status_of(&out, id), "completed");
+            assert!(out.get(id).unwrap().from_ancestor_id.is_none());
+        }
+    }
+
+    #[test]
+    fn superseded_loop_body_subtree_is_all_pending() {
+        // Regression test: a loop has advanced to generation 2 (LOOP stamped i::2)
+        // while the entire previous-generation body subtree is still stamped i::1.
+        // Every superseded body node is about to re-run, so ALL of them must read
+        // `pending` — not just the top of the subtree. Before the fix the inner
+        // nodes were masked as `skipped` because their superseded THEN parent was
+        // wrongly used as a skip-deciding ancestor.
+        let g = graph(vec![
+            (
+                "loop",
+                TestNode::new("LOOP")
+                    .left("outer")
+                    .status("running")
+                    .gen("i::2"),
+            ),
+            (
+                "outer",
+                TestNode::new("THEN")
+                    .left("inner")
+                    .right("sleep2")
+                    .status("completed")
+                    .gen("i::1"),
+            ),
+            (
+                "inner",
+                TestNode::new("THEN")
+                    .left("sleep5")
+                    .right("insert")
+                    .status("completed")
+                    .gen("i::1"),
+            ),
+            (
+                "sleep5",
+                TestNode::new("SLEEP").status("completed").gen("i::1"),
+            ),
+            (
+                "insert",
+                TestNode::new("SQL").status("completed").gen("i::1"),
+            ),
+            (
+                "sleep2",
+                TestNode::new("SLEEP").status("completed").gen("i::1"),
+            ),
+        ]);
+
+        let out = infer_statuses(Some("loop"), &g);
+
+        for id in ["outer", "inner", "sleep5", "insert", "sleep2"] {
+            assert_eq!(
+                status_of(&out, id),
+                "pending",
+                "superseded body node {id} should read pending"
+            );
+        }
+    }
+
+    #[test]
+    fn current_generation_decider_still_skips_superseded_descendant() {
+        // Guard against over-correcting the fix: a terminal decider in the CURRENT
+        // generation (IF stamped i::2 that took the then-arm) must still mark its
+        // untaken else-arm `skipped`, even though that arm physically ran in an
+        // earlier generation (i::1) and is therefore superseded.
+        let g = graph(vec![
+            (
+                "loop",
+                TestNode::new("LOOP")
+                    .left("if")
+                    .status("running")
+                    .gen("i::2"),
+            ),
+            (
+                "if",
+                TestNode::new("IF")
+                    .query(r#"{"condition_node":"cond"}"#)
+                    .left("then")
+                    .right("else")
+                    .status("completed")
+                    .gen("i::2"),
+            ),
+            ("cond", TestNode::new("SQL").status("completed").gen("i::2")),
+            ("then", TestNode::new("SQL").status("completed").gen("i::2")),
+            // else ran in the previous iteration, now untaken in the current one.
+            ("else", TestNode::new("SQL").status("completed").gen("i::1")),
+        ]);
+
+        let out = infer_statuses(Some("loop"), &g);
+
+        assert_eq!(status_of(&out, "then"), "completed");
+        assert_eq!(status_of(&out, "else"), "skipped");
+        assert_eq!(
+            out.get("else").unwrap().from_ancestor_id.as_deref(),
+            Some("if")
+        );
+    }
+}

--- a/src/orchestrations/execute_function_graph.rs
+++ b/src/orchestrations/execute_function_graph.rs
@@ -309,6 +309,24 @@ pub async fn execute_subtree(
         .map_err(|e| format!("Failed to serialize subtree envelope: {e}"))
 }
 
+/// Compose the deterministic instance id for a JOIN/RACE branch sub-orchestration.
+///
+/// `schedule_sub_orchestration_with_id` uses this value verbatim (no parent prefix), so we
+/// build `{parent_instance_id}::{parent_execution_id}::{child_root_node_id}`. This guarantees
+/// (a) the second `::`-token is always the ROOT loop generation — the parent instance id
+/// already begins with `{df_instance_id}::{generation}` at every nesting level, so the
+/// generation token survives nesting; and (b) per-iteration uniqueness — the parent execution
+/// id advances on every loop `continue_as_new`, while the child root node id distinguishes
+/// sibling branches. df.instance_nodes() and the write fence both rely on that second token.
+fn subtree_instance_id(ctx: &OrchestrationContext, child_root_node_id: &str) -> String {
+    format!(
+        "{}::{}::{}",
+        ctx.instance_id(),
+        ctx.execution_id(),
+        child_root_node_id
+    )
+}
+
 /// Recursively execute function nodes with vars support
 async fn execute_function_node_with_vars(
     ctx: &OrchestrationContext,
@@ -327,11 +345,22 @@ async fn execute_function_node_with_vars(
         node_id, node.node_type
     ));
 
+    // Stamp identifying which orchestration generation is transitioning this
+    // node: "{orchestration_instance_id}::{execution_id}". For the root
+    // orchestration this is "{df_instance_id}::{loop_generation}"; for a JOIN/RACE
+    // sub-orchestration the instance id already carries the composed lineage (see
+    // `subtree_instance_id`), so the second "::"-token is always the root loop
+    // generation. df.instance_nodes() parses that token to derive pending/skipped
+    // and update_node_status uses it to fence stale writes. Both reads are
+    // deterministic (instance_id/execution_id are stable within an execution).
+    let execution_stamp = format!("{}::{}", ctx.instance_id(), ctx.execution_id());
+
     // Mark node as running
     let running_input = serde_json::json!({
         "node_id": node_id,
         "instance_id": graph.instance_id,
-        "status": "running"
+        "status": "running",
+        "execution_id": execution_stamp,
     });
     let _ = ctx
         .schedule_activity(
@@ -357,6 +386,7 @@ async fn execute_function_node_with_vars(
         "instance_id": graph.instance_id,
         "status": status,
         "result": status_result,
+        "execution_id": execution_stamp,
     });
     let _ = ctx
         .schedule_activity(
@@ -918,8 +948,13 @@ async fn execute_join_node(
     })
     .to_string();
 
-    // Build list of branch inputs
-    let mut branch_inputs = vec![left_input, right_input];
+    // Build list of branch inputs, each paired with its branch root node id so the
+    // sub-orchestration can be scheduled with a deterministic, generation-stamped
+    // instance id (see `subtree_instance_id`).
+    let mut branch_inputs: Vec<(String, String)> = vec![
+        (left_id.clone(), left_input),
+        (right_id.clone(), right_input),
+    ];
 
     // Check for extra nodes (join3)
     if let Some(config_str) = &node.query {
@@ -935,17 +970,23 @@ async fn execute_join_node(
                             "label": exec_ctx.label
                         })
                         .to_string();
-                        branch_inputs.push(extra_input);
+                        branch_inputs.push((extra_id.to_string(), extra_input));
                     }
                 }
             }
         }
     }
 
-    // Schedule sub-orchestrations and collect DurableFutures
+    // Schedule sub-orchestrations and collect DurableFutures. Each branch gets a
+    // deterministic `{parent}::{generation}::{branch_root}` instance id so its node
+    // stamps carry the root loop generation and remain unique across loop iterations.
     let mut durable_futures = Vec::new();
-    for input in branch_inputs {
-        let fut = ctx.schedule_sub_orchestration(SUBTREE_NAME, input);
+    for (child_root, input) in branch_inputs {
+        let fut = ctx.schedule_sub_orchestration_with_id(
+            SUBTREE_NAME,
+            subtree_instance_id(ctx, &child_root),
+            input,
+        );
         durable_futures.push(fut);
     }
 
@@ -1037,9 +1078,19 @@ async fn execute_race_node(
     })
     .to_string();
 
-    // Schedule sub-orchestrations
-    let left_fut = ctx.schedule_sub_orchestration(SUBTREE_NAME, left_input);
-    let right_fut = ctx.schedule_sub_orchestration(SUBTREE_NAME, right_input);
+    // Schedule sub-orchestrations with deterministic, generation-stamped instance
+    // ids so each branch's node stamps carry the root loop generation (see
+    // `subtree_instance_id`).
+    let left_fut = ctx.schedule_sub_orchestration_with_id(
+        SUBTREE_NAME,
+        subtree_instance_id(ctx, left_id),
+        left_input,
+    );
+    let right_fut = ctx.schedule_sub_orchestration_with_id(
+        SUBTREE_NAME,
+        subtree_instance_id(ctx, right_id),
+        right_input,
+    );
 
     // Use ctx.select2() - first to complete wins
     // select2 now returns Either2<Left, Right> instead of (winner_idx, DurableOutput)

--- a/tests/e2e/sql/53_inferred_status.sql
+++ b/tests/e2e/sql/53_inferred_status.sql
@@ -1,0 +1,160 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the PostgreSQL License.
+
+-- Tests: df.instance_nodes() derived `inferred_status` column.
+--   1. Untaken df.if() arm           --> inferred_status = 'skipped'
+--   2. Right side of a failed df.then() (~>) --> inferred_status = 'skipped'
+--   3. Fully-completed sequence       --> no 'skipped', inferred matches physical status
+SET SESSION AUTHORIZATION df_e2e_user;
+
+-- === Test 1: untaken IF arm is reported as skipped ===
+
+CREATE TEMP TABLE _test_state (instance_id TEXT);
+
+-- Condition is true, so the THEN arm runs and the ELSE arm is never executed.
+INSERT INTO _test_state SELECT df.start(
+    df.if('SELECT true', 'SELECT 1', 'SELECT 2'),
+    'test-inferred-if'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    skipped_count INT;
+    skipped_physical TEXT;
+    skipped_ancestor TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+    SELECT df.await_instance(inst_id) INTO status;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [if]: status = %', status;
+    END IF;
+
+    -- Exactly one node (the untaken ELSE arm) must be inferred as skipped.
+    SELECT count(*) INTO skipped_count
+    FROM df.instance_nodes(inst_id)
+    WHERE inferred_status = 'skipped';
+
+    IF skipped_count != 1 THEN
+        RAISE EXCEPTION 'TEST FAILED [if]: expected exactly 1 skipped node, got %', skipped_count;
+    END IF;
+
+    -- The skipped node never physically ran and points at an ancestor.
+    SELECT n.status, n.inferred_status_from_ancestor_id
+      INTO skipped_physical, skipped_ancestor
+    FROM df.instance_nodes(inst_id) n
+    WHERE n.inferred_status = 'skipped';
+
+    IF skipped_physical != 'pending' THEN
+        RAISE EXCEPTION 'TEST FAILED [if]: skipped node physical status = % (expected pending)', skipped_physical;
+    END IF;
+
+    IF skipped_ancestor IS NULL THEN
+        RAISE EXCEPTION 'TEST FAILED [if]: skipped node has NULL inferred_status_from_ancestor_id';
+    END IF;
+
+    -- df.explain() shares the same inference and must render the skipped marker (⊘).
+    IF df.explain(inst_id) NOT LIKE '%⊘%' THEN
+        RAISE EXCEPTION 'TEST FAILED [if]: df.explain() did not show the skipped (⊘) marker: %', df.explain(inst_id);
+    END IF;
+
+    RAISE NOTICE 'TEST PASSED: inferred_status if-untaken-skipped';
+END $$;
+
+DROP TABLE _test_state;
+
+-- === Test 2: right side of a failed df.then() is reported as skipped ===
+
+CREATE TEMP TABLE _test_state (instance_id TEXT);
+
+-- Left node divides by zero and fails; the right node must never run.
+INSERT INTO _test_state SELECT df.start(
+    'SELECT 1/0' ~> 'SELECT 42',
+    'test-inferred-then-fail'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    failed_inferred TEXT;
+    skipped_count INT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+    SELECT df.await_instance(inst_id) INTO status;
+
+    IF lower(status) != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [then-fail]: status = %', status;
+    END IF;
+
+    -- The failing node keeps its physical 'failed' status.
+    SELECT n.inferred_status INTO failed_inferred
+    FROM df.instance_nodes(inst_id) n
+    WHERE n.status = 'failed';
+
+    IF failed_inferred != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [then-fail]: failing node inferred_status = % (expected failed)', failed_inferred;
+    END IF;
+
+    -- The right (never-run) node is reported as skipped.
+    SELECT count(*) INTO skipped_count
+    FROM df.instance_nodes(inst_id)
+    WHERE inferred_status = 'skipped';
+
+    IF skipped_count != 1 THEN
+        RAISE EXCEPTION 'TEST FAILED [then-fail]: expected exactly 1 skipped node, got %', skipped_count;
+    END IF;
+
+    RAISE NOTICE 'TEST PASSED: inferred_status then-failure-skipped';
+END $$;
+
+DROP TABLE _test_state;
+
+-- === Test 3: fully-completed sequence has no skipped nodes ===
+
+CREATE TEMP TABLE _test_state (instance_id TEXT);
+
+INSERT INTO _test_state SELECT df.start(
+    'SELECT 1' ~> 'SELECT 2',
+    'test-inferred-seq-ok'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    skipped_count INT;
+    mismatch_count INT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_state;
+    SELECT df.await_instance(inst_id) INTO status;
+
+    IF lower(status) != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [seq-ok]: status = %', status;
+    END IF;
+
+    SELECT count(*) INTO skipped_count
+    FROM df.instance_nodes(inst_id)
+    WHERE inferred_status = 'skipped';
+
+    IF skipped_count != 0 THEN
+        RAISE EXCEPTION 'TEST FAILED [seq-ok]: expected 0 skipped nodes, got %', skipped_count;
+    END IF;
+
+    -- For a clean completion, inferred_status mirrors the physical status.
+    SELECT count(*) INTO mismatch_count
+    FROM df.instance_nodes(inst_id) n
+    WHERE n.status IS NOT NULL AND n.inferred_status != n.status;
+
+    IF mismatch_count != 0 THEN
+        RAISE EXCEPTION 'TEST FAILED [seq-ok]: % nodes have inferred_status != status', mismatch_count;
+    END IF;
+
+    RAISE NOTICE 'TEST PASSED: inferred_status completed-sequence';
+END $$;
+
+DROP TABLE _test_state;
+
+SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## Summary

Implements read-time node-status inference for `pg_durable` so that
`df.instance_nodes()` and `df.explain()` report structure-aware statuses for each
node, including branches that were never taken and nodes superseded by later loop
iterations.

The implementation keeps the physical node statuses as `pending`, `running`,
`completed`, and `failed`. Derived statuses such as `skipped`, and loop
re-entry-as-`pending`, are computed from graph structure plus each node's
`status_details.execution_id` lineage.

## What changed

**Schema**
- Adds a nullable `df.nodes.status_details` JSONB column holding the worker-written
  `{"execution_id": "<instance::generation[::...]>"}` stamp. The column is added
  for fresh installs in `src/lib.rs` and for existing installs through the
  `0.2.3 -> 0.2.4` upgrade script.

**Write path**
- Stamps each running and terminal node transition with deterministic execution
  lineage.
- Applies a monotonic generation fence so stale updates from superseded
  older-generation executions cannot overwrite newer node state.
- Keeps the new `.so` compatible with older schemas that do not yet have
  `df.nodes.status_details` by probing for the column at runtime.

**Read path**
- `df.instance_nodes(instance_id)` returns one row per node with stored physical
  status plus `status_details`, `inferred_status`, and
  `inferred_status_from_ancestor_id`.
- `inferred_status` is derived by walking the graph from the root:
  - a non-terminal node under a terminal ancestor reads as `skipped`;
  - a node from a prior loop iteration reads as `pending` because it will re-run;
  - a node that physically ran in the current generation keeps its stored status.
- `df.explain(instance_id)` uses the same inference helper so the tree view agrees
  with `df.instance_nodes()`.
- `df.instance_nodes(text, integer)` remains callable for old schemas and upgraded
  callers as a shape-compatible adapter. It no longer queries execution history,
  ignores `last_n_executions`, and returns one row per node with `execution_id = 1`.

## Tests & docs

- Adds `tests/e2e/sql/53_inferred_status.sql` covering untaken `df.if()` arms,
  failed `df.then()` downstream nodes, clean sequences, and `df.explain()` output.
- Updates `USER_GUIDE.md`, `docs/api-reference.md`, and the `pg-durable-sql` skill
  for the inferred-status model and the new primary `df.instance_nodes()` shape.

## Related issues

- **#171**: race-loser nodes are addressed from a reporting perspective. The
  abandoned RACE arm now reads as `skipped` via `inferred_status`; the physical
  `df.nodes.status` remains unchanged.
- **#240**: the right side of a failed `df.then()` now reads as `skipped`.

## Upgrade & migration

- The `0.2.3 -> 0.2.4` script adds `df.nodes.status_details` and recreates
  `df.instance_nodes()` so upgraded schemas match fresh installs.
- The new binary remains compatible with previous `0.2.x` schemas before
  `ALTER EXTENSION UPDATE`: write/read paths avoid referencing `status_details`
  when the column is absent, and the old two-argument `df.instance_nodes()` symbol
  remains callable.
- Drain in-flight instances before upgrading. The worker now records execution
  stamps in activity inputs, and duroxide compares recorded activity inputs by
  exact equality during replay.
