### PR TITLE
test: harden flaky 45_connection_limit_timeout e2e

### DIFF
--- a/tests/e2e/sql/45_connection_limit_timeout.sql
+++ b/tests/e2e/sql/45_connection_limit_timeout.sql
@@ -15,8 +15,26 @@ SELECT df.start(
     'test-timeout-blocker'
 ), 'blocker';
 
--- Give the blocker time to start executing and acquire the semaphore.
-SELECT pg_sleep(3);
+-- Wait until the blocker is actually running before starting the victim.
+DO $$
+DECLARE
+    blocker_id TEXT;
+    blocker_status TEXT;
+    attempts INT := 0;
+BEGIN
+    SELECT instance_id INTO blocker_id FROM _test_state WHERE label = 'blocker';
+
+    LOOP
+        SELECT s INTO blocker_status FROM df.status(blocker_id) s;
+        EXIT WHEN lower(blocker_status) = 'running' OR attempts >= 100;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF lower(blocker_status) != 'running' THEN
+        RAISE EXCEPTION 'TEST FAILED: blocker did not reach running state, got status = %', blocker_status;
+    END IF;
+END $$;
 
 -- Now start a second workflow. With max_user_connections=1, its SQL node
 -- cannot acquire the semaphore and should time out after ~2s.
@@ -33,6 +51,8 @@ DECLARE
     blocker_status TEXT;
     victim_status TEXT;
     victim_output TEXT;
+    node_result TEXT;
+    attempts INT := 0;
 BEGIN
     SELECT instance_id INTO blocker_id FROM _test_state WHERE label = 'blocker';
     SELECT instance_id INTO victim_id FROM _test_state WHERE label = 'victim';
@@ -44,12 +64,26 @@ BEGIN
         RAISE EXCEPTION 'TEST FAILED: victim status = %, expected failed', victim_status;
     END IF;
 
-    -- Verify the error message mentions connection limit
-    SELECT output INTO victim_output
-    FROM df.instance_info(victim_id);
+    -- Status becomes visible via df.instances before the failure payload is always
+    -- available through df.instance_info(), so poll briefly and fall back to the
+    -- SQL node result if needed.
+    LOOP
+        SELECT output INTO victim_output
+        FROM df.instance_info(victim_id);
+
+        SELECT result::text INTO node_result
+        FROM df.nodes
+        WHERE instance_id = victim_id AND node_type = 'SQL';
+
+        EXIT WHEN victim_output IS NOT NULL OR node_result IS NOT NULL OR attempts >= 50;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    victim_output := COALESCE(victim_output, node_result);
 
     IF victim_output IS NULL THEN
-        RAISE EXCEPTION 'TEST FAILED: victim output is NULL';
+        RAISE EXCEPTION 'TEST FAILED: victim output is NULL (status = %)', victim_status;
     END IF;
 
     IF victim_output NOT LIKE '%connection limit reached%' THEN


### PR DESCRIPTION
## Summary

This PR hardens `45_connection_limit_timeout.sql` to reduce spurious CI failures in the connection-limit timeout E2E test.

## Flakiness observed in CI

Over the last week of `CI` workflow runs on pushes to `main`, `45_connection_limit_timeout.sql` failed repeatedly with:

```text
TEST FAILED: victim output is NULL
```

The failure pattern was consistent with a timing race in the test rather than a product correctness bug:

- the test waited for terminal status via `df.await_instance(victim_id, 30)`
- then immediately read `df.instance_info(victim_id).output`
- `df.await_instance()` observes status through `df.instances`
- `df.instance_info()` gets status from `df.instances` but gets `output` from the duroxide provider path

That means CI could legitimately observe:

- `victim_status = failed`
- `victim_output IS NULL`

for a short window, even when the timeout failure had already occurred.

The test also used a fixed `pg_sleep(3)` to assume the blocker had acquired the only execution slot, which is another avoidable timing assumption under CI load.

## What changed

1. Replaced the fixed blocker sleep with a polling loop that waits until the blocker instance is actually `running` before starting the victim.
2. After the victim reaches `failed`, the test now polls briefly for a failure payload.
3. While waiting for the monitoring path to populate, the test falls back to the persisted SQL node result from `df.nodes`.

This keeps the test aligned with its original intent:

- verify the victim fails under `max_user_connections = 1`
- verify the surfaced error mentions `connection limit reached`
- verify the surfaced error includes `max_user_connections=`

without assuming that all observability surfaces become consistent at the same instant.

## Why this approach

I did **not** switch the test entirely to `df.nodes.result`.

Instead, the test still prefers `df.instance_info().output` and only falls back to the node-level result when the cross-store timing race appears. That keeps the assertion close to the original user-facing monitoring path while reducing spurious failures.

## Validation

Validated locally with:

```bash
./scripts/test-e2e-local.sh 45_connection_limit_timeout
./scripts/test-e2e-local.sh 45_connection_limit_timeout 3
```

Observed results:

- single targeted run: passed
- repeated targeted run: 3/3 passed
