### PR TITLE
Fix N+1 in df.list_instances() with a batched instance-info lookup

### DIFF
--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -74,6 +74,26 @@ pub fn list_instances(
         return TableIterator::new(vec![]);
     }
 
+    // function_name, execution_count, and output live in duroxide's internal
+    // schema, which restricted session roles are not granted to read directly.
+    // The previous implementation called the duroxide Client once per instance
+    // (an N+1 of separate provider round-trips). Replace that loop with a single
+    // batched query that invokes duroxide-pg's published get_instance_info(TEXT)
+    // SQL function once per id via LATERAL — the same function the duroxide
+    // Client uses internally — rather than hand-joining duroxide's internal
+    // instances/executions tables. This keeps our dependency on duroxide's
+    // deliberate function contract instead of its internal table layout.
+    // KEEP IN SYNC: we read the function's `instance_id`, `orchestration_name`,
+    // `current_execution_id`, and `output` OUT columns; if duroxide-pg renames
+    // them this query must follow (grep the duroxide-pg migrations for
+    // "get_instance_info"). The lookup runs over a worker-credentialed connection
+    // — the same trust boundary the per-instance Client path used — so it is not
+    // subject to the calling role's privileges on the duroxide schema. The id set
+    // is still constrained to ids already RLS-filtered from df.instances above, so
+    // no cross-user data can leak. Status is taken from df.instances so all
+    // monitoring APIs agree on the status value.
+    let ids: Vec<String> = user_instances.iter().map(|(id, _, _)| id.clone()).collect();
+
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -82,32 +102,77 @@ pub fn list_instances(
         Err(_) => return TableIterator::new(vec![]),
     };
 
-    let results = rt.block_on(async {
-        let store = match new_backend_provider(&pg_conn_str, provider_schema).await {
-            Ok(s) => s,
-            Err(_) => return vec![],
+    let mut info_by_id = rt.block_on(async {
+        use sqlx::postgres::PgPoolOptions;
+        use std::collections::HashMap;
+
+        let mut info_by_id: HashMap<String, (String, i64, Option<String>)> = HashMap::new();
+
+        let pool = match PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&pg_conn_str)
+            .await
+        {
+            Ok(p) => p,
+            // A connection failure (e.g. duroxide store unreachable on a freshly
+            // initialized database) yields no duroxide info — every instance is
+            // skipped below, matching the previous provider-failure behavior. Warn
+            // so a silently-empty result is diagnosable rather than looking like
+            // "no instances".
+            Err(e) => {
+                pgrx::warning!("df.list_instances: could not connect to duroxide store: {e}");
+                return info_by_id;
+            }
         };
 
-        let client = Client::new(store);
+        // provider_schema is a trusted config value (see backend_duroxide_schema),
+        // so format! interpolation of the schema name is safe; the id set is bound
+        // as a text[] parameter and expanded with unnest. CROSS JOIN LATERAL drops
+        // ids the function returns no row for (instances not yet known to
+        // duroxide), preserving the prior skip-on-missing behavior.
+        let batch_sql = format!(
+            "SELECT gi.instance_id, gi.orchestration_name, gi.current_execution_id, gi.output \
+             FROM unnest($1::text[]) AS t(id) \
+             CROSS JOIN LATERAL {schema}.get_instance_info(t.id) AS gi",
+            schema = provider_schema
+        );
 
-        let mut rows = Vec::new();
-        // Only query duroxide for function_name, execution_count, and output.
-        // Status is read from df.instances (already fetched above) to ensure all
-        // monitoring APIs agree on the status value.
-        for (id, label, df_status) in &user_instances {
-            if let Ok(info) = client.get_instance_info(id).await {
-                rows.push((
-                    info.instance_id,
-                    label.clone(),
-                    info.orchestration_name,
-                    df_status.clone(),
-                    info.current_execution_id as i64,
-                    info.output,
-                ));
+        let rows = match sqlx::query_as::<_, (String, String, i64, Option<String>)>(&batch_sql)
+            .bind(&ids)
+            .fetch_all(&pool)
+            .await
+        {
+            Ok(rows) => rows,
+            // Best-effort: a duroxide lookup failure must not fail the whole
+            // listing (consistent with the other df monitoring functions), but
+            // surface it as a warning so a silently-empty result is diagnosable
+            // rather than looking like "no instances".
+            Err(e) => {
+                pgrx::warning!("df.list_instances: duroxide instance-info lookup failed: {e}");
+                Vec::new()
             }
+        };
+
+        for (id, function_name, execution_count, output) in rows {
+            info_by_id.insert(id, (function_name, execution_count, output));
         }
-        rows
+
+        info_by_id
     });
+
+    // Reassemble in df.instances order (created_at DESC). Instances with no
+    // corresponding duroxide row are intentionally skipped — same as the prior
+    // per-instance skip-on-error behavior, and consistent with df.instance_info(),
+    // which returns nothing for an instance duroxide does not (yet) know about. id
+    // is unique in df.instances, so remove() (a move, not a clone) is safe.
+    let results: Vec<(String, Option<String>, String, String, i64, Option<String>)> =
+        user_instances
+            .into_iter()
+            .filter_map(|(id, label, df_status)| {
+                let (function_name, execution_count, output) = info_by_id.remove(&id)?;
+                Some((id, label, function_name, df_status, execution_count, output))
+            })
+            .collect();
 
     TableIterator::new(results)
 }

--- a/tests/e2e/sql/05_monitoring_and_explain.sql
+++ b/tests/e2e/sql/05_monitoring_and_explain.sql
@@ -127,5 +127,107 @@ BEGIN
     RAISE NOTICE 'TEST PASSED: explain plain SQL';
 END $body$;
 
+-- === Test: multi-instance list ordering + list/instance_info equivalence ===
+-- Exercises the batched instance-info reassembly in df.list_instances(): start
+-- several same-user instances with distinct outputs, then assert (a) they appear
+-- newest-first (created_at DESC) in list_instances(), and (b) function_name,
+-- execution_count, and output for each agree with df.instance_info() (the
+-- per-instance path), proving the batch lookup reassembles the right metadata
+-- against the right id.
+
+CREATE TEMP TABLE _multi_state (n INT, instance_id TEXT);
+
+-- Start three instances in separate statements (separate transactions) with a
+-- short gap so created_at (DEFAULT now(), the transaction timestamp) is strictly
+-- increasing and the created_at DESC order is deterministic.
+INSERT INTO _multi_state SELECT 1, df.start('SELECT 1001', 'sf3-a');
+SELECT pg_sleep(0.05);
+INSERT INTO _multi_state SELECT 2, df.start('SELECT 1002', 'sf3-b');
+SELECT pg_sleep(0.05);
+INSERT INTO _multi_state SELECT 3, df.start('SELECT 1003', 'sf3-c');
+
+DO $multi$
+DECLARE
+    ids TEXT[];
+    expected_order TEXT[];
+    listed_order TEXT[];
+    rec RECORD;
+    li RECORD;
+    ii RECORD;
+    settled INT;
+    attempts INT := 0;
+BEGIN
+    -- Await all three to completion.
+    FOR rec IN SELECT instance_id FROM _multi_state LOOP
+        PERFORM df.await_instance(rec.instance_id);
+    END LOOP;
+
+    SELECT array_agg(instance_id ORDER BY n) INTO ids FROM _multi_state;
+    -- created_at DESC => most recently started first => reverse of start order.
+    SELECT array_agg(instance_id ORDER BY n DESC) INTO expected_order FROM _multi_state;
+
+    -- await_instance() returns when df.instances.status is terminal, but
+    -- duroxide's execution output can become visible a moment later. Both
+    -- monitoring paths (list_instances and instance_info) observe the same
+    -- eventual state, so wait until output has materialized for all three before
+    -- comparing snapshots, otherwise we would race the completion boundary.
+    LOOP
+        SELECT count(*) INTO settled
+        FROM df.list_instances()
+        WHERE list_instances.instance_id = ANY(ids) AND output IS NOT NULL;
+        EXIT WHEN settled = 3 OR attempts > 100;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+
+    IF settled <> 3 THEN
+        RAISE EXCEPTION 'TEST FAILED: only % of 3 instances have materialized output in list_instances()', settled;
+    END IF;
+
+    -- (a) Order of our three ids within list_instances() output. WITH ORDINALITY
+    -- numbers rows in the exact order the function emits them (the just-created
+    -- instances are newest, so they sort first under created_at DESC).
+    SELECT array_agg(instance_id ORDER BY ord) INTO listed_order
+    FROM df.list_instances()
+        WITH ORDINALITY AS t(instance_id, label, function_name, status, execution_count, output, ord)
+    WHERE t.instance_id = ANY(ids);
+
+    IF listed_order IS DISTINCT FROM expected_order THEN
+        RAISE EXCEPTION 'TEST FAILED: list_instances order % != expected created_at DESC order %',
+            listed_order, expected_order;
+    END IF;
+
+    -- (b) Per-instance equivalence between list_instances() and instance_info().
+    -- list_instances.execution_count maps to instance_info.current_execution_id.
+    -- Distinct outputs (1001/1002/1003) prove the batch reassembly maps each
+    -- instance's metadata back to the right id rather than scrambling rows.
+    FOR li IN
+        SELECT instance_id, function_name, execution_count, output
+        FROM df.list_instances()
+        WHERE list_instances.instance_id = ANY(ids)
+    LOOP
+        SELECT function_name, current_execution_id, output
+        INTO ii
+        FROM df.instance_info(li.instance_id);
+
+        IF ii.function_name IS DISTINCT FROM li.function_name THEN
+            RAISE EXCEPTION 'TEST FAILED: function_name mismatch for %: list=% info=%',
+                li.instance_id, li.function_name, ii.function_name;
+        END IF;
+        IF ii.current_execution_id IS DISTINCT FROM li.execution_count THEN
+            RAISE EXCEPTION 'TEST FAILED: execution_count mismatch for %: list=% info=%',
+                li.instance_id, li.execution_count, ii.current_execution_id;
+        END IF;
+        IF ii.output IS DISTINCT FROM li.output THEN
+            RAISE EXCEPTION 'TEST FAILED: output mismatch for %: list=% info=%',
+                li.instance_id, li.output, ii.output;
+        END IF;
+    END LOOP;
+
+    RAISE NOTICE 'TEST PASSED: multi-instance ordering + list/instance_info equivalence';
+END $multi$;
+
+DROP TABLE _multi_state;
+
 RESET SESSION AUTHORIZATION;
 SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## What

Replace the N+1 in `df.list_instances()` with a single batched lookup.

Previously `df.list_instances()`:
1. ran one RLS-filtered SPI query on `df.instances` (newest-first, limited), then
2. built a tokio runtime + duroxide `Client` and called `client.get_instance_info(id)` **once per row** — a separate round-trip per instance — only to read `orchestration_name` (→ `function_name`), `current_execution_id` (→ `execution_count`), and `output`.

Now step 2 is a **single** set-based query over the same worker-credentialed connection. Rather than hand-join duroxide's internal tables, it invokes duroxide-pg's **published** `get_instance_info(TEXT)` SQL function — the same function the duroxide `Client` calls internally — once per id via `CROSS JOIN LATERAL`:

```sql
SELECT gi.instance_id, gi.orchestration_name, gi.current_execution_id, gi.output
FROM unnest($1::text[]) AS t(id)
CROSS JOIN LATERAL <duroxide_schema>.get_instance_info(t.id) AS gi
```

The id set (`$1`) is exactly the RLS-filtered ids from step 1, bound as `text[]`. Depending on the published function's documented OUT columns (rather than duroxide's internal table layout) keeps our coupling on its deliberate contract. `CROSS JOIN LATERAL` returns no row for an id the function yields nothing for, so instances not yet known to duroxide are dropped — preserving the prior per-instance skip-on-missing behavior. Results are reassembled in the original `created_at DESC` order. `status` and `label` continue to come from `df.instances` (authoritative), so all three monitoring APIs still agree on status.

File: `src/monitoring.rs` (`list_instances` only).

## Why

This is **PR 3** of the agreed, incremental monitoring-functions plan on #167 (issues #87 and #146). Listing N instances previously issued 1 + N queries; for the paginated/external-client listing path (#146) that is the dominant cost. This collapses it to 2 queries total regardless of N.

### Design note (trust boundary)

The batched lookup runs over a **worker-credentialed** connection (`postgres_connection_string()`), the same trust boundary the original per-row `Client` path used — *not* SPI. `df.list_instances()` is `SECURITY INVOKER`, and the duroxide internal schema is not granted to ordinary session roles; routing the lookup through SPI would run it as the calling role and fail with `permission denied` for restricted users (e.g. under the RLS isolation policy). The result set is still constrained to ids already RLS-filtered from `df.instances`, so no cross-user data can leak — the security posture is identical to before.

## Upgrade & compatibility

- **Pure Rust query logic — no SQL/schema contract change.** No upgrade-script edit; `test-upgrade.sh` is not required.
- **Scenario B1:** The new `.so` calls duroxide-pg's published `get_instance_info(TEXT)` over the same worker connection the previous per-row `Client.get_instance_info` path used (its body *is* that lookup), so it works unchanged against all prior `df` schemas.
- No behavior or signature change to `df.list_instances()`: same columns, same `created_at DESC` ordering, same skip-on-missing semantics, same status source.

`0.2.4` is still unreleased, so there is no version bump.

## Testing

Extends `tests/e2e/sql/05_monitoring_and_explain.sql` with a multi-instance case that starts three same-user instances with distinct outputs and asserts (a) they list newest-first (`created_at DESC`) and (b) `function_name`, `execution_count`, and `output` for each agree with `df.instance_info()` — proving the batch lookup reassembles each instance's metadata against the right id rather than scrambling rows. Full suite: 37/37 e2e pass (incl. the RLS-isolation tests that previously caught the SPI trust-boundary regression), `cargo clippy` clean, `cargo fmt` clean.

## Scope

N+1 fix only — no change to the `df.list_instances()` signature, columns, or ordering. `label_filter` + keyset pagination and the truncation policy land in subsequent PRs per the plan.

cc @pinodeca
