### PR TITLE
docs: add targeted local testing guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,35 @@ Please do not report security vulnerabilities through public GitHub issues. Foll
 
 ## Development workflow
 
+### Targeted local checks
+
+For small changes, you do not need to run the entire E2E suite before opening a PR.
+Run the narrowest check that covers your change and include the command in the PR description.
+
+In a Codespace or VS Code Dev Container, Rust, pgrx, and PostgreSQL 17 are already installed. For most Rust changes, a useful minimal check is:
+
+```bash
+cargo fmt -p pg_durable -- --check
+cargo check --features pg17
+```
+
+For an E2E scenario, run the matching SQL test by filename prefix or name:
+
+```bash
+./scripts/test-e2e-local.sh --verbose 05_monitoring_and_explain
+```
+
+The local E2E script starts and stops PostgreSQL automatically. Use `--keep` if you want to inspect the database or logs after a failure:
+
+```bash
+./scripts/test-e2e-local.sh --keep --verbose 05_monitoring_and_explain
+tail -f ~/.pgrx/17.log
+```
+
+If you cannot run the targeted check locally, say so in the PR and CI will still run the full suite.
+
+### Full pre-PR checks
+
 Before opening a pull request, run the checks relevant to your change:
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a contributor-facing snippet for targeted local checks
- Document the minimal Rust checks for Codespaces/devcontainers
- Show how to run a single local E2E SQL test and keep PostgreSQL running for logs/debugging

## Validation

- `git diff --check`