### PR TITLE
ci(e2e-docker): skip 54_reconcile_orphans in Docker harness

### DIFF
--- a/scripts/test-e2e-docker.sh
+++ b/scripts/test-e2e-docker.sh
@@ -35,6 +35,11 @@ SKIP_TESTS=(
     "46_connection_limit_startup_validation"
     "47_http_dsl_disabled"
     "48_http_allow_all"
+    # Needs the "reconcile" phase GUCs (reconcile_interval=2, retention_days=0)
+    # so a pass acts within the 30s test window. The single fixed-config Docker
+    # container keeps the production defaults (reconcile_interval=3600,
+    # retention_days=30), under which the orphan is never reclaimed in time.
+    "54_reconcile_orphans"
 )
 
 # Defaults


### PR DESCRIPTION
## Problem

The nightly Docker E2E run has failed 2 days in a row at `54_reconcile_orphans`:

```
TEST FAILED [orphan_reclaimed]: reconciliation did not reclaim the df-less engine record
```

## Root cause

`scripts/test-e2e-docker.sh` runs **every test against a single container with fixed, production-default configuration**. Tests that need non-default startup GUCs are listed in `SKIP_TESTS` (superuser GUC, connection-limit, HTTP phases).

`54_reconcile_orphans` (added in #283) needs the `reconcile` phase GUCs — `pg_durable.reconcile_interval = 2` and `pg_durable.retention_days = 0` — which the local harness applies by rewriting `postgresql.conf` and restarting per phase. In the Docker container those GUCs stay at production defaults (`reconcile_interval = 3600`, `retention_days = 30`):

- The BGW arms its reconcile timer **once at startup** for 3600s, so no pass runs within the test's 30s poll window.
- Even a pass wouldn't reclaim a seconds-old orphan under a 30-day retention.

The GUCs can't be applied at runtime either (the reconcile cadence is computed once before the worker loop). PR CI passes because `ci.yml` uses the local harness that honors phases; only the nightly Docker run exercises this path.

PR #283 introduced a phase-specific test but didn't add it to the Docker skip list — matching when the nightly began failing.

## Fix

Add `54_reconcile_orphans` to `SKIP_TESTS` in `scripts/test-e2e-docker.sh`, consistent with the other phase-dependent tests.