### PR TITLE
chore: begin 0.2.5 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file. The format is b
 
 Pre-1.0 note: while `pg_durable` is in major version `0`, minor releases may include breaking changes.
 
+## [0.2.5] - Unreleased
+
 ## [0.2.4] - 2026-07-02
 
 Provider-line note: v0.2.4 stays in the `duroxide-pg` provider compatibility line, so the upgrade source is v0.2.3 (`sql/pg_durable--0.2.3--0.2.4.sql`).
@@ -11,7 +13,7 @@ Provider-line note: v0.2.4 stays in the `duroxide-pg` provider compatibility lin
 ### Added
 
 - **Instance retention/pruning (#265):** terminal instances are now pruned by a hard cap and a retention window, bounding unbounded growth of `df.instances`.
-- **`df.list_instances()` pagination & filtering (#278):** added a `label_filter`, keyset pagination (`after_cursor`/`next_cursor`), and `created_at`/`updated_at` timestamps to the result set.
+- **`df.list_instances()` pagination & filtering (#278):** added a `label_filter` and a paginated overload with keyset pagination (`after_cursor`/`next_cursor`) that also returns `created_at`/`completed_at` timestamps and a `next_cursor` column.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "pg_durable"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_durable"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "PostgreSQL"
 repository = "https://github.com/microsoft/pg_durable"

--- a/sql/pg_durable--0.2.4--0.2.5.sql
+++ b/sql/pg_durable--0.2.4--0.2.5.sql
@@ -1,0 +1,10 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the PostgreSQL License.
+
+-- pg_durable upgrade: 0.2.4 → 0.2.5
+--
+-- See docs/upgrade-testing.md for the upgrade-script and backward-compatibility
+-- requirements (Scenario A / B1 / B2).
+--
+-- No schema changes yet for 0.2.5. Add DDL below as the 0.2.5 cycle lands
+-- extension-schema changes.


### PR DESCRIPTION
Opens the 0.2.5 development cycle now that **v0.2.4** is released (https://github.com/microsoft/pg_durable/releases/tag/v0.2.4).

## Changes
- Bump version `0.2.4` → `0.2.5` (`Cargo.toml`, `Cargo.lock`)
- Add no-op upgrade stub `sql/pg_durable--0.2.4--0.2.5.sql` (DDL to be added as the cycle lands schema changes)
- Add `## [0.2.5] - Unreleased` changelog placeholder
- Fix the shipped `[0.2.4]` changelog wording for `df.list_instances()` — `updated_at` → `completed_at` and clarify the paginated overload / `next_cursor` column

Closes #296.
Wraps up the v0.2.4 release tracked in #286.