### PR TITLE
Switch Rust toolchain from nightly to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust nightly
+      - name: Install Rust stable
         run: |
-          rustup toolchain install nightly --profile minimal --component rustfmt
-          rustup default nightly
+          rustup toolchain install stable --profile minimal --component rustfmt
+          rustup default stable
 
       - name: Check formatting
         run: cargo fmt --package pg_durable -- --check
@@ -102,10 +102,10 @@ jobs:
           echo "Disk usage after cleanup"
           df -h
 
-      - name: Install Rust nightly
+      - name: Install Rust stable
         run: |
-          rustup toolchain install nightly --profile minimal --component clippy
-          rustup default nightly
+          rustup toolchain install stable --profile minimal --component clippy
+          rustup default stable
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -108,7 +108,7 @@ jobs:
             -v "$PWD:/work" \
             -w /work \
             --user root \
-            rustlang/rust:nightly-bookworm \
+            rust:bookworm \
             bash -euxo pipefail -c '
               export DEBIAN_FRONTEND=noninteractive
               apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 # Multi-stage build for pg_durable extension
 # Stage 1: Build the extension
-FROM rustlang/rust:nightly-bookworm AS builder
+FROM rust:bookworm AS builder
 
 # Install PostgreSQL 17 dev packages and build dependencies
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Each release also publishes source archives for building from source and a `SHA2
 ### Prerequisites
 
 - PostgreSQL 17 or 18
-- Rust (nightly)
+- Rust (stable)
 - [cargo-pgrx](https://github.com/pgcentralfoundation/pgrx) 0.16.1
 
 ### GitHub Codespace

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Switches the project from an unpinned nightly Rust toolchain to **stable**.

The project doesn't use any nightly-only features (no `#![feature(...)]` attributes, no unstable rustfmt options), yet CI and the release Docker builds pulled the *latest* nightly via `rustlang/rust:nightly-bookworm`. That inherited every upstream nightly regression — including a codegen **ICE** in `rustc 1.99.0-nightly (2026-07-25)` that crashed release builds of `tokio 1.53.1` and broke the Dependabot bump in #298.

## Changes

- **Add `rust-toolchain.toml`** pinning `channel = "stable"` with `rustfmt` + `clippy` components, for reproducible builds across local/CI/Docker.
- **`.github/workflows/ci.yml`** — format and test jobs install and default to `stable`.
- **`Dockerfile`** — build stage uses `rust:bookworm` (stable) instead of `rustlang/rust:nightly-bookworm`.
- **`.github/workflows/package-release.yml`** — package build container uses `rust:bookworm`.
- **`README.md`** — prerequisite updated to Rust (stable).

## Validation (stable 1.95.0)

- `cargo pgrx package` (release profile: `opt-level=3`, `lto="fat"`) — passes.
- `cargo clippy` — clean.
- `cargo fmt --check` — clean (no formatting drift vs. nightly rustfmt).
- `tokio 1.53.1` + `serde_json 1.0.151` (the versions from #298) compile cleanly in release mode — **no ICE**.

## Follow-up

After this merges, comment `@dependabot rebase` on #298 so it re-runs CI on the stable base and goes green.