### PR TITLE
docs: document how to detect signal waits, schedule waits, and timer waits on instances

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1556,6 +1556,54 @@ is what a previous iteration's stored `completed`/`failed` (or an in-flight
 `running`) *looks like* once a newer iteration supersedes it and has not yet
 re-reached the node.
 
+### Detecting What an Instance is Waiting On
+
+An instance with status `'running'` may be actively processing or blocked waiting for an external event (signal, schedule, or timer). Use `df.instance_nodes()` to inspect what an instance is waiting on.
+
+#### Waiting on Signals
+
+To check if an instance has active signal waits:
+
+```sql
+SELECT n.node_id,
+       n.query::jsonb->>'signal_name' AS signal_name,
+       n.inferred_status
+FROM df.instance_nodes('a1b2c3d4') AS n
+WHERE n.node_type = 'SIGNAL'
+  AND n.inferred_status = 'running';
+```
+
+**Key points:**
+- An instance can wait on **multiple signals simultaneously** (e.g., in parallel branches via `&` or `|`)
+- Each row represents one active signal wait
+- `inferred_status = 'running'` means the node is currently waiting (not completed or failed)
+- No rows means the instance is not currently blocked on any signals (it may still be `running` if other nodes are executing)
+
+#### Waiting on Schedules and Timers
+
+Similarly, detect timer and schedule waits:
+
+```sql
+-- Waiting on cron schedule
+SELECT n.node_id,
+       n.query::jsonb->>'cron_expr' AS cron_schedule,
+       n.inferred_status
+FROM df.instance_nodes('a1b2c3d4') AS n
+WHERE n.node_type = 'WAIT_SCHEDULE'
+  AND n.inferred_status = 'running';
+
+-- Waiting on timer (sleep)
+SELECT n.node_id,
+       n.query::text AS duration_seconds,
+       n.inferred_status
+FROM df.instance_nodes('a1b2c3d4') AS n
+WHERE n.node_type = 'SLEEP'
+  AND n.inferred_status = 'running';
+```
+
+This is useful for dashboards and operational queries that need to understand why a running instance is not making progress.
+
+---
 
 ### System Metrics (Explicit Grant Required)
 


### PR DESCRIPTION
Adds a new subsection 'Detecting What an Instance is Waiting On' in the Monitoring section of USER_GUIDE.md that explains how to query `df.instance_nodes()` to determine:

- If an instance is waiting on one or more signals
- If an instance is waiting on a cron schedule  
- If an instance is waiting on a timer (sleep)

This addresses issue #239 by providing users with an observable way to determine why a 'running' instance is not making progress, without requiring custom joins into df.nodes.

## Testing

All queries have been validated against a live PostgreSQL instance:

✅ **Signal waits detection** - Verified with parallel signal waits (approval & notification)
✅ **Timer waits detection** - Verified with SLEEP node (df.sleep operation)
✅ **Schedule waits detection** - Verified with WAIT_SCHEDULE node (cron expression)

## Implementation Notes

- Documents the use of `df.instance_nodes()` to inspect wait state
- Includes specific node types discovered during testing:
  - `SIGNAL` for df.wait_for_signal() operations
  - `SLEEP` for df.sleep() operations  
  - `WAIT_SCHEDULE` for df.wait_for_schedule() operations
- Explains that instances can wait on multiple signals simultaneously

Closes #239