### PR TITLE
docs: correct df.instance_nodes column types to TEXT

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1503,9 +1503,12 @@ SELECT * FROM df.instance_nodes('a1b2c3d4');
 
 - **`status`** — the status physically stored on the node: `pending`, `running`,
   `completed`, or `failed`.
+- **`result`** — JSON payload returned as text for compatibility. Cast when
+    using JSON operators: `result::jsonb->...`.
 - **`status_details`** — JSON execution metadata written by the worker (the
-  `execution_id` generation stamp). You normally do not read this directly; it is
-  what `inferred_status` is derived from.
+    `execution_id` generation stamp), returned as text for compatibility. Cast when
+    using JSON operators: `status_details::jsonb->...`. You normally do not read
+    this directly; it is what `inferred_status` is derived from.
 - **`inferred_status`** — the stored status reinterpreted top-down from the root
   node. It adds one derived value, **`skipped`**, and reconciles loop re-entry:
   - `skipped` — a node on a branch that was decided against and will not (further)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -416,11 +416,14 @@ Return columns:
 | `left_node` | TEXT | First child node id, or `NULL` |
 | `right_node` | TEXT | Second child node id, or `NULL` |
 | `status` | TEXT | **Physical** stored status: `pending`, `running`, `completed`, `failed` |
-| `result` | JSONB | Result/error payload for `completed`/`failed` nodes, else `NULL` |
-| `status_details` | JSONB | Worker-written node metadata (see below), or `NULL` if never transitioned |
+| `result` | TEXT | JSON text payload for `completed`/`failed` nodes, else `NULL` |
+| `status_details` | TEXT | JSON text metadata (see below), or `NULL` if never transitioned |
 | `inferred_status` | TEXT | **Derived** status: physical status plus `skipped`, and loop re-entry surfaced as `pending` |
 | `inferred_status_from_ancestor_id` | TEXT | Ancestor node id that drove a derived `skipped`/`pending`, or `NULL` |
 | `updated_at` | TIMESTAMPTZ | Last physical status change |
+
+`result` and `status_details` are returned as TEXT for compatibility. Cast to
+`jsonb` when you need JSON operators (for example, `status_details::jsonb->>'execution_id'`).
 
 **`status_details` JSON contract.** Written by the worker through the
 `update-node-status` activity and stored verbatim in `df.nodes.status_details`:
@@ -450,7 +453,7 @@ always agree.
 
 ```sql
 SELECT node_id, node_type, status AS physical, inferred_status,
-       status_details->>'execution_id' AS execution_id
+  status_details::jsonb->>'execution_id' AS execution_id
 FROM df.instance_nodes('a1b2c3d4')
 ORDER BY node_id;
 ```


### PR DESCRIPTION
## Problem

`df.instance_nodes()` documents `result` and `status_details` as `JSONB`, but
the function actually returns them as `TEXT`.

The values originate from genuine `JSONB` columns on `df.nodes`, but the
function explicitly casts them on the way out:

- `result::text` in the SPI projection (`src/monitoring.rs`)
- `"status_details::text"` returned by `status_details_select_expr`
  (`src/node_status.rs`)

This also made the documented example **non-functional**. `->>` is only defined
for `json`/`jsonb`, so copy-pasting the documented query:

```sql
SELECT status_details->>'execution_id' FROM df.instance_nodes('a1b2c3d4');
```

fails with `operator does not exist: text ->> unknown`.

## Changes

- `docs/api-reference.md`: column types for `result` and `status_details`
  corrected from `JSONB` to `TEXT`, with a note that they carry JSON text and
  need an explicit `::jsonb` cast for JSON operators.
- `docs/api-reference.md`: the example query now casts before extracting.
- `USER_GUIDE.md`: the Function Nodes column descriptions note the same cast
  requirement.

Documentation only — no code, schema, or upgrade-script changes.

## Follow-up (not in this PR)

Whether `TEXT` is the *right* return type is a separate question. The sibling
APIs (`df.result()`, `df.instance_info().output`) return TEXT because their
payload comes back from the duroxide runtime as an opaque string with no schema
guarantee. That reasoning does not apply here: these two columns come from real
`JSONB` columns whose contents are guaranteed well-formed, so the cast is pure
ceremony and converts an impossible failure into a possible one.

Changing it is a breaking signature change (`DROP FUNCTION` + `CREATE`, plus a
retained TEXT-returning wrapper symbol for Scenario B1 against frozen 0.2.2-0.2.4
schemas). Worth deciding while the 0.2.5 upgrade script is still open, since the
API is only one release old and the pre-1.0 breaking-change allowance goes away
at 1.0.

Closes #295
