### PR TITLE
Support http multipart/form-data uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1910,7 @@ dependencies = [
 name = "pg_durable"
 version = "0.2.5"
 dependencies = [
+ "base64",
  "bigdecimal",
  "chrono",
  "cron",
@@ -2412,6 +2429,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -3502,6 +3520,12 @@ name = "unescape"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,10 @@ chrono = "0.4"
 # tokio-native-tls). duroxide-pg also selects native-tls on the same resolved
 # reqwest version; Cargo feature unification merges them, so the whole graph
 # stays on native-tls with no rustls/ring/aws-lc in the tree.
-reqwest = { version = "0.13", default-features = false, features = ["json", "native-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "native-tls", "multipart"] }
+
+# For df.http_multipart() — base64-decodes part payloads carried in the config JSON.
+base64 = "0.22"
 
 # For duroxide tracing integration
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/docs/upgrade-testing.md
+++ b/docs/upgrade-testing.md
@@ -203,6 +203,13 @@ gate, so they never need to be added to the exclude list.
 Each schema-changing PR should add a section here documenting what changed,
 what the upgrade script handles, and any backward compatibility considerations.
 
+### v0.2.4 → v0.2.5
+
+#### Add `df.http_multipart()` for multipart/form-data uploads
+- **DDL change (df schema):** Adds a new node type `HTTP_MULTIPART` and a new `#[pg_extern(schema = "df")]` function `df.http_multipart(text, text, jsonb, jsonb, integer)`. The upgrade script `sql/pg_durable--0.2.4--0.2.5.sql` hand-writes the `CREATE FUNCTION ... LANGUAGE c AS 'MODULE_PATHNAME', 'http_multipart_wrapper'` (pgrx emits it for fresh installs from `src/dsl.rs`), re-adds the `nodes_node_type_chk` / `nodes_structure_chk` constraints and `df.ensure_durofut()` validator with `HTTP_MULTIPART` admitted, and re-emits `df.grant_usage()` / `df.revoke_usage()` so they GRANT/REVOKE `df.http_multipart()` alongside `df.http()`. The signature `df.grant_usage(text, boolean, boolean)` is unchanged.
+- **Grant gating:** `df.http_multipart()` rides on the existing `include_http => true` flag (HTTP egress is treated as one privilege). `REVOKE EXECUTE ... FROM PUBLIC` is added for `df.http_multipart()` at install/upgrade time, matching `df.http()`.
+- **Scenario B1 considerations:** The new `.so` adds the `http_multipart_wrapper` C symbol and a new activity `execute_multipart`. Pre-0.2.5 schemas have no catalog entry for `df.http_multipart` and no `HTTP_MULTIPART` rows, so a binary-only swap (no `ALTER EXTENSION UPDATE`) changes nothing for existing workflows — the new function and node type are simply absent until the customer upgrades. No existing symbol is removed or renamed.
+
 ### v0.2.3 → v0.2.4
 
 #### Simplify `df.grant_usage()` — drop the explicit function allowlist

--- a/scripts/run-pgspot.sh
+++ b/scripts/run-pgspot.sh
@@ -42,14 +42,18 @@ PGSPOT_ALLOW=(
   # example, `df.sql(...) ~> df.sql(...)`) so users do not need df in search_path.
   # pgspot reports the generated CREATE OPERATOR name as an unqualified object.
   '^PS017: Unqualified object reference: ~> at line [0-9]+$'
-  # Upgrade scripts CREATE OR REPLACE df.grant_usage()/df.revoke_usage() to
-  # migrate pre-existing installs. pgspot flags PS002 because a standalone
-  # upgrade script has no `CREATE SCHEMA df` to prove df is extension-owned (the
-  # install SQL does, so it is not flagged there). PostgreSQL 14.5+ blocks a
-  # CREATE OR REPLACE in an extension script that would replace a non-extension
-  # object, so this is safe. Scoped to these two functions only.
+  # Upgrade scripts CREATE OR REPLACE df.grant_usage()/df.revoke_usage()/
+  # df.ensure_durofut() to migrate pre-existing installs. pgspot flags PS002
+  # because a standalone upgrade script has no `CREATE SCHEMA df` to prove df is
+  # extension-owned (the install SQL does, so it is not flagged there).
+  # PostgreSQL 14.5+ blocks a CREATE OR REPLACE in an extension script that
+  # would replace a non-extension object, so this is safe. Scoped to these
+  # three functions only. ensure_durofut's PS005/PS001/PS017 are fixed at the
+  # source (its search_path omits df — see the function's NOTE comment), so
+  # only its inherent PS002 needs allowing.
   '^PS002: Unsafe function creation: df\.grant_usage\(p_role text,include_http boolean,with_grant boolean\) at line [0-9]+$'
   '^PS002: Unsafe function creation: df\.revoke_usage\(p_role text\) at line [0-9]+$'
+  '^PS002: Unsafe function creation: df\.ensure_durofut\(val text\) at line [0-9]+$'
 )
 
 # Whole codes to suppress globally (pgspot --ignore). Prefer PGSPOT_ALLOW. Empty.

--- a/sql/pg_durable--0.2.4--0.2.5.sql
+++ b/sql/pg_durable--0.2.4--0.2.5.sql
@@ -72,6 +72,12 @@ ALTER TABLE df.nodes
 -- Rejects JSON with unknown node_type values.
 -- NOTE: The valid node type list here must be kept in sync with
 -- VALID_NODE_TYPES in src/types.rs (the Rust constant is the canonical source).
+-- search_path omits df on purpose: the body only touches pg_catalog builtins
+-- (jsonb, ->>, <>) and the schema-qualified df.sql(), so df is not needed.
+-- Including df here makes pgspot deem the path insecure (an upgrade script has
+-- no CREATE SCHEMA df, so df is not provably extension-owned), which re-enables
+-- CVE-2018-1058-style search_path hijack warnings (PS005/PS001/PS017). The
+-- fresh-install DDL in src/lib.rs matches for upgrade parity (Scenario A).
 CREATE OR REPLACE FUNCTION df.ensure_durofut(val text) RETURNS text AS $$
 DECLARE
     node_type_val text;
@@ -100,7 +106,7 @@ BEGIN
     -- It's plain SQL, wrap it
     RETURN df.sql(val);
 END;
-$$ LANGUAGE plpgsql IMMUTABLE SET search_path = pg_catalog, df, pg_temp;
+$$ LANGUAGE plpgsql IMMUTABLE SET search_path = pg_catalog, pg_temp;
 
 -- ============================================================================
 -- Grant/revoke plumbing for df.http_multipart().

--- a/sql/pg_durable--0.2.4--0.2.5.sql
+++ b/sql/pg_durable--0.2.4--0.2.5.sql
@@ -3,8 +3,216 @@
 
 -- pg_durable upgrade: 0.2.4 → 0.2.5
 --
+-- Adds df.http_multipart() for multipart/form-data requests (file uploads,
+-- form posts). It builds an HTTP_MULTIPART node whose payload is a JSON array
+-- of parts (name / filename / content_type / data_b64); the execute_multipart
+-- activity base64-decodes each part and posts a reqwest::multipart::Form. The
+-- existing df.http() path is unchanged.
+--
+-- Security: df.http_multipart() is gated identically to df.http() — PUBLIC
+-- EXECUTE is revoked at upgrade time, and df.grant_usage() grants it only when
+-- include_http => true (HTTP egress is one privilege). The execute_multipart
+-- activity runs the same 4-layer gate as execute_http (privilege, scheme,
+-- allow-list, SSRF-safe DNS resolver, no redirects).
+--
 -- See docs/upgrade-testing.md for the upgrade-script and backward-compatibility
 -- requirements (Scenario A / B1 / B2).
+
+-- ============================================================================
+-- Register the new df.http_multipart() C function.
 --
--- No schema changes yet for 0.2.5. Add DDL below as the 0.2.5 cycle lands
--- extension-schema changes.
+-- pgrx emits this for fresh installs from the #[pg_extern] in src/dsl.rs; the
+-- upgrade script must create it explicitly so pre-existing installs gain the
+-- function on ALTER EXTENSION UPDATE. The C symbol http_multipart_wrapper is
+-- compiled into the new .so (matching the dsl::http_multipart Rust function).
+-- ============================================================================
+CREATE FUNCTION df."http_multipart"(
+    "url" TEXT,
+    "method" TEXT DEFAULT 'POST',
+    "parts" jsonb DEFAULT NULL,
+    "headers" jsonb DEFAULT NULL,
+    "timeout_seconds" INT DEFAULT 30
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'http_multipart_wrapper';
+
+-- ============================================================================
+-- Admit the HTTP_MULTIPART node type into the schema constraints and the
+-- df.ensure_durofut() validator. These mirror VALID_NODE_TYPES in src/types.rs
+-- (the Rust constant is the canonical source). The constraints are NOT VALID,
+-- so re-adding them does not rewrite existing rows.
+-- ============================================================================
+ALTER TABLE df.nodes DROP CONSTRAINT nodes_node_type_chk;
+ALTER TABLE df.nodes
+    ADD CONSTRAINT nodes_node_type_chk
+    CHECK (node_type OPERATOR(pg_catalog.=) ANY (ARRAY['SQL', 'THEN', 'IF', 'JOIN', 'LOOP', 'BREAK', 'RACE', 'SLEEP', 'WAIT_SCHEDULE', 'HTTP', 'HTTP_MULTIPART', 'SIGNAL'])) NOT VALID;
+
+ALTER TABLE df.nodes DROP CONSTRAINT nodes_structure_chk;
+ALTER TABLE df.nodes
+    ADD CONSTRAINT nodes_structure_chk
+    CHECK (
+        CASE
+            WHEN node_type OPERATOR(pg_catalog.=) ANY (ARRAY['SQL', 'SLEEP', 'WAIT_SCHEDULE', 'BREAK', 'HTTP', 'HTTP_MULTIPART', 'SIGNAL'])
+                THEN left_node IS NULL AND right_node IS NULL AND query IS NOT NULL
+            WHEN node_type OPERATOR(pg_catalog.=) 'THEN'
+                THEN left_node IS NOT NULL AND right_node IS NOT NULL AND query IS NULL
+            WHEN node_type OPERATOR(pg_catalog.=) 'IF'
+                THEN left_node IS NOT NULL AND right_node IS NOT NULL AND query IS NOT NULL
+            WHEN node_type OPERATOR(pg_catalog.=) 'LOOP'
+                THEN left_node IS NOT NULL AND right_node IS NULL
+            WHEN node_type OPERATOR(pg_catalog.=) 'JOIN'
+                THEN left_node IS NOT NULL AND right_node IS NOT NULL
+            WHEN node_type OPERATOR(pg_catalog.=) 'RACE'
+                THEN left_node IS NOT NULL AND right_node IS NOT NULL AND query IS NULL
+            ELSE FALSE
+        END
+    ) NOT VALID;
+
+-- Helper to ensure a value is a durofut (returns JSON string)
+-- Rejects JSON with unknown node_type values.
+-- NOTE: The valid node type list here must be kept in sync with
+-- VALID_NODE_TYPES in src/types.rs (the Rust constant is the canonical source).
+CREATE OR REPLACE FUNCTION df.ensure_durofut(val text) RETURNS text AS $$
+DECLARE
+    node_type_val text;
+BEGIN
+    -- Try to parse as JSON to check if it's already a durofut
+    BEGIN
+        node_type_val := (val::jsonb)->>'node_type';
+        IF node_type_val IS NOT NULL THEN
+            -- Has a node_type - validate it
+            IF node_type_val NOT IN ('SQL', 'THEN', 'IF', 'JOIN', 'LOOP', 'BREAK', 'RACE', 'SLEEP', 'WAIT_SCHEDULE', 'HTTP', 'HTTP_MULTIPART', 'SIGNAL') THEN
+                RAISE EXCEPTION 'Unknown node_type ''%''. Valid types: SQL, THEN, IF, JOIN, LOOP, BREAK, RACE, SLEEP, WAIT_SCHEDULE, HTTP, HTTP_MULTIPART, SIGNAL', node_type_val;
+            END IF;
+            RETURN val;
+        END IF;
+    EXCEPTION WHEN invalid_text_representation THEN
+        -- Not valid JSON, treat as SQL
+        NULL;
+    WHEN raise_exception THEN
+        -- Re-raise our validation error
+        RAISE;
+    WHEN OTHERS THEN
+        -- Not valid JSON, treat as SQL
+        NULL;
+    END;
+
+    -- It's plain SQL, wrap it
+    RETURN df.sql(val);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE SET search_path = pg_catalog, df, pg_temp;
+
+-- ============================================================================
+-- Grant/revoke plumbing for df.http_multipart().
+--
+-- grant_usage() / revoke_usage() are re-emitted in full so upgraded installs
+-- match fresh 0.2.5 installs (see src/lib.rs). The signature is unchanged
+-- (df.grant_usage(text, boolean, boolean)); http_multipart rides on the
+-- existing include_http flag.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION df.grant_usage(
+    p_role TEXT,
+    include_http boolean DEFAULT false,
+    with_grant boolean DEFAULT false
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $fn$
+DECLARE
+    grant_opt TEXT := '';
+BEGIN
+    IF with_grant THEN
+        grant_opt := ' WITH GRANT OPTION';
+    END IF;
+
+    -- Schema access — the access gate for ordinary df.* functions (see header).
+    EXECUTE pg_catalog.format('GRANT USAGE ON SCHEMA df TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+
+    -- df.http() — opt-in because it makes outbound network requests.
+    IF include_http THEN
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+        -- df.http_multipart() shares the same opt-in (HTTP egress is one privilege).
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.http_multipart(text, text, jsonb, jsonb, integer) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    END IF;
+
+    -- Admin helpers and system-wide metrics — with_grant => true marks a
+    -- pg_durable admin, so it also grants df.metrics() (cluster-wide aggregate
+    -- counts).
+    IF with_grant THEN
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.grant_usage(text, boolean, boolean) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.revoke_usage(text) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.metrics() TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    END IF;
+
+    -- Table privileges
+    EXECUTE pg_catalog.format('GRANT SELECT ON df.instances TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT UPDATE (status, updated_at) ON df.instances TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT SELECT ON df.nodes TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT INSERT (id, label, root_node, submitted_by, database) ON df.instances TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database) ON df.nodes TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+    EXECUTE pg_catalog.format('GRANT SELECT, INSERT, UPDATE, DELETE ON df.vars TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+
+    RAISE NOTICE 'pg_durable: granted df usage privileges to "%"', p_role;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION df.revoke_usage(p_role TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $fn$
+BEGIN
+    -- Mirror of df.grant_usage(): undo exactly what it grants. Revoking schema
+    -- USAGE is the access gate that locks the role out of ordinary df.*
+    -- functions; the sensitive functions and table privileges are undone below.
+    -- CASCADE also removes any sub-grants the role made via WITH GRANT OPTION.
+
+    -- Sensitive functions (granted explicitly by grant_usage()).  A delegated
+    -- admin may lack privilege on some of these (e.g. df.http); skip those.
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.metrics() FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.http_multipart(text, text, jsonb, jsonb, integer) FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.grant_usage(text, boolean, boolean) FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.revoke_usage(text) FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+
+    -- Table privileges.
+    -- Column-level revokes must match the column-level grants from grant_usage().
+    EXECUTE pg_catalog.format('REVOKE SELECT, INSERT, UPDATE, DELETE ON df.vars FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE INSERT (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database) ON df.nodes FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE SELECT ON df.nodes FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE INSERT (id, label, root_node, submitted_by, database) ON df.instances FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE UPDATE (status, updated_at) ON df.instances FROM %I CASCADE', p_role);
+    EXECUTE pg_catalog.format('REVOKE SELECT ON df.instances FROM %I CASCADE', p_role);
+
+    -- Schema access — the access gate for all ordinary df.* functions.
+    EXECUTE pg_catalog.format('REVOKE USAGE ON SCHEMA df FROM %I CASCADE', p_role);
+
+    RAISE NOTICE 'pg_durable: revoked df usage privileges granted by "%" from "%"', current_user, p_role;
+END;
+$fn$;
+
+-- df.http_multipart() is sensitive (network access), so revoke PostgreSQL's
+-- default PUBLIC EXECUTE — same treatment as df.http(). df.grant_usage()
+-- re-grants it explicitly to authorized roles (include_http => true).
+REVOKE EXECUTE ON FUNCTION df.http_multipart(text, text, jsonb, jsonb, integer) FROM PUBLIC;

--- a/src/activities/execute_http.rs
+++ b/src/activities/execute_http.rs
@@ -57,7 +57,7 @@ async fn check_http_privilege(pool: &PgPool, submitted_by: &str) -> Result<(), S
 /// could host a 302 redirecting to `http://169.254.169.254/...`, and reqwest
 /// would follow it without calling our DNS resolver (since the target is an IP
 /// literal).
-fn build_client(timeout: Duration) -> Result<reqwest::Client, String> {
+pub(crate) fn build_client(timeout: Duration) -> Result<reqwest::Client, String> {
     let builder = reqwest::Client::builder()
         .timeout(timeout)
         .user_agent(concat!("pg_durable/", env!("CARGO_PKG_VERSION")))

--- a/src/activities/execute_multipart.rs
+++ b/src/activities/execute_multipart.rs
@@ -1,0 +1,243 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the PostgreSQL License.
+
+//! ExecuteMultipart activity - makes multipart/form-data HTTP requests.
+//!
+//! This is the file-upload / form-post counterpart to `execute_http`. It shares
+//! the same security model (privilege check, scheme validation, Azure
+//! allow-list, SSRF-safe DNS resolver, no redirects) and reuses
+//! `execute_http::build_client` so the two paths cannot drift on client
+//! configuration. The only differences are the body construction (a
+//! `reqwest::multipart::Form` built from base64-encoded parts) and the
+//! privilege target (`df.http_multipart` instead of `df.http`).
+//!
+//! Cargo features controlling outbound HTTP(S) are the same as for df.http —
+//! see docs/http-security.md for the full security model.
+
+use base64::Engine as _;
+use duroxide::ActivityContext;
+use std::sync::Arc;
+use std::time::Duration;
+
+use sqlx::PgPool;
+
+use crate::activities::execute_http::build_client;
+use crate::types::MultipartConfig;
+
+/// Activity name for registration and scheduling
+pub const NAME: &str = "pg_durable::activity::execute-multipart";
+
+/// Check that `submitted_by` holds EXECUTE privilege on `df.http_multipart()`.
+///
+/// Mirrors `execute_http::check_http_privilege` — closes the bypass path where
+/// a user crafts a raw Durofut JSON and passes it directly to `df.start()`,
+/// inserting an HTTP_MULTIPART node without going through the DSL guard.
+async fn check_multipart_privilege(pool: &PgPool, submitted_by: &str) -> Result<(), String> {
+    let has_priv: Option<bool> = sqlx::query_scalar(
+        "SELECT has_function_privilege($1::regrole, \
+             'df.http_multipart(text,text,jsonb,jsonb,integer)'::regprocedure, \
+             'EXECUTE')",
+    )
+    .bind(submitted_by)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| format!("HTTP privilege check failed for role '{submitted_by}': {e}"))?;
+
+    match has_priv {
+        Some(true) => Ok(()),
+        _ => Err(format!(
+            "Blocked: role '{submitted_by}' does not have EXECUTE privilege on df.http_multipart(). \
+             Grant EXECUTE ON FUNCTION df.http_multipart(text,text,jsonb,jsonb,integer) TO {submitted_by} to allow multipart HTTP requests."
+        )),
+    }
+}
+
+/// Execute a multipart/form-data HTTP request and return the response as JSON
+pub async fn execute(
+    ctx: ActivityContext,
+    pool: Arc<PgPool>,
+    config_json: String,
+) -> Result<String, String> {
+    let config: MultipartConfig = serde_json::from_str(&config_json)
+        .map_err(|e| format!("Invalid multipart HTTP config: {e}"))?;
+
+    // Audit context — submitted_by is always set by the orchestration, but guard
+    // explicitly so a missing value produces a clear error.
+    let audit_user = config.submitted_by.as_deref().ok_or(
+        "Blocked: HTTP_MULTIPART node has no submitted_by \u{2014} cannot verify privilege",
+    )?;
+
+    // Validation chain — order is security-critical and mirrors execute_http:
+    //   0. Privilege: submitted_by must hold EXECUTE on df.http_multipart().
+    //   1. Scheme:    blocks file://, gopher://, etc.
+    //   2. Allowlist: blocks ALL bare IPs (public and private) + non-Azure
+    //                 domains. Fails-closed on malformed URLs.
+    //   3. DNS resolver (SsrfSafeResolver): catches DNS rebinding.
+
+    // --- Privilege check (Layer 0) ---
+    check_multipart_privilege(&pool, audit_user)
+        .await
+        .inspect_err(|_| {
+            ctx.trace_info(format!(
+                "HTTP_MULTIPART BLOCKED (privilege) url={} submitted_by={audit_user}",
+                config.url
+            ));
+        })?;
+
+    // --- Scheme validation (always enforced) ---
+    crate::ssrf::validate_url_scheme(&config.url).inspect_err(|_| {
+        ctx.trace_info(format!(
+            "HTTP_MULTIPART BLOCKED (scheme) url={} submitted_by={audit_user}",
+            config.url
+        ));
+    })?;
+
+    // --- Azure endpoint allow-list ---
+    crate::ssrf::validate_url_allowlist(&config.url).inspect_err(|_| {
+        ctx.trace_info(format!(
+            "HTTP_MULTIPART BLOCKED (allowlist) url={} submitted_by={audit_user}",
+            config.url
+        ));
+    })?;
+
+    let start = std::time::Instant::now();
+    ctx.trace_info(format!(
+        "HTTP_MULTIPART {} {} ({} parts) submitted_by={audit_user}",
+        config.method,
+        config.url,
+        config.parts.len()
+    ));
+
+    // Build client (shared SSRF-safe resolver + timeout) with execute_http.
+    let client = build_client(Duration::from_secs(config.timeout_seconds))?;
+
+    // Build request based on method. Multipart only makes sense for
+    // body-carrying methods; the DSL guard restricts to POST/PUT/PATCH and we
+    // defend in depth here.
+    let mut request = match config.method.as_str() {
+        "POST" => client.post(&config.url),
+        "PUT" => client.put(&config.url),
+        "PATCH" => client.patch(&config.url),
+        _ => {
+            return Err(format!(
+                "Unsupported HTTP method for multipart: {}",
+                config.method
+            ))
+        }
+    };
+
+    // Add headers — but NEVER Content-Type. reqwest sets
+    // `multipart/form-data; boundary=...` itself when .multipart() is called; a
+    // caller-supplied Content-Type would clobber the boundary and the server
+    // would receive an unparseable body.
+    if let Some(headers) = &config.headers {
+        if let Some(obj) = headers.as_object() {
+            for (key, value) in obj {
+                if key.eq_ignore_ascii_case("content-type") {
+                    continue;
+                }
+                if let Some(v) = value.as_str() {
+                    request = request.header(key, v);
+                }
+            }
+        }
+    }
+
+    // Build the multipart form from base64-encoded parts.
+    let mut form = reqwest::multipart::Form::new();
+    for part in &config.parts {
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&part.data_b64)
+            .map_err(|e| format!("Invalid base64 in part '{}': {e}", part.name))?;
+        let mut req_part = reqwest::multipart::Part::bytes(bytes);
+        if let Some(ct) = &part.content_type {
+            req_part = req_part
+                .mime_str(ct)
+                .map_err(|e| format!("Invalid content_type for part '{}': {e}", part.name))?;
+        }
+        if let Some(filename) = &part.filename {
+            req_part = req_part.file_name(filename.clone());
+        }
+        form = form.part(part.name.clone(), req_part);
+    }
+
+    // Execute request
+    let response = request.multipart(form).send().await.map_err(|e| {
+        let err_string = e.to_string();
+
+        // Detect SSRF IP-blocklist rejections from the resolver.
+        if crate::ssrf::is_ssrf_block_error(&err_string) {
+            ctx.trace_info(format!(
+                "HTTP_MULTIPART BLOCKED (ip) url={} submitted_by={audit_user}",
+                config.url
+            ));
+            return err_string;
+        }
+
+        let status_info = e
+            .status()
+            .map(|s| format!(" (HTTP {})", s.as_u16()))
+            .unwrap_or_default();
+
+        if e.is_timeout() {
+            format!(
+                "HTTP timeout after {}s{}: {}",
+                config.timeout_seconds, status_info, config.url
+            )
+        } else if e.is_connect() {
+            format!(
+                "HTTP connection failed{}: {} - {}",
+                status_info, config.url, e
+            )
+        } else {
+            format!("HTTP request failed{}: {} - {}", status_info, config.url, e)
+        }
+    })?;
+
+    let status = response.status();
+    let status_code = status.as_u16();
+
+    // Collect response headers
+    let response_headers: serde_json::Map<String, serde_json::Value> = response
+        .headers()
+        .iter()
+        .filter_map(|(k, v)| {
+            v.to_str()
+                .ok()
+                .map(|s| (k.to_string(), serde_json::Value::String(s.to_string())))
+        })
+        .collect();
+
+    let response_body = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read response body: {e}"))?;
+
+    let duration_ms = start.elapsed().as_millis() as u64;
+    let is_ok = status.is_success();
+
+    // Build response object — same envelope as execute_http.
+    let result = serde_json::json!({
+        "status": status_code,
+        "body": response_body,
+        "headers": response_headers,
+        "ok": is_ok,
+        "duration_ms": duration_ms
+    });
+
+    ctx.trace_info(format!(
+        "HTTP_MULTIPART {} completed: status={}, ok={}, duration={}ms",
+        config.method, status_code, is_ok, duration_ms
+    ));
+
+    // Fail on 5xx server errors (transient, should retry)
+    if status.is_server_error() {
+        return Err(format!(
+            "HTTP_MULTIPART {} {} returned {}: {}",
+            config.method, config.url, status_code, response_body
+        ));
+    }
+
+    // Return response for all other cases (including 4xx)
+    Ok(result.to_string())
+}

--- a/src/activities/mod.rs
+++ b/src/activities/mod.rs
@@ -7,6 +7,7 @@
 //! This enables IDE navigation (F12 jumps to implementation).
 
 pub mod execute_http;
+pub mod execute_multipart;
 pub mod execute_sql;
 pub mod load_function_graph;
 pub mod update_instance_status;

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -544,6 +544,95 @@ pub fn http(
     .to_json()
 }
 
+/// Creates a multipart/form-data HTTP request node (file uploads / form fields).
+///
+/// Each part in `parts` is a JSON object: `{"name": "...", "filename": "...",
+/// "content_type": "...", "data_b64": "..."}`. Only `name` and `data_b64`
+/// (base64-encoded payload) are required; `filename` and `content_type` are
+/// optional. The response shape and security model match `df.http`.
+///
+/// # Arguments
+/// * `url` - The URL to request. Supports $variable substitution
+/// * `method` - HTTP method (POST, PUT, PATCH). Default: POST
+/// * `parts` - JSONB array of part objects (see above)
+/// * `headers` - JSONB object of headers. Content-Type is ignored (multipart
+///   owns the boundary). Example: '{"Authorization": "Bearer token"}'
+/// * `timeout_seconds` - Request timeout in seconds. Default: 30
+///
+/// # Returns
+/// JSON object with: status, body, headers, ok (boolean), duration_ms
+#[pg_extern(schema = "df")]
+pub fn http_multipart(
+    url: &str,
+    method: default!(&str, "'POST'"),
+    // parts defaults to NULL solely to satisfy PostgreSQL's rule that every
+    // parameter after a defaulted one (method) must also have a default. A NULL
+    // parts list is rejected below — at least one part is required.
+    parts: default!(Option<pgrx::JsonB>, "NULL"),
+    headers: default!(Option<pgrx::JsonB>, "NULL"),
+    timeout_seconds: default!(i32, "30"),
+) -> String {
+    // Fail early when no http feature is compiled in — same guard as df.http.
+    if !crate::ssrf::http_enabled() {
+        pgrx::error!(
+            "df.http_multipart() is disabled. Rebuild with the 'http-allow-azure-domains' \
+             Cargo feature to enable outbound HTTP requests."
+        );
+    }
+
+    // Validate URL scheme at DSL time (skip when URL contains variable
+    // placeholders — substitution happens at execution time). Mirrors df.http.
+    if !url.contains('{') {
+        if let Err(e) = crate::ssrf::validate_url_scheme(url) {
+            pgrx::error!("{}", e);
+        }
+    }
+
+    // Validate method — multipart only makes sense for body-carrying methods.
+    let method_upper = method.to_uppercase();
+    if !["POST", "PUT", "PATCH"].contains(&method_upper.as_str()) {
+        pgrx::error!(
+            "Invalid HTTP method for multipart: {}. Must be POST, PUT, or PATCH",
+            method
+        );
+    }
+
+    if timeout_seconds <= 0 {
+        pgrx::error!("Timeout must be positive");
+    }
+
+    // parts is required — the NULL default is only there to keep the SQL
+    // signature valid (see the signature comment).
+    let parts_value = match &parts {
+        Some(p) => &p.0,
+        None => pgrx::error!("parts is required and cannot be NULL"),
+    };
+
+    // Validate parts is a non-empty array. Per-part shape is checked when the
+    // activity deserializes MultipartConfig.
+    let parts_arr = match parts_value.as_array() {
+        None => pgrx::error!("parts must be a JSON array of part objects"),
+        Some(arr) if arr.is_empty() => pgrx::error!("parts must contain at least one part"),
+        Some(arr) => arr,
+    };
+    let _ = parts_arr; // shape validated; activity re-parses from the JSON below
+
+    let config = serde_json::json!({
+        "url": url,
+        "method": method_upper,
+        "parts": parts_value,
+        "headers": headers.as_ref().map(|h| &h.0),
+        "timeout_seconds": timeout_seconds
+    });
+
+    Durofut {
+        node_type: "HTTP_MULTIPART".to_string(),
+        query: Some(config.to_string()),
+        ..Default::default()
+    }
+    .to_json()
+}
+
 // ============================================================================
 // Signals
 // ============================================================================

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -476,6 +476,7 @@ fn build_tree_recursive(
                     && seq_node.node_type != "SLEEP"
                     && seq_node.node_type != "WAIT_SCHEDULE"
                     && seq_node.node_type != "HTTP"
+                    && seq_node.node_type != "HTTP_MULTIPART"
                 {
                     let child_prefix = format!("{prefix}    ");
                     render_children(seq_node, nodes, &child_prefix, output, show_status);
@@ -695,7 +696,7 @@ fn format_node_display(node: &ExplainNode) -> String {
                 .unwrap_or_else(|| "?".to_string());
             format!("WAIT '{cron}'{name_suffix}")
         }
-        "HTTP" => {
+        "HTTP" | "HTTP_MULTIPART" => {
             // Parse config to get method and URL
             let (method, url) = node
                 .query
@@ -713,7 +714,7 @@ fn format_node_display(node: &ExplainNode) -> String {
                     (method.to_string(), display_url)
                 })
                 .unwrap_or_else(|| ("?".to_string(), "?".to_string()));
-            format!("HTTP {method} {url}{name_suffix}")
+            format!("{} {method} {url}{name_suffix}", node.node_type)
         }
         "SIGNAL" => {
             // Parse config to get signal name and timeout

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,7 +791,7 @@ BEGIN
     -- It's plain SQL, wrap it
     RETURN df.sql(val);
 END;
-$$ LANGUAGE plpgsql IMMUTABLE SET search_path = pg_catalog, df, pg_temp;
+$$ LANGUAGE plpgsql IMMUTABLE SET search_path = pg_catalog, pg_temp;
 
 CREATE OPERATOR ?> (
     FUNCTION = df.if_then_op,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ ALTER TABLE df.nodes
     ADD CONSTRAINT nodes_right_node_format_chk
         CHECK (right_node IS NULL OR right_node OPERATOR(pg_catalog.~) '^[0-9a-f]{8}$') NOT VALID,
     ADD CONSTRAINT nodes_node_type_chk
-        CHECK (node_type OPERATOR(pg_catalog.=) ANY (ARRAY['SQL', 'THEN', 'IF', 'JOIN', 'LOOP', 'BREAK', 'RACE', 'SLEEP', 'WAIT_SCHEDULE', 'HTTP', 'SIGNAL'])) NOT VALID,
+        CHECK (node_type OPERATOR(pg_catalog.=) ANY (ARRAY['SQL', 'THEN', 'IF', 'JOIN', 'LOOP', 'BREAK', 'RACE', 'SLEEP', 'WAIT_SCHEDULE', 'HTTP', 'HTTP_MULTIPART', 'SIGNAL'])) NOT VALID,
     ADD CONSTRAINT nodes_result_name_chk
         CHECK (result_name IS NULL OR result_name OPERATOR(pg_catalog.~) '^[A-Za-z_][A-Za-z0-9_]*$') NOT VALID,
     ADD CONSTRAINT nodes_status_chk
@@ -377,7 +377,7 @@ ALTER TABLE df.nodes
     ADD CONSTRAINT nodes_structure_chk
         CHECK (
             CASE
-                WHEN node_type OPERATOR(pg_catalog.=) ANY (ARRAY['SQL', 'SLEEP', 'WAIT_SCHEDULE', 'BREAK', 'HTTP', 'SIGNAL'])
+                WHEN node_type OPERATOR(pg_catalog.=) ANY (ARRAY['SQL', 'SLEEP', 'WAIT_SCHEDULE', 'BREAK', 'HTTP', 'HTTP_MULTIPART', 'SIGNAL'])
                     THEN left_node IS NULL AND right_node IS NULL AND query IS NOT NULL
                 WHEN node_type OPERATOR(pg_catalog.=) 'THEN'
                     THEN left_node IS NOT NULL AND right_node IS NOT NULL AND query IS NULL
@@ -495,6 +495,8 @@ BEGIN
     -- df.http() — opt-in because it makes outbound network requests.
     IF include_http THEN
         EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
+        -- df.http_multipart() shares the same opt-in (HTTP egress is one privilege).
+        EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION df.http_multipart(text, text, jsonb, jsonb, integer) TO %I', p_role) OPERATOR(pg_catalog.||) grant_opt;
     END IF;
 
     -- Admin helpers and system-wide metrics — with_grant => true marks a
@@ -541,6 +543,11 @@ BEGIN
     END;
     BEGIN
         EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.metrics() FROM %I CASCADE', p_role);
+    EXCEPTION WHEN insufficient_privilege THEN
+        NULL;
+    END;
+    BEGIN
+        EXECUTE pg_catalog.format('REVOKE EXECUTE ON FUNCTION df.http_multipart(text, text, jsonb, jsonb, integer) FROM %I CASCADE', p_role);
     EXCEPTION WHEN insufficient_privilege THEN
         NULL;
     END;
@@ -600,11 +607,17 @@ END $$;
 -- with_grant => true admins or by a direct administrator GRANT.
 REVOKE EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION df.metrics() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION df.http_multipart(text, text, jsonb, jsonb, integer) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION df.grant_usage(text, boolean, boolean) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION df.revoke_usage(text) FROM PUBLIC;
 "#,
     name = "rls_and_grants",
-    requires = ["create_tables", dsl::http, monitoring::metrics]
+    requires = [
+        "create_tables",
+        dsl::http,
+        dsl::http_multipart,
+        monitoring::metrics
+    ]
 );
 
 // ============================================================================
@@ -759,8 +772,8 @@ BEGIN
         node_type_val := (val::jsonb)->>'node_type';
         IF node_type_val IS NOT NULL THEN
             -- Has a node_type - validate it
-            IF node_type_val NOT IN ('SQL', 'THEN', 'IF', 'JOIN', 'LOOP', 'BREAK', 'RACE', 'SLEEP', 'WAIT_SCHEDULE', 'HTTP', 'SIGNAL') THEN
-                RAISE EXCEPTION 'Unknown node_type ''%''. Valid types: SQL, THEN, IF, JOIN, LOOP, BREAK, RACE, SLEEP, WAIT_SCHEDULE, HTTP, SIGNAL', node_type_val;
+            IF node_type_val NOT IN ('SQL', 'THEN', 'IF', 'JOIN', 'LOOP', 'BREAK', 'RACE', 'SLEEP', 'WAIT_SCHEDULE', 'HTTP', 'HTTP_MULTIPART', 'SIGNAL') THEN
+                RAISE EXCEPTION 'Unknown node_type ''%''. Valid types: SQL, THEN, IF, JOIN, LOOP, BREAK, RACE, SLEEP, WAIT_SCHEDULE, HTTP, HTTP_MULTIPART, SIGNAL', node_type_val;
             END IF;
             RETURN val;
         END IF;

--- a/src/orchestrations/execute_function_graph.rs
+++ b/src/orchestrations/execute_function_graph.rs
@@ -423,6 +423,9 @@ async fn execute_node_inner(
         "join" => execute_join_node(ctx, graph, node, node_id, results, exec_ctx).await,
         "race" => execute_race_node(ctx, graph, node, node_id, results, exec_ctx).await,
         "http" => execute_http_node(ctx, node, node_id, results, exec_ctx, &sys_vars).await,
+        "http_multipart" => {
+            execute_http_multipart_node(ctx, node, node_id, results, exec_ctx, &sys_vars).await
+        }
         "signal" => execute_signal_node(ctx, node, node_id, results).await,
         "break" => execute_break_node(ctx, node, node_id).await,
         other => Err(NodeError::Failure(format!("Unknown node type: {other}"))),
@@ -1185,6 +1188,83 @@ async fn execute_http_node(
     // Store result if named
     if let Some(name) = &node.result_name {
         ctx.trace_info(format!("Storing HTTP result as ${name}"));
+        results.insert(name.clone(), result.clone());
+    }
+
+    Ok(result)
+}
+
+async fn execute_http_multipart_node(
+    ctx: &OrchestrationContext,
+    node: &FunctionNode,
+    node_id: &str,
+    results: &mut HashMap<String, String>,
+    exec_ctx: &ExecutionContext,
+    sys_vars: &SystemVars,
+) -> NodeResult {
+    let config_str = node
+        .query
+        .as_ref()
+        .ok_or_else(|| format!("HTTP_MULTIPART node {node_id} has no config"))?;
+
+    let mut config: serde_json::Value = serde_json::from_str(config_str)
+        .map_err(|e| format!("Invalid multipart HTTP config: {e}"))?;
+
+    // Substitute variables in URL.
+    if let Some(url) = config.get("url").and_then(|u| u.as_str()) {
+        let substituted_url = substitute_all_raw(url, results, &exec_ctx.vars, sys_vars)?;
+        config["url"] = serde_json::Value::String(substituted_url);
+    }
+
+    // Substitute variables in headers (same pattern as execute_http_node).
+    if let Some(headers) = config.get("headers").and_then(|h| h.as_object()) {
+        let mut new_headers = serde_json::Map::new();
+        let mut sorted_keys: Vec<_> = headers.keys().collect();
+        sorted_keys.sort();
+        for key in sorted_keys {
+            if let Some(value) = headers.get(key) {
+                if let Some(v) = value.as_str() {
+                    let substituted = substitute_all_raw(v, results, &exec_ctx.vars, sys_vars)?;
+                    new_headers.insert(key.clone(), serde_json::Value::String(substituted));
+                } else {
+                    new_headers.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        config["headers"] = serde_json::Value::Object(new_headers);
+    }
+
+    // Substitute variables in each part's text metadata (name, filename), but
+    // NEVER in data_b64 — it is base64-encoded binary; substituting into it is
+    // meaningless and could corrupt the payload.
+    if let Some(parts) = config.get_mut("parts").and_then(|p| p.as_array_mut()) {
+        for part in parts.iter_mut() {
+            if let Some(name) = part.get("name").and_then(|n| n.as_str()) {
+                let substituted = substitute_all_raw(name, results, &exec_ctx.vars, sys_vars)?;
+                part["name"] = serde_json::Value::String(substituted);
+            }
+            if let Some(filename) = part.get("filename").and_then(|f| f.as_str()) {
+                let substituted = substitute_all_raw(filename, results, &exec_ctx.vars, sys_vars)?;
+                part["filename"] = serde_json::Value::String(substituted);
+            }
+        }
+    }
+
+    // Inject audit context from the function node.
+    config["submitted_by"] = serde_json::Value::String(node.submitted_by.clone());
+
+    let final_config = config.to_string();
+    let url = config["url"].as_str().unwrap_or("?");
+    let method = config["method"].as_str().unwrap_or("POST");
+    ctx.trace_info(format!("Executing HTTP_MULTIPART {method} {url}"));
+
+    let result = ctx
+        .schedule_activity(activities::execute_multipart::NAME, final_config)
+        .await?;
+
+    // Store result if named
+    if let Some(name) = &node.result_name {
+        ctx.trace_info(format!("Storing HTTP_MULTIPART result as ${name}"));
         results.insert(name.clone(), result.clone());
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -19,6 +19,7 @@ pub fn create_activity_registry(pool: Arc<PgPool>, semaphore: Arc<Semaphore>) ->
     let status_pool = pool.clone();
     let node_status_pool = pool.clone();
     let http_pool = pool.clone();
+    let multipart_pool = pool.clone();
 
     ActivityRegistry::builder()
         .register(activities::execute_sql::NAME, move |ctx: ActivityContext, input_json: String| {
@@ -40,6 +41,10 @@ pub fn create_activity_registry(pool: Arc<PgPool>, semaphore: Arc<Semaphore>) ->
         .register(activities::execute_http::NAME, move |ctx: ActivityContext, config_json: String| {
             let pool = http_pool.clone();
             async move { activities::execute_http::execute(ctx, pool, config_json).await }
+        })
+        .register(activities::execute_multipart::NAME, move |ctx: ActivityContext, config_json: String| {
+            let pool = multipart_pool.clone();
+            async move { activities::execute_multipart::execute(ctx, pool, config_json).await }
         })
         .build()
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -963,6 +963,36 @@ fn default_http_timeout() -> u64 {
     30
 }
 
+/// One part of a multipart/form-data body (df.http_multipart).
+///
+/// `data_b64` is the base64-encoded part payload. The config is serialized to
+/// JSON and durably checkpointed as a string, so raw bytes cannot ride inline;
+/// base64 keeps it text-safe. Decoded by the execute_multipart activity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultipartPart {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    pub data_b64: String,
+}
+
+/// Configuration for multipart/form-data HTTP requests (df.http_multipart).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultipartConfig {
+    pub url: String,
+    pub method: String,
+    pub parts: Vec<MultipartPart>,
+    #[serde(default)]
+    pub headers: Option<serde_json::Value>,
+    #[serde(default = "default_http_timeout")]
+    pub timeout_seconds: u64,
+    /// Role that called df.start() (audit trail)
+    #[serde(default)]
+    pub submitted_by: Option<String>,
+}
+
 // ============================================================================
 // Durofut Type - Represents a function node reference
 // ============================================================================
@@ -979,6 +1009,7 @@ pub const VALID_NODE_TYPES: &[&str] = &[
     "SLEEP",
     "WAIT_SCHEDULE",
     "HTTP",
+    "HTTP_MULTIPART",
     "SIGNAL",
 ];
 const NON_FUTURE_HELPER_GUC: &str = "df.non_future_helper";

--- a/tests/e2e/sql/06_http_and_ssrf.sql
+++ b/tests/e2e/sql/06_http_and_ssrf.sql
@@ -71,6 +71,77 @@ END $$;
 
 DROP TABLE _test_http_post;
 
+-- Test 2b: multipart/form-data upload (one text field + one file part)
+CREATE TEMP TABLE _test_http_multipart (instance_id TEXT);
+
+INSERT INTO _test_http_multipart SELECT df.start(
+    df.http_multipart(
+        'https://httpbingo.org/post',
+        'POST',
+        jsonb_build_array(
+            jsonb_build_object(
+                'name', 'field1',
+                'data_b64', encode('hello multipart'::bytea, 'base64')
+            ),
+            jsonb_build_object(
+                'name', 'file1',
+                'filename', 'test.txt',
+                'content_type', 'text/plain',
+                'data_b64', encode('file contents here'::bytea, 'base64')
+            )
+        )
+    ) |=> 'response'
+    ~> 'SELECT ($response::jsonb->>''ok'')::boolean as ok',
+    'test-http-multipart'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    node_result TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_http_multipart;
+    RAISE NOTICE 'Testing HTTP multipart upload: %', inst_id;
+
+    SELECT df.await_instance(inst_id) INTO status;
+
+    IF status != 'completed' THEN
+        -- Surface the node result so failures are diagnosable.
+        SELECT result::text INTO node_result
+        FROM df.nodes WHERE instance_id = inst_id AND node_type = 'HTTP_MULTIPART';
+        RAISE EXCEPTION 'TEST FAILED: HTTP multipart status = %, result = %', status, node_result;
+    END IF;
+
+    -- Verify the request was sent as multipart/form-data and that the field
+    -- value round-tripped through httpbingo.org/post's echoed body. httpbingo
+    -- echoes request headers (incl. Content-Type) and form fields in the body.
+    SELECT result::text INTO node_result
+    FROM df.nodes WHERE instance_id = inst_id AND node_type = 'HTTP_MULTIPART';
+
+    IF node_result IS NULL THEN
+        RAISE EXCEPTION 'TEST FAILED: no HTTP_MULTIPART node result for %', inst_id;
+    END IF;
+
+    -- When httpbingo returns 200 (ok=true), assert the multipart content
+    -- round-tripped. If httpbingo is having a bad day (non-200), the workflow
+    -- completing is sufficient evidence the multipart path executed — skip the
+    -- body checks with a notice rather than fail the suite on a flaky upstream.
+    IF (node_result::jsonb->>'ok')::boolean THEN
+        IF node_result NOT ILIKE '%multipart/form-data%' THEN
+            RAISE EXCEPTION 'TEST FAILED: expected multipart/form-data in response, got: %', node_result;
+        END IF;
+        IF node_result NOT ILIKE '%hello multipart%' THEN
+            RAISE EXCEPTION 'TEST FAILED: field value did not round-trip, got: %', node_result;
+        END IF;
+        RAISE NOTICE 'TEST PASSED: http_multipart (content verified)';
+    ELSE
+        RAISE NOTICE 'TEST PASSED: http_multipart (completed; httpbingo non-200, body checks skipped): %', node_result;
+    END IF;
+END $$;
+
+DROP TABLE _test_http_multipart;
+
 -- Test 3: HTTP with custom headers
 CREATE TEMP TABLE _test_http_headers (instance_id TEXT);
 


### PR DESCRIPTION
Adds a dedicated SQL function `df.http_multipart(url, method, parts, headers, timeout)` for multipart/form-data requests (file uploads, form posts). Binary part payloads are base64-inlined in the config JSON (which is durably checkpointed).

Briefly verified e2e but lacks polish. Would appreciate a thorough review and any edits to get it production ready.

Thank you!