### PR TITLE
Fix df.http_multipart for payloads over 57 bytes, and document it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Pre-1.0 note: while `pg_durable` is in major version `0`, minor releases may inc
 
 ## [0.2.5] - Unreleased
 
+### Added
+
+- **`df.http_multipart()` (#302):** send `multipart/form-data` requests. Parts are described as a JSONB array of objects with `name` and `data_b64`, optionally `filename` and `content_type`. Gated by the same `include_http => true` grant as `df.http()`.
+- **Variable substitution in multipart `data_b64`:** a part's `data_b64` can now reference an earlier result, e.g. `'data_b64', '$payload.b64'`, letting a payload produced by one step be uploaded by the next with no intermediate table. The reference must be the *whole* value; mixing it with surrounding text fails the node rather than sending a corrupt part, because splicing into base64 cannot produce a valid encoding.
+
+### Fixed
+
+- **Multipart parts larger than 57 bytes (#302):** `data_b64` was decoded with a strict base64 decoder that rejects embedded whitespace, but PostgreSQL's `encode(bytea, 'base64')` wraps its output at 76 columns. Any part whose source data exceeded 57 bytes therefore failed to decode. Whitespace in `data_b64` is now ignored, so `encode()` output can be used directly.
+
 ## [0.2.4] - 2026-07-02
 
 Provider-line note: v0.2.4 stays in the `duroxide-pg` provider compatibility line, so the upgrade source is v0.2.3 (`sql/pg_durable--0.2.3--0.2.4.sql`).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -15,17 +15,18 @@ pg_durable is a PostgreSQL extension that brings durable, fault-tolerant functio
 5. [Condition Evaluation](#condition-evaluation)
 6. [Function Examples](#function-examples)
 7. [HTTP Requests](#http-requests)
-8. [Durable Function Variables](#durable-function-variables)
-9. [Loops & Cron Jobs](#loops--cron-jobs)
-10. [Signals](#signals)
-11. [Multi-Database Support](#multi-database-support)
-12. [Visualizing Functions](#visualizing-functions)
-13. [Monitoring](#monitoring)
-14. [User Isolation & Privileges](#user-isolation--privileges)
-15. [Connection Limits](#connection-limits)
-16. [Troubleshooting](#troubleshooting)
-17. [Quick Reference Card](#quick-reference-card)
-18. [Appendix: Test Data Setup](#appendix-test-data-setup)
+8. [Multipart Uploads](#multipart-uploads)
+9. [Durable Function Variables](#durable-function-variables)
+10. [Loops & Cron Jobs](#loops--cron-jobs)
+11. [Signals](#signals)
+12. [Multi-Database Support](#multi-database-support)
+13. [Visualizing Functions](#visualizing-functions)
+14. [Monitoring](#monitoring)
+15. [User Isolation & Privileges](#user-isolation--privileges)
+16. [Connection Limits](#connection-limits)
+17. [Troubleshooting](#troubleshooting)
+18. [Quick Reference Card](#quick-reference-card)
+19. [Appendix: Test Data Setup](#appendix-test-data-setup)
 
 ---
 
@@ -321,7 +322,7 @@ SELECT df.result('a1b2c3d4')::jsonb->'rows'->0->>'answer';
 - A SQL query returning no rows produces: `{"rows": [], "row_count": 0}`
 - `df.sleep()` returns a top-level JSON object like `{"slept": true, "seconds": 60}`
 - `df.wait_for_schedule()` returns a top-level JSON object: `{"scheduled": true}`
-- `df.http()` returns a top-level JSON object with `status`, `body`, `headers`, `ok`, and `duration_ms` fields
+- `df.http()` and `df.http_multipart()` return a top-level JSON object with `status`, `body`, `headers`, `ok`, and `duration_ms` fields
 - `df.break('value')` stores the literal value as the loop result (not wrapped in `rows`)
 
 
@@ -813,6 +814,63 @@ This demonstrates:
 - Parsing nested JSON (extracting `commit.author.name` and `commit.message`)
 - Upserting with ON CONFLICT
 - Creating a scheduled loop that runs every 30 minutes
+
+---
+
+## Multipart Uploads
+
+`df.http_multipart()` sends a `multipart/form-data` request — the format file uploads use.
+It needs the same `include_http => true` grant as `df.http()`.
+
+```sql
+df.http_multipart(
+    url TEXT,                     -- Required: endpoint URL
+    method TEXT DEFAULT 'POST',
+    parts JSONB DEFAULT '[]',     -- Array of part objects
+    headers JSONB DEFAULT '{}',
+    timeout_seconds INT DEFAULT 30
+) RETURNS TEXT                    -- Same JSON envelope as df.http()
+```
+
+Each part is an object with `name` and `data_b64`, optionally `filename` (which makes it a
+file upload) and `content_type`:
+
+```sql
+SELECT df.start(
+    'SELECT id, doc FROM invoices WHERE id = 1' |=> 'inv'
+    ~> df.http_multipart(
+        'https://api.example.com/upload', 'POST',
+        jsonb_build_array(
+            jsonb_build_object(
+                'name', 'file',
+                'filename', 'invoice.pdf',
+                'content_type', 'application/pdf',
+                'data_b64', (SELECT encode(doc, 'base64') FROM invoices WHERE id = 1))),
+        '{"Authorization": "Bearer token"}'::jsonb
+    ) |=> 'upload'
+    ~> 'UPDATE invoices SET uploaded = ($upload::jsonb->>''ok'')::boolean WHERE id = $inv.id',
+    'upload-invoice'
+);
+```
+
+`encode(bytea, 'base64')` wraps its output at 76 columns. That is accepted as-is — no
+`replace(..., E'\n', '')` needed.
+
+### data_b64 Is Whole-Value Only
+
+A part's `data_b64` can reference an earlier result, which lets one step produce a payload
+and the next upload it without an intermediate table. The reference must be the *entire*
+value:
+
+```sql
+'data_b64', '$payload.b64'        -- ✅
+'data_b64', '{my_payload}'        -- ✅
+'data_b64', 'prefix$payload.b64'  -- ❌ node fails
+```
+
+Splicing a value into the middle of a base64 string cannot produce valid base64, so
+pg_durable fails the node with a clear message instead of uploading a corrupt part. Every
+other field — `url`, `name`, `filename`, headers — interpolates normally.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -262,6 +262,57 @@ df.http(url, 'GET', NULL, '{"Auth": "Bearer token"}'::jsonb, 60)
 
 ---
 
+### df.http_multipart(url [, method, parts, headers, timeout])
+
+Makes an HTTP request with a `multipart/form-data` body. Requires the same
+`include_http => true` grant as `df.http()`.
+
+| Parameter | Type | Auto-wrap | Description |
+|-----------|------|-----------|-------------|
+| `url` | TEXT | ❌ Literal | Request URL (supports `$var` substitution) |
+| `method` | TEXT | ❌ Literal | HTTP method (default: POST) |
+| `parts` | JSONB | ❌ Literal | Array of part objects (see below) |
+| `headers` | JSONB | ❌ Literal | Request headers |
+| `timeout` | INTEGER | ❌ Literal | Timeout in seconds (default: 30) |
+
+Each element of `parts` is an object:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `name` | ✅ | Form field name (supports `$var`) |
+| `data_b64` | ✅ | Part content, base64-encoded |
+| `filename` | ❌ | Sets the part's filename, making it a file upload (supports `$var`) |
+| `content_type` | ❌ | Part `Content-Type` |
+
+`data_b64` accepts base64 with embedded whitespace, so PostgreSQL's
+`encode(bytea, 'base64')` output — which wraps at 76 columns — can be used directly.
+
+```sql
+df.http_multipart(
+    'https://api.example.com/upload', 'POST',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'file', 'filename', 'report.pdf',
+            'content_type', 'application/pdf',
+            'data_b64', encode(pg_read_binary_file('report.pdf'), 'base64'))),
+    '{"Authorization": "Bearer token"}'::jsonb, 60)
+```
+
+**`data_b64` substitution is whole-value only.** A reference must be the entire value:
+
+```sql
+'data_b64', '$payload.b64'    -- ✅ substituted
+'data_b64', 'prefix$payload'  -- ❌ error: mixes a reference with other text
+```
+
+This is deliberate. Splicing a variable into the middle of a base64 string cannot produce
+valid base64, so pg_durable reports it as a node failure rather than sending a corrupt
+part. Other fields (`url`, `name`, `filename`, headers) interpolate normally.
+
+Returns the same envelope as `df.http()`.
+
+---
+
 ## Control Functions
 
 ### df.start(fut [, label])

--- a/src/activities/execute_multipart.rs
+++ b/src/activities/execute_multipart.rs
@@ -52,6 +52,30 @@ async fn check_multipart_privilege(pool: &PgPool, submitted_by: &str) -> Result<
     }
 }
 
+/// Decode a part's `data_b64` payload, tolerating ASCII whitespace.
+///
+/// PostgreSQL's `encode(bytea, 'base64')` follows RFC 2045 §6.8 and breaks its
+/// output into 76-character lines separated by newlines. The `STANDARD` engine
+/// rejects any character outside the base64 alphabet, so unwrapped decoding
+/// fails for every payload larger than 57 source bytes — which is to say, for
+/// the canonical way a PostgreSQL user produces base64. Whitespace is not part
+/// of the alphabet, so stripping it loosens nothing that was ever meaningful.
+///
+/// The strip allocates only when whitespace is actually present; the common
+/// case of a single unwrapped line decodes without a copy.
+fn decode_part_data(data_b64: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    let engine = base64::engine::general_purpose::STANDARD;
+    if data_b64.bytes().any(|b| b.is_ascii_whitespace()) {
+        let stripped: String = data_b64
+            .chars()
+            .filter(|c| !c.is_ascii_whitespace())
+            .collect();
+        engine.decode(&stripped)
+    } else {
+        engine.decode(data_b64)
+    }
+}
+
 /// Execute a multipart/form-data HTTP request and return the response as JSON
 pub async fn execute(
     ctx: ActivityContext,
@@ -146,8 +170,7 @@ pub async fn execute(
     // Build the multipart form from base64-encoded parts.
     let mut form = reqwest::multipart::Form::new();
     for part in &config.parts {
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(&part.data_b64)
+        let bytes = decode_part_data(&part.data_b64)
             .map_err(|e| format!("Invalid base64 in part '{}': {e}", part.name))?;
         let mut req_part = reqwest::multipart::Part::bytes(bytes);
         if let Some(ct) = &part.content_type {
@@ -240,4 +263,64 @@ pub async fn execute(
 
     // Return response for all other cases (including 4xx)
     Ok(result.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mirror of PostgreSQL's `encode(bytea, 'base64')`: RFC 2045 §6.8 line
+    /// breaking at 76 characters.
+    fn pg_style_encode(data: &[u8]) -> String {
+        let flat = base64::engine::general_purpose::STANDARD.encode(data);
+        flat.as_bytes()
+            .chunks(76)
+            .map(|c| std::str::from_utf8(c).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn decodes_unwrapped_base64() {
+        let encoded = base64::engine::general_purpose::STANDARD.encode(b"hello");
+        assert_eq!(decode_part_data(&encoded).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn decodes_pg_wrapped_base64() {
+        // 200 bytes -> 268 base64 chars -> wrapped across 4 lines.
+        let payload: Vec<u8> = (0u8..200).collect();
+        let encoded = pg_style_encode(&payload);
+        assert!(
+            encoded.contains('\n'),
+            "fixture must exercise line wrapping"
+        );
+        assert_eq!(decode_part_data(&encoded).unwrap(), payload);
+    }
+
+    #[test]
+    fn decodes_with_surrounding_whitespace() {
+        let encoded = base64::engine::general_purpose::STANDARD.encode(b"hello");
+        let padded = format!("  \n{encoded}\n  ");
+        assert_eq!(decode_part_data(&padded).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn decodes_with_crlf_line_endings() {
+        let payload: Vec<u8> = (0u8..200).collect();
+        let encoded = pg_style_encode(&payload).replace('\n', "\r\n");
+        assert_eq!(decode_part_data(&encoded).unwrap(), payload);
+    }
+
+    #[test]
+    fn decodes_empty_payload() {
+        assert_eq!(decode_part_data("").unwrap(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn rejects_malformed_base64() {
+        assert!(decode_part_data("!!!!").is_err());
+        // Whitespace stripping must not rescue genuinely invalid input.
+        assert!(decode_part_data("!!\n!!").is_err());
+    }
 }

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -551,6 +551,12 @@ pub fn http(
 /// (base64-encoded payload) are required; `filename` and `content_type` are
 /// optional. The response shape and security model match `df.http`.
 ///
+/// `data_b64` may contain whitespace, so `encode(bytea, 'base64')` output —
+/// which PostgreSQL wraps at 76 columns — can be passed straight through. It
+/// also supports $variable substitution, but only as a whole value (e.g.
+/// `"$payload.b64"`); mixing a reference with surrounding text fails the node,
+/// since splicing into a base64 string cannot yield a valid encoding.
+///
 /// # Arguments
 /// * `url` - The URL to request. Supports $variable substitution
 /// * `method` - HTTP method (POST, PUT, PATCH). Default: POST

--- a/src/orchestrations/execute_function_graph.rs
+++ b/src/orchestrations/execute_function_graph.rs
@@ -1234,9 +1234,16 @@ async fn execute_http_multipart_node(
         config["headers"] = serde_json::Value::Object(new_headers);
     }
 
-    // Substitute variables in each part's text metadata (name, filename), but
-    // NEVER in data_b64 — it is base64-encoded binary; substituting into it is
-    // meaningless and could corrupt the payload.
+    // Substitute variables in each part's text metadata (name, filename) with
+    // the usual inline rules.
+    //
+    // `data_b64` follows a stricter rule: it is substituted only when its entire
+    // value is a single reference (e.g. `$payload.b64` or `{payload}`). That is
+    // what lets one step's output become the next step's upload. Splicing a
+    // substitution into the *middle* of a base64 string, by contrast, can only
+    // corrupt the payload, so partial interpolation is rejected outright rather
+    // than silently producing garbage. The base64 alphabet contains neither `$`
+    // nor `{`, so their presence is unambiguously an attempted reference.
     if let Some(parts) = config.get_mut("parts").and_then(|p| p.as_array_mut()) {
         for part in parts.iter_mut() {
             if let Some(name) = part.get("name").and_then(|n| n.as_str()) {
@@ -1246,6 +1253,21 @@ async fn execute_http_multipart_node(
             if let Some(filename) = part.get("filename").and_then(|f| f.as_str()) {
                 let substituted = substitute_all_raw(filename, results, &exec_ctx.vars, sys_vars)?;
                 part["filename"] = serde_json::Value::String(substituted);
+            }
+            if let Some(data_b64) = part.get("data_b64").and_then(|d| d.as_str()) {
+                if crate::types::is_whole_value_reference(data_b64) {
+                    let substituted =
+                        substitute_all_raw(data_b64, results, &exec_ctx.vars, sys_vars)?;
+                    part["data_b64"] = serde_json::Value::String(substituted);
+                } else if data_b64.contains('$') || data_b64.contains('{') {
+                    let part_name = part.get("name").and_then(|n| n.as_str()).unwrap_or("?");
+                    return Err(NodeError::Failure(format!(
+                        "HTTP_MULTIPART node {node_id}: data_b64 for part '{part_name}' mixes a \
+                         variable reference with other text. Only a whole-value reference is \
+                         supported (e.g. data_b64 => '$result' or '{{myvar}}'), because splicing \
+                         into base64 would corrupt the payload."
+                    )));
+                }
             }
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -884,6 +884,55 @@ pub fn substitute_all_raw(
     substitute_all_with_options(query, results, vars, sys_vars, false)
 }
 
+/// Report whether `value` consists of exactly one variable reference and nothing
+/// else, ignoring surrounding whitespace.
+///
+/// Accepted forms:
+/// - `$name`, `$name?`
+/// - `$name.col`, `$name.col?`
+/// - `{name}` — covers user variables and `{sys_*}` alike
+///
+/// Deliberately rejected:
+/// - `$name.*` — a row-set expansion is never a single opaque value
+/// - anything with surrounding literal text, or more than one reference
+///
+/// This exists for contexts where a value must be replaced wholesale or not at
+/// all — notably a multipart part's `data_b64`, where splicing a substitution
+/// into the middle of a base64 string can only corrupt the payload.
+pub fn is_whole_value_reference(value: &str) -> bool {
+    let value = value.trim();
+
+    if let Some(rest) = value.strip_prefix('$') {
+        let name = parse_identifier(rest);
+        if name.is_empty() {
+            return false;
+        }
+        let rest = &rest[name.len()..];
+
+        // Dot notation, but never the `.*` row-set form.
+        let rest = match rest.strip_prefix('.') {
+            Some(after_dot) => {
+                let col = parse_identifier(after_dot);
+                if col.is_empty() {
+                    return false;
+                }
+                &after_dot[col.len()..]
+            }
+            None => rest,
+        };
+
+        // An optional null-safe marker may follow, and nothing else.
+        return rest.is_empty() || rest == "?";
+    }
+
+    if let Some(rest) = value.strip_prefix('{') {
+        let name = parse_identifier(rest);
+        return !name.is_empty() && &rest[name.len()..] == "}";
+    }
+
+    false
+}
+
 /// Legacy function for backward compatibility - only substitutes $name results
 pub fn substitute_variables(
     query: &str,
@@ -1335,6 +1384,74 @@ fn summarize_json_type(v: &serde_json::Value) -> &'static str {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn whole_value_reference_accepts_single_references() {
+        for value in [
+            "$payload",
+            "$payload?",
+            "$resp.body",
+            "$resp.body?",
+            "$_leading_underscore",
+            "{myvar}",
+            "{sys_instance_id}",
+        ] {
+            assert!(
+                is_whole_value_reference(value),
+                "expected `{value}` to be a whole-value reference"
+            );
+        }
+    }
+
+    #[test]
+    fn whole_value_reference_tolerates_surrounding_whitespace() {
+        assert!(is_whole_value_reference("  $payload  "));
+        assert!(is_whole_value_reference("\n{myvar}\t"));
+    }
+
+    #[test]
+    fn whole_value_reference_rejects_partial_interpolation() {
+        for value in [
+            "prefix$payload",
+            "$payload suffix",
+            "$a$b",
+            "{a}{b}",
+            "{a}tail",
+            "head{a}",
+            "$resp.body extra",
+        ] {
+            assert!(
+                !is_whole_value_reference(value),
+                "expected `{value}` to be rejected as partial interpolation"
+            );
+        }
+    }
+
+    #[test]
+    fn whole_value_reference_rejects_row_set_expansion() {
+        // A row-set expansion is never a single opaque value.
+        assert!(!is_whole_value_reference("$rows.*"));
+    }
+
+    #[test]
+    fn whole_value_reference_rejects_malformed_and_plain_text() {
+        for value in [
+            "",
+            "   ",
+            "$",
+            "$1abc",
+            "$resp.",
+            "{",
+            "{}",
+            "{unclosed",
+            "aGVsbG8=", // ordinary base64
+        ] {
+            assert!(
+                !is_whole_value_reference(value),
+                "expected `{value}` to be rejected"
+            );
+        }
+    }
 
     #[test]
     fn is_truthy_all_types() {

--- a/tests/e2e/sql/06_http_and_ssrf.sql
+++ b/tests/e2e/sql/06_http_and_ssrf.sql
@@ -142,6 +142,126 @@ END $$;
 
 DROP TABLE _test_http_multipart;
 
+-- Test 2c: a part payload produced by an earlier node.
+--
+-- Exercises two things that a literal, short payload cannot:
+--   1. `data_b64` whole-value substitution — the bytes come from `$payload.b64`,
+--      not from the DSL call site.
+--   2. Whitespace-tolerant base64 decoding — PostgreSQL's encode(bytea,'base64')
+--      breaks output at 76 characters per RFC 2045 §6.8, so the payload below is
+--      deliberately long enough to be wrapped across multiple lines.
+CREATE TEMP TABLE _test_multipart_produced (instance_id TEXT);
+
+INSERT INTO _test_multipart_produced SELECT df.start(
+    df.sql('SELECT encode(repeat(''pg_durable produced payload. '', 5)::bytea, ''base64'') AS b64') |=> 'payload'
+    ~> df.http_multipart(
+        'https://httpbingo.org/post',
+        'POST',
+        jsonb_build_array(
+            jsonb_build_object(
+                'name', 'blob',
+                'data_b64', '$payload.b64'
+            )
+        )
+    ) |=> 'response'
+    ~> 'SELECT ($response::jsonb->>''ok'')::boolean as ok',
+    'test-multipart-produced'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    node_result TEXT;
+    encoded TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_multipart_produced;
+    RAISE NOTICE 'Testing multipart with produced payload: %', inst_id;
+
+    -- Guard the premise: if encode() ever stops wrapping, this test silently
+    -- stops covering the whitespace-tolerance path.
+    SELECT encode(repeat('pg_durable produced payload. ', 5)::bytea, 'base64') INTO encoded;
+    IF position(E'\n' IN encoded) = 0 THEN
+        RAISE EXCEPTION 'TEST SETUP INVALID: fixture base64 is not line-wrapped';
+    END IF;
+
+    SELECT df.await_instance(inst_id) INTO status;
+
+    SELECT result::text INTO node_result
+    FROM df.nodes WHERE instance_id = inst_id AND node_type = 'HTTP_MULTIPART';
+
+    IF status != 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED: produced-payload multipart status = %, result = %', status, node_result;
+    END IF;
+
+    IF node_result IS NULL THEN
+        RAISE EXCEPTION 'TEST FAILED: no HTTP_MULTIPART node result for %', inst_id;
+    END IF;
+
+    -- Same upstream-flakiness allowance as Test 2b: only assert on the echoed
+    -- body when httpbingo actually returned 200.
+    IF (node_result::jsonb->>'ok')::boolean THEN
+        IF node_result NOT ILIKE '%pg_durable produced payload.%' THEN
+            RAISE EXCEPTION 'TEST FAILED: produced payload did not round-trip, got: %', node_result;
+        END IF;
+        RAISE NOTICE 'TEST PASSED: http_multipart_produced_payload (content verified)';
+    ELSE
+        RAISE NOTICE 'TEST PASSED: http_multipart_produced_payload (completed; httpbingo non-200, body checks skipped): %', node_result;
+    END IF;
+END $$;
+
+DROP TABLE _test_multipart_produced;
+
+-- Test 2d: partial interpolation into data_b64 is rejected.
+--
+-- Splicing a substitution into the middle of a base64 string can only corrupt
+-- the payload, so the orchestration must fail the node rather than upload
+-- garbage. This fails before any network call is made.
+CREATE TEMP TABLE _test_multipart_partial (instance_id TEXT);
+
+INSERT INTO _test_multipart_partial SELECT df.start(
+    df.sql('SELECT ''aGVsbG8='' AS b64') |=> 'payload'
+    ~> df.http_multipart(
+        'https://httpbingo.org/post',
+        'POST',
+        jsonb_build_array(
+            jsonb_build_object(
+                'name', 'blob',
+                'data_b64', 'prefix$payload.b64'
+            )
+        )
+    ),
+    'test-multipart-partial'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    status TEXT;
+    node_result TEXT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _test_multipart_partial;
+    RAISE NOTICE 'Testing multipart partial interpolation rejection: %', inst_id;
+
+    SELECT df.await_instance(inst_id) INTO status;
+
+    IF status != 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED: expected partial interpolation to fail, status = %', status;
+    END IF;
+
+    SELECT result::text INTO node_result
+    FROM df.nodes
+    WHERE instance_id = inst_id AND node_type = 'HTTP_MULTIPART';
+
+    IF node_result IS NULL OR node_result NOT ILIKE '%whole-value reference%' THEN
+        RAISE EXCEPTION 'TEST FAILED: expected whole-value reference error, got: %', node_result;
+    END IF;
+
+    RAISE NOTICE 'TEST PASSED: http_multipart_partial_interpolation_rejected';
+END $$;
+
+DROP TABLE _test_multipart_partial;
+
 -- Test 3: HTTP with custom headers
 CREATE TEMP TABLE _test_http_headers (instance_id TEXT);
 


### PR DESCRIPTION
## Why

#302 added `df.http_multipart()`, but the feature is effectively unusable for real payloads, and it shipped with no user-facing documentation. Both are fixed here.

`0.2.5` is still unreleased, so neither problem has reached users — but nothing else should be released off `main` until this lands.

## The bug

A part's `data_b64` was decoded with the `STANDARD` base64 engine, which rejects any character outside the base64 alphabet. PostgreSQL's `encode(bytea, 'base64')` follows [RFC 2045 §6.8](https://www.rfc-editor.org/rfc/rfc2045#section-6.8) and breaks its output into 76-character lines.

76 base64 characters encode 57 source bytes. So **every part whose payload exceeded 57 bytes contained a newline and failed to decode** — and `encode(bytea, 'base64')` is precisely how a PostgreSQL user produces base64. The feature worked only for payloads small enough to fit on one line.

Decoding now ignores ASCII whitespace, so `encode()` output can be passed straight through with no `replace(..., E'\n', '')` workaround. The strip allocates only when whitespace is actually present, so the single-line case still decodes without a copy. Whitespace was never meaningful inside base64, so nothing that previously round-tripped changes meaning.

## Also included: `data_b64` variable substitution

A part's `data_b64` can now reference an earlier result, letting one step's output become the next step's upload with no intermediate table:

```sql
'data_b64', '$payload.b64'
```

The reference must be the **whole** value. Splicing a substitution into the middle of a base64 string cannot produce a valid encoding, so partial interpolation fails the node with a clear message rather than silently uploading a corrupt part. Every other field — `url`, `name`, `filename`, headers — interpolates as before.

This is grouped with the decode fix deliberately: the two together are what make "produce bytes in one step, upload them in the next" actually work, and the substituted value is itself usually wrapped `encode()` output.

## Docs

#302 shipped no user-facing docs. This adds:

- `USER_GUIDE.md` — a "Multipart Uploads" section (plus TOC entry)
- `docs/api-reference.md` — the `df.http_multipart()` reference, including the parts table
- `CHANGELOG.md` — entries for the feature itself and for this fix

## Tests

- 11 unit tests: wrapped / unwrapped / CRLF / surrounding-whitespace / empty / malformed base64, and whole-value reference detection including the rejection cases
- E2E in `tests/e2e/sql/06_http_and_ssrf.sql`: a payload large enough to wrap making a full round trip, and a partial interpolation being rejected

Verified locally: `cargo fmt --check` clean, `cargo clippy` adds no new warnings (4 pre-existing in `src/lib.rs` remain), `./scripts/test-unit.sh` 214 passed / 0 failed.

## Follow-up

A second PR based on this branch will add binary HTTP response capture (an `encoding` field on the response envelope), dot-notation access to envelope fields, and a worked audio round-trip example. That work depends on this one.
