### PR TITLE
chore(deps): bump duroxide to 0.1.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,9 +688,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "duroxide"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9377f5bf81d9a8ce56a13f913f60ca0e0ba8a9464349c407e7d11c326488bf0c"
+checksum = "92b17ebe10f702644ad65a9c624b4060023955b4cd145c23ed4c6942b17fdac9"
 dependencies = [
  "async-trait",
  "futures",
@@ -702,6 +702,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 percent-encoding = "2.3"
 
 # duroxide integration
-duroxide = "=0.1.29"
+duroxide = "=0.1.30"
 duroxide-pg = "=0.1.34"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 


### PR DESCRIPTION
## Summary

- bump the exact `duroxide` dependency from 0.1.29 to 0.1.30
- keep `duroxide-pg` at 0.1.34 because no provider source changes are required for duroxide 0.1.30
- update the lockfile for the new runtime release and UUID dependency

## Compatibility

`duroxide-pg` 0.1.34 declares `duroxide@0.1.29` with caret semantics, so Cargo resolves both pg_durable and duroxide-pg to one `duroxide 0.1.30` package. No duroxide-pg source changes are needed to support this runtime release, so a new provider release is not required.

The existing provider version builds successfully with duroxide 0.1.30 and passes pg_durable integration and upgrade tests.

## Validation

- `cargo fmt -p pg_durable -- --check`
- `cargo build --features pg17`
- `cargo clippy --features pg17 -- -D warnings`
- `./scripts/test-unit.sh` (229 passed)
- `./scripts/test-e2e-local.sh` (40 passed)
- `./scripts/test-upgrade.sh` (51 passed)
