### PR TITLE
Fix loop status correctness and coverage

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1192,7 +1192,7 @@ SELECT df.start(
 
 Each loop iteration advances via *continue-as-new*, which restarts the loop with fresh state while preserving durability. Where that restart happens depends on whether the loop is the **root** of the function:
 
-- A **root loop** (the outermost node, e.g. `df.start(df.loop(...))` or the `@>` prefix) runs inline on the function's own orchestration. There is no surrounding work to preserve, so each iteration simply restarts the function.
+- A **root loop** (the function graph's outermost node, e.g. `df.start(df.loop(...))` or `df.start(@> 'SELECT work()')`) runs inline on the function's own orchestration. There is no surrounding work to preserve, so each iteration simply restarts the function. The `@>` operator does not make a loop root by itself: `df.seq('SELECT setup()', @> 'SELECT work()')` is non-root because the sequence is the graph root.
 - A **non-root loop** (a loop with prefix/suffix nodes, or one nested inside a `df.if()`, JOIN (`&`), or RACE (`|`) branch) runs as its own **child sub-orchestration**. Only the loop body restarts on each iteration — any work *before* the loop runs exactly once and is never re-executed, and a loop nested in a parallel branch gets its own durable instance.
 
 This is transparent to your workflow; it only affects observability. The child sub-orchestration is an internal durable instance: it does **not** appear in `df.list_instances()` (which lists only the instances you started with `df.start()`). Instead, the loop node's status in `df.instance_nodes()` / `df.explain()` reflects the child's progress, so you observe the loop through its parent instance as usual.
@@ -1208,6 +1208,8 @@ SELECT instance_id FROM df.list_instances() WHERE label = 'every-minute-tick';
 -- Then cancel with the found ID
 SELECT df.cancel('found_id', 'Stopping cron job');
 ```
+
+Cancellation cascades from the parent instance to active loop children. A loop cancelled because it lost a `df.race()` is shown as a terminal `failed` node with a cancellation reason in `df.instance_nodes()` / `df.explain()`; the parent instance can still complete through the winning branch. Cancelling the whole workflow with `df.cancel()` reports the parent instance as `cancelled`.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -468,6 +468,10 @@ pub fn register_orchestrations(registry: &mut OrchestrationRegistry) {
         execute_function_graph::SUBTREE_NAME,
         execute_function_graph::execute_subtree,
     );
+    registry.register(
+        execute_function_graph::LOOP_NAME,
+        execute_function_graph::execute_loop,
+    );
 }
 
 pub fn register_activities(registry: &mut ActivityRegistry<PgPool>) {
@@ -781,55 +785,14 @@ For RACE, duroxide's `select` is used to return the first completed result.
 
 ### Loops and Continue-As-New
 
-Loops use duroxide's `continue_as_new` to avoid unbounded history growth:
+Loops use duroxide's `continue_as_new` to avoid unbounded history growth. Their execution context is determined by graph position:
 
-```rust
-async fn execute_loop_node(
-    ctx: &OrchestrationContext,
-    graph: &FunctionGraph,
-    node: &FunctionNode,
-    results: &mut HashMap<String, String>,
-    exec_ctx: &ExecutionContext,
-) -> NodeResult {
-    let body_id = node.left_node.as_ref().ok_or("LOOP missing body")?;
-    
-    // Execute loop body. A df.break() anywhere in the body (including inside nested
-    // IF/JOIN/RACE) surfaces here as Err(NodeError::Break); the loop is the only node
-    // that catches it. NodeError::Failure keeps propagating out via `?`.
-    let body_result = match execute_function_node_with_vars(
-        ctx, graph, body_id, results, exec_ctx
-    ).await {
-        Ok(v) => v,
-        Err(NodeError::Break(break_value)) => return Ok(break_value), // exit the loop
-        Err(e @ NodeError::Failure(_)) => return Err(e),
-    };
-    
-    // Check while-condition if present (conditions are SQL and cannot break)
-    if let Some(condition_node_id) = get_condition_node(node) {
-        let condition_result = execute_function_node_with_vars(
-            ctx, graph, &condition_node_id, results, exec_ctx
-        ).await?;
-        
-        let should_continue = evaluate_condition(&condition_result)?;
-        if !should_continue {
-            return Ok(body_result);  // Exit loop
-        }
-    }
-    
-    // Continue as new for next iteration (avoids unbounded history)
-    let new_input = FunctionInput {
-        instance_id: graph.instance_id.clone(),
-        label: exec_ctx.label.clone(),
-        vars: exec_ctx.vars.clone(),
-    };
-    
-    return ctx
-        .continue_as_new(serde_json::to_string(&new_input)?)
-        .await
-        .map(|_| body_result)
-        .map_err(|e| NodeError::Failure(format!("continue_as_new failed: {:?}", e)));
-}
-```
+- A loop that is the function graph's root runs inline in `execute_function_graph`. Its `continue_as_new` starts the next root orchestration generation.
+- Every non-root loop runs in a dedicated `execute_loop` child orchestration. Its `continue_as_new` advances only that child, preserving prefix and suffix work in the waiting parent. A loop used directly as a JOIN or RACE branch is also spawned as an `execute_loop` child rather than wrapped in `execute_subtree`.
+
+Both paths call `run_loop_iteration`, which executes the body, catches `NodeError::Break`, evaluates the optional post-body condition, and propagates `NodeError::Failure`. The root and child paths differ only in who owns `continue_as_new` and status stamping. The child stamps its LOOP node `running` on each generation and `completed` or `failed` on exit. If a live loop loses a RACE, the parent records the loop node as terminal `failed` with a cancellation reason because duroxide cancellation stops the child before it can run its own terminal stamp.
+
+Node status stamps contain the full composed orchestration lineage: `{root_instance}::{generation}::{child_node}::{generation}...`. Read-time inference and the write fence walk that lineage so stale writes and superseded nested branches are evaluated at every ancestor generation.
 
 ---
 

--- a/src/activities/update_node_status.rs
+++ b/src/activities/update_node_status.rs
@@ -4,7 +4,7 @@
 //! UpdateNodeStatus activity - updates df.nodes status, result, and status_details
 
 use duroxide::ActivityContext;
-use sqlx::{PgPool, Postgres, QueryBuilder};
+use sqlx::{PgPool, Postgres, QueryBuilder, Transaction};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
@@ -134,9 +134,9 @@ fn push_status_update<'a>(
             .push(", result = ")
             .push_bind(json_result)
             .push("::jsonb");
-    } else if status == "running" {
-        // When marking as running, clear any stale result from a previous loop
-        // iteration to satisfy nodes_result_status_chk
+    } else if !matches!(status, "completed" | "failed") {
+        // When marking as non-terminal, clear any stale result from a previous
+        // transition to satisfy nodes_result_status_chk
         // (result IS NULL OR status IN ('completed', 'failed')).
         update.push(", result = NULL");
     }
@@ -148,6 +148,15 @@ fn push_status_update<'a>(
             .push_bind(details)
             .push("::jsonb");
     }
+}
+
+pub(crate) async fn finish_fenced_status_update(
+    tx: Transaction<'_, Postgres>,
+) -> Result<String, String> {
+    tx.rollback()
+        .await
+        .map_err(|e| format!("Failed to roll back fenced node status update: {e}"))?;
+    Ok("Node status write fenced (superseded by newer generation)".to_string())
 }
 
 /// Update the status and optionally the result of a node in df.nodes.
@@ -224,7 +233,7 @@ pub async fn execute(
 
         let existing_execution_id = execution_id_from_details(existing_details.as_ref());
         if incoming_stamp_is_superseded(execution_id.unwrap_or_default(), existing_execution_id) {
-            return Ok("Node status write fenced (superseded by newer generation)".to_string());
+            return finish_fenced_status_update(tx).await;
         }
 
         update
@@ -288,6 +297,24 @@ pub async fn execute(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn status_update_sql(status: &str, result: Option<&str>) -> String {
+        let mut update = QueryBuilder::<Postgres>::new("");
+        push_status_update(&mut update, status, result, None, false);
+        update.sql().to_string()
+    }
+
+    #[test]
+    fn clears_result_for_every_non_terminal_status() {
+        assert!(status_update_sql("pending", None).contains("result = NULL"));
+        assert!(status_update_sql("running", None).contains("result = NULL"));
+    }
+
+    #[test]
+    fn preserves_result_for_terminal_status_without_replacement() {
+        assert!(!status_update_sql("completed", None).contains("result = NULL"));
+        assert!(!status_update_sql("failed", None).contains("result = NULL"));
+    }
 
     #[test]
     fn accepts_terminal_write_in_same_generation() {
@@ -363,5 +390,82 @@ mod tests {
             "root::1::inner::2::left::1",
             Some("root::1::inner::2::right::9")
         ));
+    }
+
+    #[test]
+    fn sibling_scopes_never_fence_each_other_in_either_direction() {
+        assert!(!incoming_stamp_is_superseded(
+            "root::0::left::9",
+            Some("root::0::right::0")
+        ));
+        assert!(!incoming_stamp_is_superseded(
+            "root::0::right::0",
+            Some("root::0::left::9")
+        ));
+    }
+
+    #[test]
+    fn unequal_depth_scopes_have_no_ordering_in_either_direction() {
+        assert!(!incoming_stamp_is_superseded(
+            "root::0",
+            Some("root::0::loop::7")
+        ));
+        assert!(!incoming_stamp_is_superseded(
+            "root::0::loop::7",
+            Some("root::0")
+        ));
+    }
+
+    #[test]
+    fn compares_generations_within_same_loop_child() {
+        assert!(incoming_stamp_is_superseded(
+            "root::0::loop::7",
+            Some("root::0::loop::8")
+        ));
+        assert!(!incoming_stamp_is_superseded(
+            "root::0::loop::8",
+            Some("root::0::loop::7")
+        ));
+    }
+
+    #[test]
+    fn rejects_join_branch_spawned_by_older_loop_generation() {
+        assert!(incoming_stamp_is_superseded(
+            "root::0::loop::3::branch::0",
+            Some("root::0::loop::4")
+        ));
+    }
+
+    #[test]
+    fn odd_token_count_disables_fence() {
+        assert!(stamp_lineage("root::0::loop").is_none());
+        assert!(!incoming_stamp_is_superseded(
+            "root::0::loop",
+            Some("root::0::loop::8")
+        ));
+    }
+
+    #[test]
+    fn nonnumeric_generation_disables_fence() {
+        assert!(stamp_lineage("root::generation").is_none());
+        assert!(!incoming_stamp_is_superseded(
+            "root::generation",
+            Some("root::8")
+        ));
+    }
+
+    #[test]
+    fn unparseable_existing_stamp_does_not_fence_valid_incoming_write() {
+        assert!(!incoming_stamp_is_superseded(
+            "root::8",
+            Some("root::generation")
+        ));
+    }
+
+    #[test]
+    fn numeric_node_id_remains_in_node_slot() {
+        let (generations, nodes) = stamp_lineage("root::1::12345678::2").unwrap();
+        assert_eq!(generations, vec![1, 2]);
+        assert_eq!(nodes, vec!["12345678"]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1701,6 +1701,86 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_fenced_node_status_update_releases_row_lock_before_return() {
+        let conn = test_database_connection_string();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+
+        rt.block_on(async {
+            let pool = sqlx::postgres::PgPoolOptions::new()
+                .max_connections(2)
+                .connect(&conn)
+                .await
+                .expect("connect to test database");
+
+            delete_expired_test_rows(&pool, "'aa265001'").await;
+            let mut fixture_tx = pool.begin().await.expect("begin fixture transaction");
+            sqlx::query("SET CONSTRAINTS ALL DEFERRED")
+                .execute(&mut *fixture_tx)
+                .await
+                .expect("defer fixture constraints");
+            sqlx::query(
+                "INSERT INTO df.instances (id, root_node, status, submitted_by) \
+                 VALUES ('aa265001', 'bb265001', 'running', current_user::regrole)",
+            )
+            .execute(&mut *fixture_tx)
+            .await
+            .expect("insert test instance");
+            sqlx::query(
+                "INSERT INTO df.nodes \
+                 (id, instance_id, node_type, query, status, submitted_by, status_details) \
+                 VALUES ('bb265001', 'aa265001', 'SQL', 'SELECT 1', 'running', \
+                         current_user::regrole, '{\"execution_id\":\"aa265001::2\"}'::jsonb)",
+            )
+            .execute(&mut *fixture_tx)
+            .await
+            .expect("insert test node");
+            fixture_tx.commit().await.expect("commit test fixture");
+
+            let mut tx = pool.begin().await.expect("begin locking transaction");
+            sqlx::query(
+                "SELECT status_details FROM df.nodes \
+                 WHERE id = 'bb265001' AND instance_id = 'aa265001' FOR UPDATE",
+            )
+            .fetch_one(&mut *tx)
+            .await
+            .expect("lock test node");
+
+            let writer_pool = pool.clone();
+            let writer = tokio::spawn(async move {
+                sqlx::query(
+                    "UPDATE df.nodes SET updated_at = pg_catalog.now() \
+                     WHERE id = 'bb265001' AND instance_id = 'aa265001'",
+                )
+                .execute(&writer_pool)
+                .await
+            });
+            tokio::task::yield_now().await;
+            assert!(
+                !writer.is_finished(),
+                "second writer should wait on row lock"
+            );
+
+            let result = crate::activities::update_node_status::finish_fenced_status_update(tx)
+                .await
+                .expect("fenced rollback");
+            assert!(result.contains("fenced"));
+
+            let rows = tokio::time::timeout(std::time::Duration::from_secs(1), writer)
+                .await
+                .expect("second writer remained blocked after fenced return")
+                .expect("second writer task")
+                .expect("second writer update")
+                .rows_affected();
+            assert_eq!(rows, 1);
+
+            delete_expired_test_rows(&pool, "'aa265001'").await;
+        });
+    }
+
+    #[pg_test]
     fn test_select_orphans_excludes_present_and_sub_orchestrations() {
         use std::collections::HashSet;
 

--- a/src/node_status.rs
+++ b/src/node_status.rs
@@ -319,7 +319,7 @@ mod tests {
             self.query = Some(q.to_string());
             self
         }
-        /// Stamp the node with an `execution_id` whose second "::"-token is `gen`.
+        /// Stamp the node with the complete `execution_id` string.
         fn gen(mut self, exec_id: &str) -> Self {
             self.status_details = Some(format!(r#"{{"execution_id":"{exec_id}"}}"#));
             self
@@ -558,5 +558,27 @@ mod tests {
             out.get("else").unwrap().from_ancestor_id.as_deref(),
             Some("if")
         );
+    }
+
+    #[test]
+    fn nested_scope_is_superseded_when_ancestor_advanced() {
+        let scope_max = HashMap::from([
+            ("root".to_string(), 2),
+            ("root::1::loop".to_string(), 4),
+            ("root::1::loop::3::branch".to_string(), 8),
+        ]);
+
+        assert!(is_superseded("root::1::loop::3::branch", 8, &scope_max));
+    }
+
+    #[test]
+    fn nested_scope_is_current_when_no_ancestor_advanced() {
+        let scope_max = HashMap::from([
+            ("root".to_string(), 1),
+            ("root::1::loop".to_string(), 3),
+            ("root::1::loop::3::branch".to_string(), 8),
+        ]);
+
+        assert!(!is_superseded("root::1::loop::3::branch", 8, &scope_max));
     }
 }

--- a/src/orchestrations/execute_function_graph.rs
+++ b/src/orchestrations/execute_function_graph.rs
@@ -314,11 +314,9 @@ pub async fn execute_subtree(
 ///
 /// `schedule_sub_orchestration_with_id` uses this value verbatim (no parent prefix), so we
 /// build `{parent_instance_id}::{parent_execution_id}::{child_root_node_id}`. This guarantees
-/// (a) the second `::`-token is always the ROOT loop generation — the parent instance id
-/// already begins with `{df_instance_id}::{generation}` at every nesting level, so the
-/// generation token survives nesting; and (b) per-iteration uniqueness — the parent execution
-/// id advances on every loop `continue_as_new`, while the child root node id distinguishes
-/// sibling branches. df.instance_nodes() and the write fence both rely on that second token.
+/// a complete parent-to-child lineage and per-generation uniqueness: the parent execution id
+/// advances on every loop `continue_as_new`, while the child root node id distinguishes sibling
+/// branches. df.instance_nodes() and the write fence walk the full composed lineage.
 fn subtree_instance_id(ctx: &OrchestrationContext, child_root_node_id: &str) -> String {
     format!(
         "{}::{}::{}",
@@ -360,10 +358,9 @@ async fn execute_function_node_with_vars(
     // node: "{orchestration_instance_id}::{execution_id}". For the root
     // orchestration this is "{df_instance_id}::{loop_generation}"; for a JOIN/RACE
     // sub-orchestration the instance id already carries the composed lineage (see
-    // `subtree_instance_id`), so the second "::"-token is always the root loop
-    // generation. df.instance_nodes() parses that token to derive pending/skipped
-    // and update_node_status uses it to fence stale writes. Both reads are
-    // deterministic (instance_id/execution_id are stable within an execution).
+    // `subtree_instance_id`). df.instance_nodes() and update_node_status walk the
+    // lineage generations to infer superseded nodes and fence stale writes. Both
+    // reads are deterministic (instance_id/execution_id are stable within an execution).
     let execution_stamp = format!("{}::{}", ctx.instance_id(), ctx.execution_id());
 
     // Mark node as running
@@ -670,6 +667,63 @@ async fn stamp_loop_node(
         .await;
 }
 
+async fn fail_loop_node(
+    ctx: &OrchestrationContext,
+    instance_id: &str,
+    loop_node_id: &str,
+    stamp: &str,
+    error: String,
+) -> Result<String, String> {
+    stamp_loop_node(
+        ctx,
+        instance_id,
+        loop_node_id,
+        "failed",
+        Some(&error),
+        stamp,
+    )
+    .await;
+    Err(error)
+}
+
+async fn fail_loop_before_start(
+    ctx: &OrchestrationContext,
+    graph: &FunctionGraph,
+    loop_node_id: &str,
+    error: String,
+) -> NodeResult {
+    let execution_stamp = format!("{}::{}", ctx.instance_id(), ctx.execution_id());
+    stamp_loop_node(
+        ctx,
+        &graph.instance_id,
+        loop_node_id,
+        "failed",
+        Some(&error),
+        &execution_stamp,
+    )
+    .await;
+    Err(NodeError::Failure(error))
+}
+
+async fn fail_loop_child_future(
+    ctx: &OrchestrationContext,
+    graph: &FunctionGraph,
+    loop_node_id: &str,
+    error: String,
+) -> NodeResult {
+    let child_stamp = format!("{}::1", subtree_instance_id(ctx, loop_node_id));
+    stamp_loop_node(
+        ctx,
+        &graph.instance_id,
+        loop_node_id,
+        "failed",
+        Some(&error),
+        &child_stamp,
+    )
+    .await;
+    Err(NodeError::Failure(error))
+}
+
 /// Run one iteration of a loop body (and its optional while-condition) for the
 /// `execute_loop` sub-orchestration.
 ///
@@ -774,9 +828,17 @@ pub async fn execute_loop(ctx: OrchestrationContext, input_json: String) -> Resu
         .as_str()
         .ok_or("Missing loop_node_id in ExecuteLoop input")?
         .to_string();
-    let results_json = input["results"]
-        .as_str()
-        .ok_or("Missing results in ExecuteLoop input")?;
+    let execution_stamp = format!("{}::{}", ctx.instance_id(), ctx.execution_id());
+    let Some(results_json) = input["results"].as_str() else {
+        return fail_loop_node(
+            &ctx,
+            &instance_id,
+            &loop_node_id,
+            &execution_stamp,
+            "Missing results in ExecuteLoop input".to_string(),
+        )
+        .await;
+    };
 
     // Iteration counter threaded across continue_as_new generations (M7).
     // Absent on the first generation (spawned by execute_loop_node), so default to 0.
@@ -784,18 +846,57 @@ pub async fn execute_loop(ctx: OrchestrationContext, input_json: String) -> Resu
 
     // re-load the graph from the database on every generation — this re-validates
     // submitted_by and catches cross-iteration security tampering.
-    let graph_json = ctx
+    let graph_json = match ctx
         .schedule_activity(activities::load_function_graph::NAME, instance_id.clone())
-        .await?;
-    let graph: FunctionGraph = serde_json::from_str(&graph_json)
-        .map_err(|e| format!("Failed to parse graph in ExecuteLoop: {e}"))?;
+        .await
+    {
+        Ok(graph_json) => graph_json,
+        Err(e) => {
+            return fail_loop_node(&ctx, &instance_id, &loop_node_id, &execution_stamp, e).await;
+        }
+    };
+    let graph: FunctionGraph = match serde_json::from_str(&graph_json) {
+        Ok(graph) => graph,
+        Err(e) => {
+            return fail_loop_node(
+                &ctx,
+                &instance_id,
+                &loop_node_id,
+                &execution_stamp,
+                format!("Failed to parse graph in ExecuteLoop: {e}"),
+            )
+            .await;
+        }
+    };
 
-    let mut results: HashMap<String, String> = serde_json::from_str(results_json)
-        .map_err(|e| format!("Failed to parse results in ExecuteLoop: {e}"))?;
+    let mut results: HashMap<String, String> = match serde_json::from_str(results_json) {
+        Ok(results) => results,
+        Err(e) => {
+            return fail_loop_node(
+                &ctx,
+                &instance_id,
+                &loop_node_id,
+                &execution_stamp,
+                format!("Failed to parse results in ExecuteLoop: {e}"),
+            )
+            .await;
+        }
+    };
 
     let vars: HashMap<String, String> = if let Some(vars_str) = input["vars"].as_str() {
-        serde_json::from_str(vars_str)
-            .map_err(|e| format!("Failed to parse vars in ExecuteLoop: {e}"))?
+        match serde_json::from_str(vars_str) {
+            Ok(vars) => vars,
+            Err(e) => {
+                return fail_loop_node(
+                    &ctx,
+                    &instance_id,
+                    &loop_node_id,
+                    &execution_stamp,
+                    format!("Failed to parse vars in ExecuteLoop: {e}"),
+                )
+                .await;
+            }
+        }
     } else {
         HashMap::new()
     };
@@ -807,16 +908,27 @@ pub async fn execute_loop(ctx: OrchestrationContext, input_json: String) -> Resu
         loop_iteration: iteration,
     };
 
-    let node = graph
-        .nodes
-        .get(&loop_node_id)
-        .ok_or_else(|| format!("Loop node not found: {loop_node_id}"))?;
+    let Some(node) = graph.nodes.get(&loop_node_id) else {
+        return fail_loop_node(
+            &ctx,
+            &instance_id,
+            &loop_node_id,
+            &execution_stamp,
+            format!("Loop node not found: {loop_node_id}"),
+        )
+        .await;
+    };
 
-    let body_id = node
-        .left_node
-        .as_ref()
-        .ok_or_else(|| format!("LOOP node {loop_node_id} has no body"))?
-        .clone();
+    let Some(body_id) = node.left_node.clone() else {
+        return fail_loop_node(
+            &ctx,
+            &instance_id,
+            &loop_node_id,
+            &execution_stamp,
+            format!("LOOP node {loop_node_id} has no body"),
+        )
+        .await;
+    };
 
     // Capture iteration start time for rate-limiting continue_as_new.
     let iter_started = ctx.utc_now().await.ok();
@@ -827,7 +939,6 @@ pub async fn execute_loop(ctx: OrchestrationContext, input_json: String) -> Resu
     // the composed lineage (subtree_instance_id), so the trailing `::`-token is this child's
     // continue_as_new generation — what df.instance_nodes()/df.explain() and the write fence
     // read to infer pending/skipped and to fence stale writes.
-    let execution_stamp = format!("{}::{}", ctx.instance_id(), ctx.execution_id());
     stamp_loop_node(
         &ctx,
         &instance_id,
@@ -920,18 +1031,49 @@ pub async fn execute_loop(ctx: OrchestrationContext, input_json: String) -> Resu
     ctx.trace_info(format!(
         "Loop continuing with continue_as_new at node {loop_node_id}"
     ));
-    let new_results_json = string_map_to_json(&results)
-        .map_err(|e| format!("Failed to serialize updated results: {e}"))?;
+    let new_results_json = match string_map_to_json(&results) {
+        Ok(results) => results,
+        Err(e) => {
+            return fail_loop_node(
+                &ctx,
+                &instance_id,
+                &loop_node_id,
+                &execution_stamp,
+                format!("Failed to serialize updated results: {e}"),
+            )
+            .await;
+        }
+    };
     let mut new_input = input.clone();
     new_input["results"] = serde_json::Value::String(new_results_json);
     // Persist the incremented iteration counter for the next generation (M7).
     new_input["iteration"] = serde_json::Value::Number(next_iteration.into());
-    let new_input_json = serde_json::to_string(&new_input)
-        .map_err(|e| format!("Failed to serialize loop input: {e}"))?;
-    ctx.continue_as_new(new_input_json)
-        .await
-        .map(|_| String::new())
-        .map_err(|e| format!("continue_as_new failed: {e:?}"))
+    let new_input_json = match serde_json::to_string(&new_input) {
+        Ok(input) => input,
+        Err(e) => {
+            return fail_loop_node(
+                &ctx,
+                &instance_id,
+                &loop_node_id,
+                &execution_stamp,
+                format!("Failed to serialize loop input: {e}"),
+            )
+            .await;
+        }
+    };
+    match ctx.continue_as_new(new_input_json).await {
+        Ok(_) => Ok(String::new()),
+        Err(e) => {
+            fail_loop_node(
+                &ctx,
+                &instance_id,
+                &loop_node_id,
+                &execution_stamp,
+                format!("continue_as_new failed: {e:?}"),
+            )
+            .await
+        }
+    }
 }
 
 /// Execute a loop node.
@@ -942,8 +1084,8 @@ pub async fn execute_loop(ctx: OrchestrationContext, input_json: String) -> Resu
 /// `continue_as_new` restarts the root orchestration, and with no upstream prefix to
 /// re-execute, re-entering from the root lands back on this same loop node each
 /// generation. Running inline also keeps the body's node stamps under the root df
-/// instance id (so the second `::`-token of every stamp is the loop generation), which
-/// df.instance_nodes()/df.explain() and the write fence rely on.
+/// instance id; df.instance_nodes()/df.explain() and the write fence compare the
+/// trailing generation and any composed ancestor generations.
 async fn execute_loop_node(
     ctx: &OrchestrationContext,
     graph: &FunctionGraph,
@@ -1030,10 +1172,10 @@ async fn execute_loop_node(
 /// parallel branch needs its own durable instance (#233). The child (`execute_loop`)
 /// advances iterations via its own `continue_as_new`, so the parent's prefix is preserved.
 ///
-/// The child instance id is built with `subtree_instance_id`, giving it the root loop
-/// generation as the second `::`-token (for node-status inference and the write fence) and a
-/// per-iteration-unique id (the parent execution id advances on each generation, so a loop
-/// inside a parallel branch never collides across iterations). The loop node itself is the
+/// The child instance id is built with `subtree_instance_id`, preserving every ancestor
+/// scope and generation for node-status inference and the write fence. It is unique per
+/// iteration because the parent execution id advances on each generation, so a loop inside
+/// a parallel branch never collides across iterations. The loop node itself is the
 /// root of this child instance and is stamped (running/completed/failed) there — NOT by the
 /// parent — so the parent invokes this *before* any status stamping (see
 /// `execute_function_node_with_vars`).
@@ -1046,14 +1188,40 @@ async fn execute_loop_suborchestration(
     exec_ctx: &ExecutionContext,
 ) -> NodeResult {
     // Validate the loop has a body before spawning the child sub-orchestration.
-    node.left_node
-        .as_ref()
-        .ok_or_else(|| format!("LOOP node {node_id} has no body"))?;
+    if node.left_node.is_none() {
+        return fail_loop_before_start(
+            ctx,
+            graph,
+            node_id,
+            format!("LOOP node {node_id} has no body"),
+        )
+        .await;
+    }
 
-    let results_json =
-        serde_json::to_string(results).map_err(|e| format!("Failed to serialize results: {e}"))?;
-    let vars_json =
-        string_map_to_json(&exec_ctx.vars).map_err(|e| format!("Failed to serialize vars: {e}"))?;
+    let results_json = match string_map_to_json(results) {
+        Ok(results) => results,
+        Err(e) => {
+            return fail_loop_before_start(
+                ctx,
+                graph,
+                node_id,
+                format!("Failed to serialize results: {e}"),
+            )
+            .await;
+        }
+    };
+    let vars_json = match string_map_to_json(&exec_ctx.vars) {
+        Ok(vars) => vars,
+        Err(e) => {
+            return fail_loop_before_start(
+                ctx,
+                graph,
+                node_id,
+                format!("Failed to serialize vars: {e}"),
+            )
+            .await;
+        }
+    };
 
     let loop_input = serde_json::json!({
         "instance_id": graph.instance_id,
@@ -1069,14 +1237,25 @@ async fn execute_loop_suborchestration(
         "Spawning loop sub-orchestration for node {node_id}"
     ));
 
-    let raw = ctx
+    let raw = match ctx
         .schedule_sub_orchestration_with_id(
             LOOP_NAME,
             subtree_instance_id(ctx, node_id),
             loop_input,
         )
         .await
-        .map_err(|e| format!("Loop sub-orchestration failed: {e}"))?;
+    {
+        Ok(raw) => raw,
+        Err(e) => {
+            return fail_loop_child_future(
+                ctx,
+                graph,
+                node_id,
+                format!("Loop sub-orchestration failed: {e}"),
+            )
+            .await;
+        }
+    };
 
     // Merge named results from the loop sub-orchestration back into the parent map and
     // return the loop's final result.  The loop always returns a `Normal` envelope (a break
@@ -1311,6 +1490,33 @@ fn branch_child_orchestration(
     }
 }
 
+async fn cancel_losing_loop_branch(
+    ctx: &OrchestrationContext,
+    graph: &FunctionGraph,
+    branch_node_id: &str,
+) {
+    let is_loop = graph
+        .nodes
+        .get(branch_node_id)
+        .map(|node| node.node_type.eq_ignore_ascii_case("loop"))
+        .unwrap_or(false);
+    if !is_loop {
+        return;
+    }
+
+    let child_instance_id = subtree_instance_id(ctx, branch_node_id);
+    let child_stamp = format!("{child_instance_id}::1");
+    stamp_loop_node(
+        ctx,
+        &graph.instance_id,
+        branch_node_id,
+        "failed",
+        Some("Loop branch cancelled after losing RACE"),
+        &child_stamp,
+    )
+    .await;
+}
+
 async fn execute_join_node(
     ctx: &OrchestrationContext,
     graph: &FunctionGraph,
@@ -1397,6 +1603,20 @@ async fn execute_join_node(
                 join_results.push(parsed);
             }
             Err(e) => {
+                if graph
+                    .nodes
+                    .get(&branch_ids[i])
+                    .map(|branch| branch.node_type.eq_ignore_ascii_case("loop"))
+                    .unwrap_or(false)
+                {
+                    return fail_loop_child_future(
+                        ctx,
+                        graph,
+                        &branch_ids[i],
+                        format!("JOIN branch {} failed: {}", i + 1, e),
+                    )
+                    .await;
+                }
                 return Err(NodeError::Failure(format!(
                     "JOIN branch {} failed: {}",
                     i + 1,
@@ -1485,14 +1705,50 @@ async fn execute_race_node(
     let raw = match ctx.select2(left_fut, right_fut).await {
         duroxide::Either2::First(Ok(r)) => {
             ctx.trace_info("RACE completed - left branch won");
+            cancel_losing_loop_branch(ctx, graph, right_id).await;
             Ok(r)
         }
-        duroxide::Either2::First(Err(e)) => Err(format!("RACE left branch failed: {e}")),
+        duroxide::Either2::First(Err(e)) => {
+            cancel_losing_loop_branch(ctx, graph, right_id).await;
+            if graph
+                .nodes
+                .get(left_id)
+                .map(|branch| branch.node_type.eq_ignore_ascii_case("loop"))
+                .unwrap_or(false)
+            {
+                return fail_loop_child_future(
+                    ctx,
+                    graph,
+                    left_id,
+                    format!("RACE left branch failed: {e}"),
+                )
+                .await;
+            }
+            Err(format!("RACE left branch failed: {e}"))
+        }
         duroxide::Either2::Second(Ok(r)) => {
             ctx.trace_info("RACE completed - right branch won");
+            cancel_losing_loop_branch(ctx, graph, left_id).await;
             Ok(r)
         }
-        duroxide::Either2::Second(Err(e)) => Err(format!("RACE right branch failed: {e}")),
+        duroxide::Either2::Second(Err(e)) => {
+            cancel_losing_loop_branch(ctx, graph, left_id).await;
+            if graph
+                .nodes
+                .get(right_id)
+                .map(|branch| branch.node_type.eq_ignore_ascii_case("loop"))
+                .unwrap_or(false)
+            {
+                return fail_loop_child_future(
+                    ctx,
+                    graph,
+                    right_id,
+                    format!("RACE right branch failed: {e}"),
+                )
+                .await;
+            }
+            Err(format!("RACE right branch failed: {e}"))
+        }
     }?;
 
     // Parse the subtree output envelope produced by execute_subtree and merge any named

--- a/tests/e2e/sql/53_inferred_status.sql
+++ b/tests/e2e/sql/53_inferred_status.sql
@@ -193,24 +193,25 @@ DO $$
 DECLARE
     inst_id TEXT;
     status TEXT;
-    skipped_count INT;
+    skipped_status TEXT;
     running_count INT;
     loop_inferred TEXT;
 BEGIN
     SELECT instance_id INTO inst_id FROM _test_state;
-    SELECT df.wait_for_completion(inst_id, 90) INTO status;
+    SELECT df.await_instance(inst_id, 90) INTO status;
 
     IF lower(status) != 'completed' THEN
         RAISE EXCEPTION 'TEST FAILED [nonroot-loop-inferred]: status = %', status;
     END IF;
 
-    -- The untaken ELSE arm ('SELECT 999') never runs in any generation → skipped.
-    SELECT count(*) INTO skipped_count
+    -- Assert the specific untaken ELSE arm. A count of all skipped nodes is vacuous here
+    -- because the break-IF also has an untaken sleep branch.
+    SELECT inferred_status INTO skipped_status
     FROM df.instance_nodes(inst_id)
-    WHERE inferred_status = 'skipped';
+    WHERE query = 'SELECT 999';
 
-    IF skipped_count < 1 THEN
-        RAISE EXCEPTION 'TEST FAILED [nonroot-loop-inferred]: expected >= 1 skipped node, got %', skipped_count;
+    IF skipped_status IS DISTINCT FROM 'skipped' THEN
+        RAISE EXCEPTION 'TEST FAILED [nonroot-loop-inferred]: SELECT 999 inferred_status = % (expected skipped)', skipped_status;
     END IF;
 
     -- After completion nothing may be reported as still running (superseded older-generation

--- a/tests/e2e/sql/55_nonroot_loop.sql
+++ b/tests/e2e/sql/55_nonroot_loop.sql
@@ -47,7 +47,7 @@ BEGIN
     SELECT instance_id INTO v_id FROM _t1;
     RAISE NOTICE 'Test 1 - non-root loop prefix: instance %', v_id;
 
-    SELECT df.wait_for_completion(v_id, 90) INTO v_status;
+    SELECT df.await_instance(v_id, 90) INTO v_status;
 
     IF v_status != 'completed' THEN
         RAISE EXCEPTION 'TEST FAILED [nonroot-prefix]: expected completed, got %', v_status;
@@ -114,7 +114,7 @@ BEGIN
     SELECT instance_id INTO v_id FROM _t2;
     RAISE NOTICE 'Test 2 - non-root loop prefix+suffix: instance %', v_id;
 
-    SELECT df.wait_for_completion(v_id, 90) INTO v_status;
+    SELECT df.await_instance(v_id, 90) INTO v_status;
 
     IF v_status != 'completed' THEN
         RAISE EXCEPTION 'TEST FAILED [nonroot-suffix]: expected completed, got %', v_status;
@@ -151,22 +151,27 @@ DROP TABLE test_nonroot2_suffix;
 -- sub-orchestration's input).
 
 DROP TABLE IF EXISTS test_nonroot3_log;
+DROP TABLE IF EXISTS test_nonroot3_suffix;
 CREATE TABLE test_nonroot3_log (id SERIAL, val TEXT, ts TIMESTAMPTZ DEFAULT clock_timestamp());
+CREATE TABLE test_nonroot3_suffix (val TEXT);
 
 CREATE TEMP TABLE _t3 AS
 SELECT df.start(
     df.seq(
         ('SELECT ''hello'' AS greeting' |=> 'prefix_result'),
-        df.loop(
-            ($$INSERT INTO test_nonroot3_log (val)
-               VALUES ($prefix_result)
-               RETURNING val$$
-            |=> 'last_val')
-            ~> (
-                'SELECT COUNT(*) >= 2 FROM test_nonroot3_log'
-                    ?> df.break()
-                    !> df.sleep(1)
-            )
+        df.seq(
+            df.loop(
+                ($$INSERT INTO test_nonroot3_log (val)
+                   VALUES ($prefix_result)
+                   RETURNING val$$
+                |=> 'last_val')
+                ~> (
+                    'SELECT COUNT(*) >= 2 FROM test_nonroot3_log'
+                        ?> df.break()
+                        !> df.sleep(1)
+                )
+            ),
+            $$INSERT INTO test_nonroot3_suffix (val) VALUES ($last_val.val)$$
         )
     ),
     'test-nonroot-loop-named-result'
@@ -178,11 +183,12 @@ DECLARE
     v_status TEXT;
     v_cnt    INT;
     v_val    TEXT;
+    v_suffix TEXT;
 BEGIN
     SELECT instance_id INTO v_id FROM _t3;
     RAISE NOTICE 'Test 3 - non-root loop uses prefix named result: instance %', v_id;
 
-    SELECT df.wait_for_completion(v_id, 90) INTO v_status;
+    SELECT df.await_instance(v_id, 90) INTO v_status;
 
     IF v_status != 'completed' THEN
         RAISE EXCEPTION 'TEST FAILED [nonroot-named]: expected completed, got %', v_status;
@@ -198,11 +204,17 @@ BEGIN
         RAISE EXCEPTION 'TEST FAILED [nonroot-named]: expected ''hello'', got ''%''', v_val;
     END IF;
 
+    SELECT val INTO v_suffix FROM test_nonroot3_suffix;
+    IF v_suffix IS DISTINCT FROM 'hello' THEN
+        RAISE EXCEPTION 'TEST FAILED [nonroot-named]: loop child named result did not reach suffix, got ''%''', v_suffix;
+    END IF;
+
     RAISE NOTICE 'PASSED: non-root loop uses prefix named result across iterations';
 END $$;
 
 DROP TABLE _t3;
 DROP TABLE test_nonroot3_log;
+DROP TABLE test_nonroot3_suffix;
 
 RESET SESSION AUTHORIZATION;
 SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/56_loop_contains_join_race.sql
+++ b/tests/e2e/sql/56_loop_contains_join_race.sql
@@ -54,7 +54,7 @@ BEGIN
     SELECT instance_id INTO v_id FROM _t1;
     RAISE NOTICE 'Test 1 - JOIN inside loop body: instance %', v_id;
 
-    SELECT df.wait_for_completion(v_id, 90) INTO v_status;
+    SELECT df.await_instance(v_id, 90) INTO v_status;
 
     IF v_status != 'completed' THEN
         RAISE EXCEPTION 'TEST FAILED [loop-join]: expected completed, got %', v_status;
@@ -124,7 +124,7 @@ BEGIN
     SELECT instance_id INTO v_id FROM _t2;
     RAISE NOTICE 'Test 2 - RACE inside loop body: instance %', v_id;
 
-    SELECT df.wait_for_completion(v_id, 90) INTO v_status;
+    SELECT df.await_instance(v_id, 90) INTO v_status;
 
     IF v_status != 'completed' THEN
         RAISE EXCEPTION 'TEST FAILED [loop-race]: expected completed, got %', v_status;

--- a/tests/e2e/sql/57_loop_in_join_race_branch.sql
+++ b/tests/e2e/sql/57_loop_in_join_race_branch.sql
@@ -48,7 +48,7 @@ BEGIN
     SELECT instance_id INTO v_id FROM _t1;
     RAISE NOTICE 'Test 1 - loop inside JOIN branch: instance %', v_id;
 
-    SELECT df.wait_for_completion(v_id, 90) INTO v_status;
+    SELECT df.await_instance(v_id, 90) INTO v_status;
 
     IF v_status != 'completed' THEN
         RAISE EXCEPTION 'TEST FAILED [join-loop]: expected completed, got %', v_status;
@@ -106,7 +106,7 @@ BEGIN
     SELECT instance_id INTO v_id FROM _t2;
     RAISE NOTICE 'Test 2 - loop inside RACE branch: instance %', v_id;
 
-    SELECT df.wait_for_completion(v_id, 90) INTO v_status;
+    SELECT df.await_instance(v_id, 90) INTO v_status;
 
     IF v_status != 'completed' THEN
         RAISE EXCEPTION 'TEST FAILED [race-loop]: expected completed, got %', v_status;
@@ -136,7 +136,7 @@ DROP TABLE test_raceloop_body;
 -- The loop branch must NOT be double-wrapped (execute-subtree -> execute-loop): doing so
 -- would create a third sub-orchestration for the single loop branch.  We verify the loop's
 -- own node is stamped by an orchestration instance that is a *direct* child of the parent,
--- i.e. `{parent}::1::{loop_node_id}` — not `{parent}::1::{loop_node_id}::1::{loop_node_id}`.
+-- i.e. `{parent}::{parent_generation}::{loop_node_id}`, with no subtree wrapper in between.
 --
 -- The stamp recorded in df.nodes.status_details->>'execution_id' has the shape
 -- `{orchestration_instance_id}::{execution_id}`, and an orchestration instance id is itself
@@ -168,13 +168,14 @@ DECLARE
     v_loop_node     TEXT;
     v_loop_scope    TEXT;
     v_body_scope    TEXT;
-    v_expected      TEXT;
+    v_loop_tokens   TEXT[];
+    v_loop_parent   TEXT;
     v_distinct_orch INT;
 BEGIN
     SELECT instance_id INTO v_id FROM _t3;
     RAISE NOTICE 'Test 3 - race(loop, sleep) topology: instance %', v_id;
 
-    SELECT df.wait_for_completion(v_id, 90) INTO v_status;
+    SELECT df.await_instance(v_id, 90) INTO v_status;
     IF v_status != 'completed' THEN
         RAISE EXCEPTION 'TEST FAILED [topo]: expected completed, got %', v_status;
     END IF;
@@ -186,21 +187,26 @@ BEGIN
 
     -- Strip the trailing ::<generation> token from the loop node's stamp to recover the
     -- loop sub-orchestration's instance id.
-    SELECT substring(status_details->>'execution_id' FROM '^(.*)::[0-9]+$')
+    SELECT array_to_string(
+               (string_to_array(status_details->>'execution_id', '::'))[1:array_length(string_to_array(status_details->>'execution_id', '::'), 1) - 1],
+               '::'
+           )
       INTO v_loop_scope
       FROM df.nodes
      WHERE instance_id = v_id AND id = v_loop_node;
 
-    -- A directly-spawned loop child runs in `{parent}::1::{loop_node_id}`.  A double-wrapped
-    -- loop (subtree -> loop) would instead read `{parent}::1::{loop_node_id}::1::{loop_node_id}`.
-    v_expected := v_id || '::1::' || v_loop_node;
-    IF v_loop_scope IS DISTINCT FROM v_expected THEN
-        RAISE EXCEPTION 'TEST FAILED [topo]: loop sub-orchestration id = % (expected %); loop was double-wrapped',
-            v_loop_scope, v_expected;
+    v_loop_tokens := string_to_array(v_loop_scope, '::');
+    v_loop_parent := array_to_string(v_loop_tokens[1:array_length(v_loop_tokens, 1) - 2], '::');
+    IF v_loop_parent IS DISTINCT FROM v_id OR v_loop_tokens[array_length(v_loop_tokens, 1)] IS DISTINCT FROM v_loop_node THEN
+        RAISE EXCEPTION 'TEST FAILED [topo]: loop scope % is not a direct child of parent % rooted at node %',
+            v_loop_scope, v_id, v_loop_node;
     END IF;
 
     -- The loop body (the INSERT SQL node) must run inside the SAME loop sub-orchestration.
-    SELECT substring(status_details->>'execution_id' FROM '^(.*)::[0-9]+$')
+    SELECT array_to_string(
+               (string_to_array(status_details->>'execution_id', '::'))[1:array_length(string_to_array(status_details->>'execution_id', '::'), 1) - 1],
+               '::'
+           )
       INTO v_body_scope
       FROM df.nodes
      WHERE instance_id = v_id
@@ -212,22 +218,20 @@ BEGIN
     END IF;
 
     -- Count distinct orchestration instances that stamped any node of this instance.
-    -- Correct topology = 3 (parent RACE + loop sub + right-branch subtree).  A double-wrapped
-    -- loop would add a fourth (the redundant subtree wrapper around the loop), so <= 3 is the
-    -- regression guard.  (The abandoned right branch reliably stamps its node 'running' before
-    -- the race is decided, so 3 is what we observe.)
-    SELECT count(DISTINCT substring(status_details->>'execution_id' FROM '^(.*)::[0-9]+$'))
+    -- Correct topology is exactly three scopes: parent RACE, loop child, and right-branch
+    -- subtree. A double-wrapped loop adds a fourth. The abandoned right branch reliably stamps
+    -- its node running before the race is decided, so all three expected scopes are observable.
+    SELECT count(DISTINCT array_to_string(
+               (string_to_array(status_details->>'execution_id', '::'))[1:array_length(string_to_array(status_details->>'execution_id', '::'), 1) - 1],
+               '::'
+           ))
       INTO v_distinct_orch
       FROM df.nodes
      WHERE instance_id = v_id
        AND status_details->>'execution_id' IS NOT NULL;
 
-    IF v_distinct_orch > 3 THEN
-        RAISE EXCEPTION 'TEST FAILED [topo]: % distinct orchestration scopes (> 3 means the loop branch was double-wrapped)', v_distinct_orch;
-    END IF;
-
-    IF v_distinct_orch < 2 THEN
-        RAISE EXCEPTION 'TEST FAILED [topo]: % distinct orchestration scopes (expected parent + loop sub at minimum)', v_distinct_orch;
+    IF v_distinct_orch != 3 THEN
+        RAISE EXCEPTION 'TEST FAILED [topo]: % distinct orchestration scopes (expected exactly parent + loop child + sibling child)', v_distinct_orch;
     END IF;
 
     RAISE NOTICE 'PASSED: race(loop, sleep) = 1 parent + 2 subs; loop spawned directly (% distinct scopes)', v_distinct_orch;

--- a/tests/e2e/sql/61_loop_child_start_failure.sql
+++ b/tests/e2e/sql/61_loop_child_start_failure.sql
@@ -1,0 +1,83 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the PostgreSQL License.
+
+-- A non-root loop child that fails before its first status stamp must still leave
+-- the LOOP node terminal. Removing the submitting role after the parent loads the
+-- graph makes the child's graph reload fail deterministically.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'loop_child_start_user') THEN
+        DROP OWNED BY loop_child_start_user;
+        DROP ROLE loop_child_start_user;
+    END IF;
+END $$;
+CREATE ROLE loop_child_start_user LOGIN;
+SELECT df.grant_usage('loop_child_start_user');
+
+DROP TABLE IF EXISTS test_loop_child_start_log;
+CREATE TABLE test_loop_child_start_log (marker INT);
+GRANT INSERT ON test_loop_child_start_log TO loop_child_start_user;
+
+CREATE TEMP TABLE _loop_child_start_instance (instance_id TEXT);
+GRANT INSERT ON _loop_child_start_instance TO loop_child_start_user;
+
+SET SESSION AUTHORIZATION loop_child_start_user;
+INSERT INTO _loop_child_start_instance
+SELECT df.start(
+    'INSERT INTO test_loop_child_start_log VALUES (1)'
+    ~> df.sleep(3)
+    ~> df.loop('SELECT 1', 'SELECT false'),
+    'test-loop-child-start-failure'
+);
+RESET SESSION AUTHORIZATION;
+
+DO $$
+DECLARE
+    attempts INT := 0;
+BEGIN
+    WHILE NOT EXISTS (SELECT 1 FROM test_loop_child_start_log) LOOP
+        IF attempts >= 100 THEN
+            RAISE EXCEPTION 'TEST FAILED [loop-child-start]: prefix did not execute';
+        END IF;
+        PERFORM pg_sleep(0.1);
+        attempts := attempts + 1;
+    END LOOP;
+END $$;
+
+DROP OWNED BY loop_child_start_user;
+DROP ROLE loop_child_start_user;
+
+DO $$
+DECLARE
+    instance_id TEXT;
+    final_status TEXT;
+    loop_status TEXT;
+    loop_inferred_status TEXT;
+BEGIN
+    SELECT i.instance_id INTO instance_id FROM _loop_child_start_instance i;
+    SELECT df.await_instance(instance_id, 30) INTO final_status;
+
+    IF final_status IS DISTINCT FROM 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [loop-child-start]: expected failed instance, got %', final_status;
+    END IF;
+
+    SELECT n.status, n.inferred_status
+    INTO loop_status, loop_inferred_status
+    FROM df.instance_nodes(instance_id) n
+    WHERE n.node_type = 'LOOP';
+
+    IF loop_status IS DISTINCT FROM 'failed' OR loop_inferred_status IS DISTINCT FROM 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [loop-child-start]: expected failed LOOP node, got physical %, inferred %',
+            loop_status, loop_inferred_status;
+    END IF;
+
+    IF df.explain(instance_id) LIKE '%LOOP%pending%' THEN
+        RAISE EXCEPTION 'TEST FAILED [loop-child-start]: df.explain() left LOOP node pending: %',
+            df.explain(instance_id);
+    END IF;
+END $$;
+
+DROP TABLE _loop_child_start_instance;
+DROP TABLE test_loop_child_start_log;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/62_root_loop_contains_join.sql
+++ b/tests/e2e/sql/62_root_loop_contains_join.sql
@@ -1,0 +1,125 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the PostgreSQL License.
+
+-- Regression for issue #230: a root loop containing a JOIN must use fresh child
+-- orchestration state on every continue-as-new generation.
+SET SESSION AUTHORIZATION df_e2e_user;
+
+DROP TABLE IF EXISTS test_root_loop_join_left;
+DROP TABLE IF EXISTS test_root_loop_join_right;
+CREATE TABLE test_root_loop_join_left (iteration INT PRIMARY KEY);
+CREATE TABLE test_root_loop_join_right (iteration INT PRIMARY KEY);
+
+CREATE TEMP TABLE _root_loop_join_instance AS
+SELECT df.start(
+    df.loop(
+        (
+            $$INSERT INTO test_root_loop_join_left
+                SELECT COUNT(*) + 1 FROM test_root_loop_join_left$$
+            &
+            $$INSERT INTO test_root_loop_join_right
+                SELECT COUNT(*) + 1 FROM test_root_loop_join_right$$
+        )
+        ~> (
+            'SELECT COUNT(*) >= 3 FROM test_root_loop_join_left'
+                ?> df.break('done')
+                !> df.sleep(1)
+        )
+    ),
+    'test-root-loop-contains-join'
+) AS instance_id;
+
+DO $$
+DECLARE
+    instance_id TEXT;
+    final_status TEXT;
+    left_iterations INT[];
+    right_iterations INT[];
+BEGIN
+    SELECT i.instance_id INTO instance_id FROM _root_loop_join_instance i;
+    SELECT df.await_instance(instance_id, 60) INTO final_status;
+
+    IF final_status IS DISTINCT FROM 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [root-loop-join]: expected completed, got %', final_status;
+    END IF;
+
+    SELECT array_agg(iteration ORDER BY iteration)
+    INTO left_iterations
+    FROM test_root_loop_join_left;
+
+    SELECT array_agg(iteration ORDER BY iteration)
+    INTO right_iterations
+    FROM test_root_loop_join_right;
+
+    IF left_iterations IS DISTINCT FROM ARRAY[1, 2, 3] THEN
+        RAISE EXCEPTION 'TEST FAILED [root-loop-join]: expected left iterations {1,2,3}, got %', left_iterations;
+    END IF;
+
+    IF right_iterations IS DISTINCT FROM ARRAY[1, 2, 3] THEN
+        RAISE EXCEPTION 'TEST FAILED [root-loop-join]: expected right iterations {1,2,3}, got %', right_iterations;
+    END IF;
+END $$;
+
+DROP TABLE _root_loop_join_instance;
+DROP TABLE test_root_loop_join_left;
+DROP TABLE test_root_loop_join_right;
+
+-- A root loop containing a RACE exercises the same generation boundary with
+-- select cancellation rather than join completion.
+DROP TABLE IF EXISTS test_root_loop_race_iterations;
+DROP TABLE IF EXISTS test_root_loop_race_winners;
+CREATE TABLE test_root_loop_race_iterations (iteration INT PRIMARY KEY);
+CREATE TABLE test_root_loop_race_winners (iteration INT PRIMARY KEY);
+
+CREATE TEMP TABLE _root_loop_race_instance AS
+SELECT df.start(
+    df.loop(
+        $$INSERT INTO test_root_loop_race_iterations
+            SELECT COUNT(*) + 1 FROM test_root_loop_race_iterations$$
+        ~> df.race(
+            $$INSERT INTO test_root_loop_race_winners
+                SELECT COUNT(*) FROM test_root_loop_race_iterations$$,
+            df.sleep(30)
+        )
+        ~> (
+            'SELECT COUNT(*) >= 3 FROM test_root_loop_race_iterations'
+                ?> df.break('done')
+                !> df.sleep(1)
+        )
+    ),
+    'test-root-loop-contains-race'
+) AS instance_id;
+
+DO $$
+DECLARE
+    instance_id TEXT;
+    final_status TEXT;
+    iterations INT[];
+    winners INT[];
+BEGIN
+    SELECT i.instance_id INTO instance_id FROM _root_loop_race_instance i;
+    SELECT df.await_instance(instance_id, 60) INTO final_status;
+
+    IF final_status IS DISTINCT FROM 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [root-loop-race]: expected completed, got %', final_status;
+    END IF;
+
+    SELECT array_agg(iteration ORDER BY iteration)
+    INTO iterations
+    FROM test_root_loop_race_iterations;
+
+    SELECT array_agg(iteration ORDER BY iteration)
+    INTO winners
+    FROM test_root_loop_race_winners;
+
+    IF iterations IS DISTINCT FROM ARRAY[1, 2, 3] OR winners IS DISTINCT FROM ARRAY[1, 2, 3] THEN
+        RAISE EXCEPTION 'TEST FAILED [root-loop-race]: expected iterations/winners {1,2,3}, got % / %',
+            iterations, winners;
+    END IF;
+END $$;
+
+DROP TABLE _root_loop_race_instance;
+DROP TABLE test_root_loop_race_iterations;
+DROP TABLE test_root_loop_race_winners;
+RESET SESSION AUTHORIZATION;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/63_race_losing_loop_cancelled.sql
+++ b/tests/e2e/sql/63_race_losing_loop_cancelled.sql
@@ -1,0 +1,55 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the PostgreSQL License.
+
+-- A loop that loses a RACE is cancelled by duroxide when its durable future is
+-- dropped. The parent must record that cancellation on the LOOP node so
+-- df.instance_nodes() and df.explain() do not leave it running.
+SET SESSION AUTHORIZATION df_e2e_user;
+
+CREATE TEMP TABLE _race_losing_loop_instance AS
+SELECT df.start(
+    df.race(
+        df.sleep(1),
+        df.loop(df.sleep(30))
+    ),
+    'test-race-losing-loop-cancelled'
+) AS instance_id;
+
+DO $$
+DECLARE
+    instance_id TEXT;
+    final_status TEXT;
+    loop_status TEXT;
+    loop_inferred_status TEXT;
+    loop_stamp TEXT;
+BEGIN
+    SELECT i.instance_id INTO instance_id FROM _race_losing_loop_instance i;
+    SELECT df.await_instance(instance_id, 30) INTO final_status;
+
+    IF final_status IS DISTINCT FROM 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [race-losing-loop]: expected completed instance, got %', final_status;
+    END IF;
+
+    SELECT n.status, n.inferred_status, n.status_details::jsonb->>'execution_id'
+    INTO loop_status, loop_inferred_status, loop_stamp
+    FROM df.instance_nodes(instance_id) n
+    WHERE n.node_type = 'LOOP';
+
+    IF loop_status IS DISTINCT FROM 'failed' OR loop_inferred_status IS DISTINCT FROM 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [race-losing-loop]: expected terminal failed LOOP node, got physical %, inferred %',
+            loop_status, loop_inferred_status;
+    END IF;
+
+    IF loop_stamp !~ ('^' || instance_id || '::1::[0-9a-f]{8}::1$') THEN
+        RAISE EXCEPTION 'TEST FAILED [race-losing-loop]: unexpected LOOP child stamp %', loop_stamp;
+    END IF;
+
+    IF df.explain(instance_id) LIKE '%LOOP%running%' OR df.explain(instance_id) LIKE '%LOOP%pending%' THEN
+        RAISE EXCEPTION 'TEST FAILED [race-losing-loop]: df.explain() left LOOP node non-terminal: %',
+            df.explain(instance_id);
+    END IF;
+END $$;
+
+DROP TABLE _race_losing_loop_instance;
+RESET SESSION AUTHORIZATION;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/64_loop_branch_failure.sql
+++ b/tests/e2e/sql/64_loop_branch_failure.sql
@@ -1,0 +1,75 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the PostgreSQL License.
+
+-- A loop running directly as a JOIN branch must propagate its body failure
+-- through the child boundary while leaving both the loop node and parent
+-- instance terminal. The sibling branch is allowed to finish independently.
+SET SESSION AUTHORIZATION df_e2e_user;
+
+DROP TABLE IF EXISTS test_loop_branch_failure_iterations;
+DROP TABLE IF EXISTS test_loop_branch_failure_sibling;
+CREATE TABLE test_loop_branch_failure_iterations (iteration INT PRIMARY KEY);
+CREATE TABLE test_loop_branch_failure_sibling (marker INT);
+
+CREATE TEMP TABLE _loop_branch_failure_instance AS
+SELECT df.start(
+    df.loop(
+        $$INSERT INTO test_loop_branch_failure_iterations
+            SELECT COUNT(*) + 1 FROM test_loop_branch_failure_iterations$$
+        ~> df.if(
+            'SELECT COUNT(*) >= 2 FROM test_loop_branch_failure_iterations',
+            'SELECT 1/0',
+            df.sleep(1)
+        )
+    )
+    & 'INSERT INTO test_loop_branch_failure_sibling VALUES (1)',
+    'test-loop-branch-failure'
+) AS instance_id;
+
+DO $$
+DECLARE
+    instance_id TEXT;
+    final_status TEXT;
+    instance_output TEXT;
+    loop_status TEXT;
+    loop_inferred_status TEXT;
+    loop_result TEXT;
+    iteration_count INT;
+    sibling_count INT;
+BEGIN
+    SELECT i.instance_id INTO instance_id FROM _loop_branch_failure_instance i;
+    SELECT df.await_instance(instance_id, 60) INTO final_status;
+
+    IF final_status IS DISTINCT FROM 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [loop-branch-failure]: expected failed instance, got %', final_status;
+    END IF;
+
+    SELECT count(*) INTO iteration_count FROM test_loop_branch_failure_iterations;
+    SELECT count(*) INTO sibling_count FROM test_loop_branch_failure_sibling;
+    IF iteration_count != 2 OR sibling_count != 1 THEN
+        RAISE EXCEPTION 'TEST FAILED [loop-branch-failure]: expected 2 loop iterations and 1 sibling write, got % / %',
+            iteration_count, sibling_count;
+    END IF;
+
+    SELECT n.status, n.inferred_status, n.result
+    INTO loop_status, loop_inferred_status, loop_result
+    FROM df.instance_nodes(instance_id) n
+    WHERE n.node_type = 'LOOP';
+
+    IF loop_status IS DISTINCT FROM 'failed' OR loop_inferred_status IS DISTINCT FROM 'failed' THEN
+        RAISE EXCEPTION 'TEST FAILED [loop-branch-failure]: LOOP node physical/inferred status = % / %',
+            loop_status, loop_inferred_status;
+    END IF;
+
+    SELECT output INTO instance_output FROM df.instance_info(instance_id);
+    IF COALESCE(instance_output, loop_result, '') NOT LIKE '%division by zero%' THEN
+        RAISE EXCEPTION 'TEST FAILED [loop-branch-failure]: original SQL error did not surface: instance %, loop %',
+            instance_output, loop_result;
+    END IF;
+END $$;
+
+DROP TABLE _loop_branch_failure_instance;
+DROP TABLE test_loop_branch_failure_iterations;
+DROP TABLE test_loop_branch_failure_sibling;
+RESET SESSION AUTHORIZATION;
+SELECT 'TEST PASSED' AS result;

--- a/tests/e2e/sql/65_nested_loops.sql
+++ b/tests/e2e/sql/65_nested_loops.sql
@@ -1,0 +1,77 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the PostgreSQL License.
+
+-- Three outer iterations each spawn an inner loop that runs twice. The outer
+-- row id is carried as a named result into the nested child so ordering and
+-- result propagation are both observable.
+SET SESSION AUTHORIZATION df_e2e_user;
+
+DROP TABLE IF EXISTS test_nested_loop_outer;
+DROP TABLE IF EXISTS test_nested_loop_inner;
+CREATE TABLE test_nested_loop_outer (outer_iteration SERIAL PRIMARY KEY);
+CREATE TABLE test_nested_loop_inner (
+    sequence_no SERIAL PRIMARY KEY,
+    outer_iteration INT NOT NULL,
+    inner_iteration INT NOT NULL
+);
+
+CREATE TEMP TABLE _nested_loop_instance AS
+SELECT df.start(
+    'SELECT 1'
+    ~> df.loop(
+        ($$INSERT INTO test_nested_loop_outer DEFAULT VALUES
+           RETURNING outer_iteration$$ |=> 'outer_row')
+        ~> df.loop(
+                        $$INSERT INTO test_nested_loop_inner (outer_iteration, inner_iteration)
+                            SELECT $outer_row.outer_iteration, COUNT(*) + 1
+                            FROM test_nested_loop_inner
+                            WHERE outer_iteration = $outer_row.outer_iteration$$,
+                        $$SELECT COUNT(*) < 2
+                            FROM test_nested_loop_inner
+                            WHERE outer_iteration = $outer_row.outer_iteration$$
+        )
+        ~> (
+            'SELECT COUNT(*) >= 3 FROM test_nested_loop_outer'
+                ?> df.break('done')
+                !> df.sleep(1)
+        )
+    ),
+    'test-nested-loops'
+) AS instance_id;
+
+DO $$
+DECLARE
+    instance_id TEXT;
+    final_status TEXT;
+    execution_order TEXT[];
+    pending_count INT;
+BEGIN
+    SELECT i.instance_id INTO instance_id FROM _nested_loop_instance i;
+    SELECT df.await_instance(instance_id, 90) INTO final_status;
+
+    IF final_status IS DISTINCT FROM 'completed' THEN
+        RAISE EXCEPTION 'TEST FAILED [nested-loops]: expected completed, got %', final_status;
+    END IF;
+
+    SELECT array_agg(format('%s.%s', outer_iteration, inner_iteration) ORDER BY sequence_no)
+    INTO execution_order
+    FROM test_nested_loop_inner;
+
+    IF execution_order IS DISTINCT FROM ARRAY['1.1', '1.2', '2.1', '2.2', '3.1', '3.2'] THEN
+        RAISE EXCEPTION 'TEST FAILED [nested-loops]: unexpected execution order %', execution_order;
+    END IF;
+
+    SELECT count(*) INTO pending_count
+    FROM df.instance_nodes(instance_id)
+    WHERE inferred_status IN ('pending', 'running');
+
+    IF pending_count != 0 THEN
+        RAISE EXCEPTION 'TEST FAILED [nested-loops]: % node(s) remain pending/running after completion', pending_count;
+    END IF;
+END $$;
+
+DROP TABLE _nested_loop_instance;
+DROP TABLE test_nested_loop_inner;
+DROP TABLE test_nested_loop_outer;
+RESET SESSION AUTHORIZATION;
+SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## Summary

- make LOOP nodes terminal when child startup, execution, continuation, or JOIN/RACE branch handling fails
- explicitly roll back fenced node-status transactions and expand full-lineage supersession coverage
- add focused E2E coverage for root JOIN/RACE loops, RACE cancellation, branch failures, nested loops, and named-result propagation
- align loop architecture and observability documentation with positional root semantics

## Validation

- `cargo fmt -p pg_durable -- --check`
- `cargo build --features pg17`
- `cargo clippy --features pg17`
- `./scripts/test-unit.sh` (251 passed, 16 ignored)
- `./scripts/test-e2e-local.sh` (50 passed)
- `./scripts/test-upgrade.sh` (51 passed)
- `git diff --check`