### PR TITLE
chore: begin 0.2.6 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file. The format is b
 
 Pre-1.0 note: while `pg_durable` is in major version `0`, minor releases may include breaking changes.
 
+## [0.2.6] - Unreleased
+
 ## [0.2.5] - 2026-07-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "pg_durable"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "base64",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_durable"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "PostgreSQL"
 repository = "https://github.com/microsoft/pg_durable"

--- a/sql/pg_durable--0.2.5--0.2.6.sql
+++ b/sql/pg_durable--0.2.5--0.2.6.sql
@@ -1,0 +1,10 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the PostgreSQL License.
+
+-- pg_durable upgrade: 0.2.5 -> 0.2.6
+--
+-- See docs/upgrade-testing.md for the upgrade-script and backward-compatibility
+-- requirements (Scenario A / B1 / B2).
+--
+-- No schema changes yet for 0.2.6. Add DDL below as the 0.2.6 cycle lands
+-- extension-schema changes.


### PR DESCRIPTION
## Summary

- bump the package version from 0.2.5 to 0.2.6
- add the empty 0.2.5 -> 0.2.6 upgrade-script stub
- add the 0.2.6 Unreleased changelog placeholder

## Validation

- `cargo fmt -p pg_durable -- --check`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`

Tracks #316