### PR TITLE
Fix reconciler child classification

### DIFF
--- a/docs/loop_rework_problems.md
+++ b/docs/loop_rework_problems.md
@@ -1,19 +1,13 @@
 # Open Problems in the Loop Rework
 
 Findings from the review of the `df.loop()` child-sub-orchestration rework in
-PR #228 (`1320f65`) that are **still unresolved** on `main` as of `560a639`,
-after the loop follow-up fixes in #306 (`7ee7f43`), #307 (`09e08f0`), and #311
-(`560a639`).
+PR #228 (`1320f65`) that remain unresolved after the loop follow-up fixes in
+#306 (`7ee7f43`), #307 (`09e08f0`), and #311 (`560a639`).
 
-Resolved findings are not repeated here. In particular, the follow-ups fixed
-replay-deterministic map serialization, root/non-root loop semantic drift,
-loop-child startup status coverage, the missing #230 regression shape, nested
-and failed-loop coverage, and stale loop documentation. #311 also replaced the
-dedicated loop orchestration with the shared `execute-subtree` path and stopped
-reloading `df.nodes` on every loop generation.
+As these get fixed, leave a placeholder in both the table and the description section.
 
-`0.2.5` is still **Unreleased**, so replay-breaking fixes can still land inside
-the drain boundary already declared for this release.
+`0.2.5` has shipped, so further replay-breaking fixes require orchestration
+versioning or another explicit drain boundary.
 
 ---
 
@@ -28,8 +22,8 @@ Ordered by severity.
 | 3 | [Replay failures strand extension instances](#3-replay-failures-strand-extension-instances) | all replay-breaking changes | 🔴 Blocking | Open |
 | 4 | [Node-status write failures are discarded](#4-node-status-write-failures-are-discarded) | all nodes | 🟡 Medium | Open |
 | 5 | [Parent fallback stamps assume child generation 1](#5-parent-fallback-stamps-assume-child-generation-1) | cancelled or failed loop children | 🟡 Medium | Open |
-| 6 | [Composed child ids block orphan reclamation](#6-composed-child-ids-block-orphan-reclamation) | loop and parallel children | 🟡 Medium | Open |
-| 7 | [Stamp grammar is duplicated and fails open](#7-stamp-grammar-is-duplicated-and-fails-open) | status write fence and inference | 🟡 Medium | Open |
+| 6 | [Composed child ids block orphan reclamation](#6-composed-child-ids-block-orphan-reclamation) | loop and parallel children | 🟡 Medium | Resolved in #323 |
+| 7 | [Stamp validation fails open](#7-stamp-validation-fails-open) | status write fence and inference | 🟡 Medium | Open |
 | 8 | [Nested loops have no cumulative iteration budget](#8-nested-loops-have-no-cumulative-iteration-budget) | nested loops | 🟡 Medium | Open |
 | 9 | [Signals inherit the sub-orchestration startup race](#9-signals-inherit-the-sub-orchestration-startup-race) | non-root loops | 🟡 Medium | Open |
 | 10 | [The 0.2.5 drain guidance is not an executable runbook](#10-the-025-drain-guidance-is-not-an-executable-runbook) | 0.2.4 → 0.2.5 upgrade | 🟡 Medium | Open |
@@ -221,52 +215,22 @@ physical and inferred node statuses are terminal.
 **Tracking:** [#312 — Reconciler misclassifies explicitly named
 sub-orchestrations as root orphans](https://github.com/microsoft/pg_durable/issues/312)
 
-`worker::is_sub_orchestration` recognizes only ids that start with `sub::` or
-contain `::sub::`:
+**Resolved:** [#323 — Fix reconciler child
+classification](https://github.com/microsoft/pg_durable/pull/323)
 
-```rust
-fn is_sub_orchestration(id: &str) -> bool {
-    id.starts_with("sub::") || id.contains("::sub::")
-}
-```
-
-The loop/subtree code instead creates explicit child ids shaped as
-`{root}::{generation}::{node}`. Those ids are classified as roots and enter
-`select_orphans` when they are failed and have no `df.instances` row. The
-worker truncates that candidate list to `RECLAIM_BATCH` before asking duroxide
-to delete it; duroxide's root-only deletion then skips records with a parent.
-
-This is a concrete mismatch between #263 and #283. #263 replaced pg_durable's
-use of duroxide-generated child ids with explicit composed ids for JOIN/RACE;
-#283 later introduced the `sub::` classifier and tests based on the obsolete
-generated-id convention. PR #228 then materially increased the affected
-population by putting non-root loops on the explicit child path, and #311
-retained that naming model.
-
-Once enough composed children occupy the batch, the same undeletable ids can
-be selected every tick and prevent genuine root orphans from being reached.
-
-### Suggested fix
-
-Parse composed child instance ids and exclude them before batching. Keep
-support for the legacy `sub::` forms. The parser should be shared with the
-execution-stamp grammar described below so reclamation does not introduce a
-third interpretation of the same lineage.
+PR #323 excludes both explicitly composed child ids and legacy Duroxide
+`sub::` ids before applying `RECLAIM_BATCH`. It also shares the typed lineage
+parser with execution-stamp fencing and status inference.
 
 ---
 
-## 7. Stamp grammar is duplicated and fails open
+## 7. Stamp validation fails open
 
 **Severity: 🟡 Medium — affects node-status fencing and inferred status.**
 
-The write and read sides still implement the composed lineage independently:
-
-- `activities/update_node_status.rs::stamp_lineage` requires an even token
-  count and parses `gen (node gen)*`.
-- `node_status.rs::stamp_of` accepts any string with a numeric final token, and
-  `is_superseded` recursively interprets the remaining tokens as a parent id.
-- `worker.rs::is_sub_orchestration` uses substring matching instead of either
-  grammar.
+#323 introduced a shared typed lineage parser for execution stamps, composed
+instance ids, read-side status inference, and the write-side fence. The
+remaining problem is how parse failures are handled.
 
 Malformed stamps disable protection. `incoming_stamp_is_superseded` returns
 `false` when either stamp fails to parse, including malformed non-legacy data.
@@ -280,12 +244,10 @@ outcome to write order.
 
 ### Suggested fix
 
-Introduce one typed lineage module with separate entry points for execution
-stamps (`{root}::{gen}::{node}::{gen}...`) and composed instance ids
-(`{root}::{gen}::{node}...`). Use one supersession predicate on both fence
-sides. Preserve the inert path only for an absent `status_details` column or an
+Preserve the inert path only for an absent `status_details` column or an
 explicitly recognized legacy value; malformed current-format data should fail
-closed with an observable diagnostic.
+closed with an observable diagnostic. Define and test the intended ordering
+between parent and descendant stamps at equal generations.
 
 ---
 

--- a/src/activities/update_node_status.rs
+++ b/src/activities/update_node_status.rs
@@ -54,24 +54,10 @@ fn execution_id_from_details(status_details: Option<&serde_json::Value>) -> Opti
 /// token count that is not `gen (node gen)*`), so a legacy/unparseable stamp
 /// degrades to an unfenced write rather than silently dropping it.
 fn stamp_lineage(execution_id: &str) -> Option<(Vec<i64>, Vec<&str>)> {
-    let tokens: Vec<&str> = execution_id.split("::").collect();
-    // token[0] is the root df instance id; the remainder must be
-    // `gen (node gen)*`, i.e. an even total token count (>= 2).
-    if tokens.len() < 2 || !tokens.len().is_multiple_of(2) {
-        return None;
-    }
-    let mut gens = Vec::new();
-    let mut nodes = Vec::new();
-    let mut i = 1;
-    while i < tokens.len() {
-        gens.push(tokens[i].parse::<i64>().ok()?);
-        i += 1;
-        if i < tokens.len() {
-            nodes.push(tokens[i]);
-            i += 1;
-        }
-    }
-    Some((gens, nodes))
+    let (lineage, current_generation) = crate::node_status::parse_execution_stamp(execution_id)?;
+    let mut generations = lineage.generations().to_vec();
+    generations.push(current_generation);
+    Some((generations, lineage.node_ids().to_vec()))
 }
 
 /// Whether the `incoming` write belongs to a superseded generation relative to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1785,14 +1785,20 @@ mod tests {
         use std::collections::HashSet;
 
         // Failed engine instances reconciliation sees: a df-backed one, a genuine
-        // orphan (rolled-back df.start), and two sub-orchestrations the engine
-        // created internally for fan-out.
-        let failed = vec![
+        // orphan (rolled-back df.start), legacy engine-named children, and current
+        // explicitly named children using the real parent/generation/node shape.
+        let mut failed = vec![
             "inst-backed".to_string(),
-            "inst-orphan".to_string(),
             "sub::inst-backed::0".to_string(),
             "inst-backed::sub::1".to_string(),
+            "aa312000::1::bb312000".to_string(),
+            "aa312000::1::bb312000::2::cc312000".to_string(),
         ];
+        failed
+            .extend((0..=crate::worker::RECLAIM_BATCH).map(|i| format!("aa312001::{i}::bb312001")));
+        // Put the genuine root last: composed children must be excluded before
+        // the caller truncates the selected roots to RECLAIM_BATCH.
+        failed.push("inst-orphan".to_string());
         // Only inst-backed still has a df.instances row.
         let present: HashSet<String> = ["inst-backed".to_string()].into_iter().collect();
 

--- a/src/node_status.rs
+++ b/src/node_status.rs
@@ -6,6 +6,75 @@
 
 use std::collections::{HashMap, HashSet};
 
+/// Parsed pg_durable orchestration instance lineage.
+///
+/// Root instance ids are a single token. Each explicitly named child appends
+/// `::{parent_generation}::{child_root_node_id}`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct InstanceLineage<'a> {
+    instance_id: &'a str,
+    generations: Vec<i64>,
+    node_ids: Vec<&'a str>,
+}
+
+impl<'a> InstanceLineage<'a> {
+    pub(crate) fn parse(instance_id: &'a str) -> Option<Self> {
+        let tokens: Vec<&str> = instance_id.split("::").collect();
+        if tokens.first().is_none_or(|root| root.is_empty()) || tokens.len().is_multiple_of(2) {
+            return None;
+        }
+
+        let mut generations = Vec::new();
+        let mut node_ids = Vec::new();
+        for pair in tokens[1..].chunks_exact(2) {
+            generations.push(pair[0].parse::<i64>().ok()?);
+            if pair[1].is_empty() {
+                return None;
+            }
+            node_ids.push(pair[1]);
+        }
+
+        Some(Self {
+            instance_id,
+            generations,
+            node_ids,
+        })
+    }
+
+    pub(crate) fn instance_id(&self) -> &'a str {
+        self.instance_id
+    }
+
+    pub(crate) fn generations(&self) -> &[i64] {
+        &self.generations
+    }
+
+    pub(crate) fn node_ids(&self) -> &[&'a str] {
+        &self.node_ids
+    }
+
+    pub(crate) fn is_composed(&self) -> bool {
+        !self.node_ids.is_empty()
+    }
+
+    fn parent(&self) -> Option<(&'a str, i64)> {
+        if !self.is_composed() {
+            return None;
+        }
+        let (parent_with_generation, _) = self.instance_id.rsplit_once("::")?;
+        let (parent_instance_id, generation) = parent_with_generation.rsplit_once("::")?;
+        Some((parent_instance_id, generation.parse().ok()?))
+    }
+}
+
+pub(crate) fn parse_execution_stamp(execution_id: &str) -> Option<(InstanceLineage<'_>, i64)> {
+    let (instance_id, generation) = execution_id.rsplit_once("::")?;
+    Some((
+        InstanceLineage::parse(instance_id)?,
+        generation.parse::<i64>().ok()?,
+    ))
+}
+
 pub(crate) fn status_details_select_expr(client: &pgrx::spi::SpiClient) -> &'static str {
     let present = client
         .select(
@@ -63,8 +132,8 @@ fn stamp_of(status_details: Option<&str>) -> Option<(String, i64)> {
     let sd = status_details?;
     let v: serde_json::Value = serde_json::from_str(sd).ok()?;
     let eid = v.get("execution_id")?.as_str()?;
-    let (instance_id, generation) = eid.rsplit_once("::")?;
-    Some((instance_id.to_string(), generation.parse::<i64>().ok()?))
+    let (lineage, generation) = parse_execution_stamp(eid)?;
+    Some((lineage.instance_id().to_string(), generation))
 }
 
 /// Whether a node stamped `(instance_id, gen)` belongs to a superseded generation.
@@ -84,15 +153,11 @@ fn is_superseded(instance_id: &str, gen: i64, scope_max: &HashMap<String, i64>) 
             return true;
         }
     }
-    let tokens: Vec<&str> = instance_id.split("::").collect();
-    if tokens.len() < 3 {
-        // Root scope: no parent scope can supersede this one.
-        return false;
-    }
-    let parent_instance = tokens[..tokens.len() - 2].join("::");
-    match tokens[tokens.len() - 2].parse::<i64>() {
-        Ok(parent_gen) => is_superseded(&parent_instance, parent_gen, scope_max),
-        Err(_) => false,
+    match InstanceLineage::parse(instance_id).and_then(|lineage| lineage.parent()) {
+        Some((parent_instance, parent_gen)) => {
+            is_superseded(parent_instance, parent_gen, scope_max)
+        }
+        None => false,
     }
 }
 
@@ -580,5 +645,27 @@ mod tests {
         ]);
 
         assert!(!is_superseded("root::1::loop::3::branch", 8, &scope_max));
+    }
+
+    #[test]
+    fn instance_lineage_distinguishes_composed_children_from_roots() {
+        let root = InstanceLineage::parse("aa312000").unwrap();
+        assert!(!root.is_composed());
+
+        let child = InstanceLineage::parse("aa312000::1::bb312000").unwrap();
+        assert!(child.is_composed());
+        assert_eq!(child.generations(), &[1]);
+        assert_eq!(child.node_ids(), &["bb312000"]);
+
+        let nested = InstanceLineage::parse("aa312000::1::bb312000::2::cc312000").unwrap();
+        assert_eq!(nested.generations(), &[1, 2]);
+        assert_eq!(nested.node_ids(), &["bb312000", "cc312000"]);
+    }
+
+    #[test]
+    fn instance_lineage_rejects_malformed_child_lookalikes() {
+        assert!(InstanceLineage::parse("root::generation::node").is_none());
+        assert!(InstanceLineage::parse("root::1").is_none());
+        assert!(InstanceLineage::parse("root::1::").is_none());
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -891,13 +891,15 @@ async fn run_until_extension_dropped_or_shutdown(
 }
 
 /// Maximum orphans one reconciliation pass reclaims, bounding a single tick's work.
-const RECLAIM_BATCH: u32 = 1000;
+pub(crate) const RECLAIM_BATCH: u32 = 1000;
 
 /// True for sub-orchestration instance ids, which the engine creates internally
-/// (JOIN/RACE fan-out) and which legitimately have no df.instances row —
-/// reconciliation must never delete them.
+/// or pg_durable names explicitly for composed graph execution. These children
+/// legitimately have no df.instances row, so reconciliation must never delete them.
 fn is_sub_orchestration(id: &str) -> bool {
-    id.starts_with("sub::") || id.contains("::sub::")
+    id.starts_with("sub::")
+        || id.contains("::sub::")
+        || crate::node_status::InstanceLineage::parse(id).is_some_and(|id| id.is_composed())
 }
 
 /// Milliseconds-since-epoch cutoff for "older than `retention`". Used as the
@@ -912,8 +914,8 @@ fn retention_cutoff_ms(retention: Duration) -> u64 {
 
 /// From the engine's `Failed` instance ids and the set that still have a
 /// df.instances row, select the orphans to reclaim: those with no df row and that
-/// are not sub-orchestrations (the engine creates sub-orchestrations internally
-/// for JOIN/RACE fan-out; they legitimately have no df row and must be kept).
+/// are not sub-orchestrations. Both legacy engine-named children and current
+/// explicitly named composed children legitimately have no df row and must be kept.
 pub(crate) fn select_orphans(
     failed_ids: Vec<String>,
     present: &std::collections::HashSet<String>,


### PR DESCRIPTION
## Summary

- classify current explicitly named sub-orchestrations using pg_durable's typed `root (generation node)+` instance lineage
- preserve legacy Duroxide `sub::` child classification
- filter children before `RECLAIM_BATCH` truncation so failed children cannot starve genuine root-orphan reclamation
- share lineage parsing with node-status inference and write fencing

The pinned Duroxide management API returns only IDs from `list_instances_by_status`, so authoritative `parent_instance_id` metadata is not available on this path without bypassing the client abstraction. The shared parser validates the exact ID shape emitted by `subtree_instance_id`.

## Testing

- `cargo pgrx test pg17 test_select_orphans_excludes_present_and_sub_orchestrations`
- `cargo test --features pg17 --no-default-features` (255 passed, 16 ignored)
- `cargo fmt -p pg_durable -- --check`
- `cargo clippy --features pg17 --no-default-features --lib -- -D warnings`
- `./scripts/test-e2e-local.sh 54_reconcile_orphans`

Fixes #312