### PR TITLE
Read non-future-helper marker without SPI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2018,7 +2018,8 @@ mod tests {
                  WITH _mark AS (
                      SELECT pg_catalog.set_config(
                          'df.non_future_helper',
-                         'df.await_instance' || E'\\n' || pg_catalog.statement_timestamp()::text,
+                         'df.await_instance' || E'\n' ||
+                             ((extract(epoch FROM pg_catalog.statement_timestamp()) - 946684800) * 1000000)::bigint::text,
                          true
                      )
                  )

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,7 +10,7 @@ use cron::Schedule as CronSchedule;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::str::FromStr;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
@@ -1149,11 +1149,22 @@ pub const VALID_NODE_TYPES: &[&str] = &[
 const NON_FUTURE_HELPER_GUC: &str = "df.non_future_helper";
 
 pub fn mark_non_future_helper_call(function_name: &str) {
-    if let Err(e) = Spi::run_with_args(
-        "SELECT pg_catalog.set_config('df.non_future_helper', $1 || E'\n' || pg_catalog.statement_timestamp()::text, true)",
-        &[function_name.into()],
-    ) {
-        pgrx::error!("Failed to mark helper call: {:?}", e);
+    let name = CString::new(NON_FUTURE_HELPER_GUC).expect("GUC name must not contain NUL bytes");
+    let statement_timestamp = unsafe { pgrx::pg_sys::GetCurrentStatementStartTimestamp() };
+    let marker = CString::new(format!("{}\n{}", function_name, statement_timestamp))
+        .expect("helper name must not contain NUL bytes");
+
+    unsafe {
+        pgrx::pg_sys::set_config_option(
+            name.as_ptr(),
+            marker.as_ptr(),
+            pgrx::pg_sys::GucContext::PGC_USERSET,
+            pgrx::pg_sys::GucSource::PGC_S_SESSION,
+            pgrx::pg_sys::GucAction::GUC_ACTION_LOCAL,
+            true,
+            pgrx::PgLogLevel::ERROR as i32,
+            false,
+        );
     }
 }
 
@@ -1188,17 +1199,15 @@ impl Durofut {
             return None;
         }
 
-        let marker = Spi::get_one::<String>(&format!(
-            "SELECT pg_catalog.current_setting('{}', true)",
-            NON_FUTURE_HELPER_GUC
-        ))
-        .ok()
-        .flatten()?;
+        let name =
+            CString::new(NON_FUTURE_HELPER_GUC).expect("GUC name must not contain NUL bytes");
+        let marker = unsafe {
+            let value = pgrx::pg_sys::GetConfigOption(name.as_ptr(), true, false);
+            (!value.is_null()).then(|| CStr::from_ptr(value).to_string_lossy().into_owned())
+        }?;
         let (helper_name, marker_timestamp) = marker.split_once('\n')?;
-        let statement_timestamp =
-            Spi::get_one::<String>("SELECT pg_catalog.statement_timestamp()::text")
-                .ok()
-                .flatten()?;
+        let marker_timestamp = marker_timestamp.parse::<pgrx::pg_sys::TimestampTz>().ok()?;
+        let statement_timestamp = unsafe { pgrx::pg_sys::GetCurrentStatementStartTimestamp() };
 
         (marker_timestamp == statement_timestamp).then(|| helper_name.to_string())
     }


### PR DESCRIPTION
Implements **Step 0** of `docs/plan-graph-rework.md`.

## Problem

`Durofut::ensure` calls `same_statement_non_future_helper_name` before doing anything else, and that helper issued SPI queries to read the `df.non_future_helper` session GUC and `statement_timestamp()`. `mark_non_future_helper_call` issued a third for `set_config`.

Every plain-SQL operand flowing through a composer paid a full plan + execute round trip. For the small graphs users actually write, this very likely dominates the composition cost.

## Change

Read and write the marker through the C API instead:

- `GetConfigOption` replaces `current_setting()`
- `set_config_option` with `GUC_ACTION_LOCAL` replaces `set_config(..., true)`
- `GetCurrentStatementStartTimestamp` replaces `statement_timestamp()`

No planner, no executor.

The marker now carries the internal `TimestampTz` integer rather than a formatted timestamp string. The GUC is transaction-local and is only ever written and read within a single statement by the same binary, so the encoding is private and needs no compatibility handling. The one unit test that synthesizes the marker in SQL is updated to match.

## Behaviour

Unchanged. Same detection semantics, same error messages, same transaction-local scope. The existing helper-misuse tests passing unchanged is the whole acceptance criterion.

## Why this is first

Two reasons from the plan:

1. It is almost certainly the largest win in the programme for realistically-sized graphs, and it carries no design risk.
2. **Measurement hygiene.** While an SPI round trip sits in the composer's hot path it masks every parsing difference, and Step 5's decision gate depends on being able to see them.

It also shrinks what Step 5 has to preserve: this check is the only hard error the composers currently raise.

## Upgrade & migration

None. No schema change, no upgrade script, no wire-format change, no runtime schema detection. No SQL query text changes, so **B1 backward compatibility is unaffected** — the new `.so` issues no new or altered queries against any schema version.

## Testing

- `cargo check --features pg17` — clean
- `cargo clippy --features pg17 -- -D warnings` — clean
- `cargo fmt -p pg_durable -- --check` — clean
- `./scripts/test-unit.sh cannot_be_used_in_seq_composition` — 4 passed

The four covering tests exercise `df.setvar`, `df.unsetvar`, `df.clearvars` and `df.await_instance` misuse detection against a real PG17 backend, including the manually synthesized marker path.
