### PR TITLE
Share iterative graph materialization

### DIFF
--- a/doc/pr-335-feedback.md
+++ b/doc/pr-335-feedback.md
@@ -1,0 +1,265 @@
+# PR 335 Review Feedback Disposition
+
+Evaluated against rebased PR 335 at commit `8fabd62` on 2026-08-05. The review
+was written against `4b3d47e`, before PR 335 was rebased onto the final PR 334
+implementation.
+
+## Decision summary
+
+| ID | Finding | Decision | Status |
+|---|---|---|---|
+| F1 | Node limit does not bound the discovery frontier | Fix in PR 335 | Completed |
+| F2 | Node insertion uses the retry helper with one fixed candidate | Fix in PR 335 | Completed |
+| F3 | Graph ID generation is unbounded and flattening has no interrupt point | Fix in PR 335 | Completed |
+| F4 | Flattened nodes contain fabricated identity fields | Fix in PR 335 | Completed |
+| F5 | `validate_recursive()` uses non-production IDs and discards the graph | Partially accept; retain the helper but make its IDs realistic and test `flatten_graph()` directly | Completed |
+| F6 | Tests do not pin the new materialization invariants and some assertions are weak | Add focused tests in PR 335 | Completed |
+| F7 | New graph-materialization APIs do not document their contracts | Add documentation in PR 335 | Completed |
+| P3.1 | `df.explain()` no longer renders a partial tree for invalid graphs | Accept behavior change | No action |
+| P3.2 | Validation error precedence changed | Accept behavior change | No action |
+| P3.3 | Pre-order insertion depends on three deferred foreign keys | Add an explicit schema regression assertion | Completed |
+| P3.4 | `root.clone()` duplicates the input graph | Defer optimization | No action in PR 335 |
+| P3.5 | Embedded-config validation runs twice | Stale after rebase | No action |
+| P3.6 | Paths allocate eagerly and can make long errors | Accept current implementation | No action |
+| P3.7 | Unknown `node_type` is echoed in errors | Pre-existing and out of scope | No action |
+| P3.8 | Root parse errors differ between start and explain | Pre-existing and out of scope | No action |
+| O1 | Batch the per-node SPI inserts | Track separately | Deferred |
+| O2 | Remove quadratic DSL envelope serialization | Track separately | Deferred |
+
+`Completed` means the accepted work was implemented and validated in follow-up
+commits on PR 335. Deferred and no-action decisions remain intentionally open
+only as separate follow-up opportunities.
+
+## Rebase impact
+
+The PR 334 rebase materially changes one review conclusion:
+
+- `flatten_graph()` now calls `validate_config_children()` once per emitted
+  node. That method enforces that `condition_node` is only used by IF/LOOP,
+  `extra_nodes` is only used by JOIN, and legacy children embedded in `query`
+  remain rejected.
+- `materialized_query()` only parses and updates the config object. It no longer
+  repeats structural validation.
+- The existing-query test now exercises `flatten_graph()` through
+  `test_flatten_graph_preserves_existing_query`.
+
+Therefore P3.5 is stale. The rebase does not resolve the other accepted
+findings below.
+
+## Accepted work
+
+### F1: Bound discovery before parsing children
+
+**Decision:** Accept. This is the highest-priority correction.
+
+`MAX_GRAPH_NODES` is checked against `nodes.len()` at the top of the pop loop,
+but all children of the current node are deserialized, assigned IDs, and added
+to `children` before another node is popped. One wide JOIN can therefore make
+the pending frontier proportional to input size rather than to the configured
+node limit.
+
+Change `flatten_graph()` to count discovered nodes, including the root, and
+reject a child in `parse_child` before `child_from_raw()` or `ids.next_id()`
+would exceed `MAX_GRAPH_NODES`. Keep the pop-time check only if it remains a
+useful defensive assertion.
+
+Validation:
+
+- Exactly 10,000 total nodes succeeds and 10,001 fails.
+- An oversized wide JOIN calls the ID source at most 10,000 times.
+- The failure retains the path of the first child beyond the limit.
+
+### F2: Remove the misleading one-attempt retry
+
+**Decision:** Accept the cleanup, not a late re-roll.
+
+Node IDs are already embedded in parent references and materialized config
+before insertion. `insert_node()` therefore cannot safely generate a new ID
+after a conflict. Calling `pick_id_with_retry()` with a constant generator and
+one attempt suggests resilience that the path cannot provide and emits an
+inaccurate exhaustion message.
+
+Use one direct `INSERT ... ON CONFLICT ... DO NOTHING RETURNING id` claim and
+report a node-ID conflict explicitly. Keep `pick_id_with_retry()` for the
+instance ID, where generating a fresh candidate is safe.
+
+### F3: Bound ID generation and make flattening interruptible
+
+**Decision:** Accept.
+
+The graph-local `HashSet` makes duplicate IDs harmless, but its generation loop
+has no attempt bound. More importantly, iterative materialization can perform a
+large amount of pure Rust work without reaching SPI, so PostgreSQL cancellation
+is not checked during the loop.
+
+- Check PostgreSQL interrupts once per `pending.pop()` iteration.
+- Limit each graph-local ID allocation to `MAX_ID_ATTEMPTS` and return a clear
+  graph-construction error on exhaustion. Adapt the ID-source abstraction if
+  necessary so failure is represented as a `Result` rather than raised inside
+  a generic closure.
+- Preserve graph-local uniqueness and the persisted eight-lowercase-hex format.
+
+The F1 frontier fix sharply bounds this work, but it does not replace an
+interrupt point.
+
+### F4: Use an honest flattened-node type
+
+**Decision:** Accept the dedicated-type recommendation.
+
+`flatten_graph()` currently returns `FunctionNode` values with
+`submitted_by: ""` and `database: None`. Current consumers happen to overwrite
+or discard those fields, but `FunctionNode` is serializable and those fields
+carry security-sensitive persistence meaning.
+
+Introduce a crate-private materialized-node type containing only `id`,
+`node_type`, `query`, `result_name`, `left_node`, and `right_node`. Use it in
+`flatten_graph()`, `insert_node()`, and explain conversion. Do not encode
+"not populated yet" as a valid `FunctionNode`.
+
+### F5: Keep validation compatibility, improve its IDs and coverage
+
+**Decision:** Partially accept.
+
+The claim that tests exercise wholly different logic is too strong:
+`validate_recursive()` calls the same `flatten_graph()` implementation used by
+production. It remains useful as a compatibility helper for callers that only
+need validation. However, its constant empty ID source is unrealistic, and the
+discarded result cannot test materialization invariants.
+
+Retain the helper, but generate deterministic, unique, eight-hex-character IDs
+within it. Keep validation-focused tests on the helper and move ordering,
+linkage, uniqueness, and boundary assertions to direct `flatten_graph()` tests.
+
+### F6: Strengthen focused tests
+
+**Decision:** Accept the substantive gaps, with the following scope:
+
+- Correct the unit depth tests to exercise depths 256 and 257 exactly. The
+  current "exactly the limit" test reaches only depth 255.
+- Add direct materialization assertions for `nodes[0].id == root_id`, unique
+  IDs, pre-order emission, and every child reference resolving to a later
+  vector entry.
+- Rename or strengthen
+  `test_flatten_graph_assigns_preorder_ids_and_reports_error_path`; it currently
+  asserts only the error path.
+- Add the exact node-count and bounded-ID-source tests listed under F1.
+- Make the invalid-node E2E test non-vacuous. Its `WHEN OTHERS` block currently
+  also catches its own `TEST FAILED` exception. Assert the returned explain
+  error rather than merely asserting that explain does not raise.
+- Add semantic assertions for IF/LOOP condition links and JOIN extra links in
+  the flattened output. Existing explain tests mostly check keywords and query
+  fragments.
+
+Do not add a 10,001-node E2E test. The limit is owned by pure materialization
+code and can be pinned precisely and much more cheaply in unit tests.
+
+The changed child-deserialization wording is acceptable: the new structural
+path is more actionable than the removed `in IF` wording. Tests should assert
+the path and the error category, not freeze the complete serde error text.
+
+### F7: Document materialization contracts
+
+**Decision:** Accept.
+
+Add concise rustdoc for the flattened-node type, `IdSource`, `GraphError`, and
+`flatten_graph()`. Document these invariants:
+
+- IDs must be unique within one graph.
+- A persistence caller must provide IDs satisfying `^[0-9a-f]{8}$`.
+- The returned vector is pre-order and parents precede referenced children.
+- The returned root ID equals the first node's ID for a non-empty valid graph.
+- The ID source may fail if F3 changes it to return `Result`.
+
+The type system need not force explain-only IDs such as `N1` to satisfy the
+database constraint, because explain does not persist them. The distinction
+must be explicit in the contract.
+
+### P3.3: Pin the deferred-FK dependency
+
+**Decision:** Accept a small regression test.
+
+Pre-order insertion now relies on the root-node and node-reference foreign keys
+being both deferrable and initially deferred. Existing E2E coverage would fail
+if this changed, but the failure would be indirect. Extend the schema
+constraint test to query `pg_constraint` and assert the required properties for
+all three constraints. No extension upgrade script is required.
+
+## No-action findings
+
+### P3.1: Explain graceful degradation
+
+The all-or-error explain behavior is intentional. A partial tree could imply
+that a graph is executable when `df.start()` would reject it, while the shared
+path now gives a precise structural location and returns a string instead of
+aborting the statement. Add the stronger error assertion described in F6, but
+do not restore partial rendering.
+
+### P3.2: Error precedence
+
+The precedence changes are real but move toward rejecting malformed parent
+configuration before traversing descendants. Error precedence is not a public
+contract, and no compatibility behavior should be added.
+
+### P3.4: Root cloning
+
+The clone temporarily increases memory use, but the shared single-pass design
+still reduces aggregate parsing and serialization work. F1 removes the more
+important unbounded-frontier amplification. Avoid complicating ownership in
+this PR; consider a borrowed-root work item only with measured evidence.
+
+### P3.5: Duplicate embedded-child validation
+
+Rejected as stale. The rebased code validates structure once in
+`flatten_graph()` and leaves `materialized_query()` responsible only for config
+parsing and mutation.
+
+### P3.6-P3.8: Paths, error echoing, and root wording
+
+Eager path allocation is bounded by F1 and negligible at the supported graph
+size. Echoing `node_type` and the start/explain root wording difference both
+predate PR 335. None warrants expanding this refactor.
+
+## Informational performance items
+
+Batching node insertion is a credible follow-up now that materialization
+produces a flat vector, but it changes SQL construction, error attribution, and
+backward-compatibility-sensitive persistence code. Track and benchmark it
+separately.
+
+The quadratic JSON envelope serialization in composition operators is also
+pre-existing and independent of this refactor. Track it separately rather than
+mixing it into PR 335.
+
+## Confirmed conclusions from the review
+
+The rebase does not invalidate these no-action conclusions:
+
+- Materialized `df.nodes.query` representations retain their prior format;
+  focused condition, existing-query, and extra-node tests cover this path.
+- Physical insertion order is not part of worker replay behavior because graph
+  loading keys nodes by ID.
+- No extension schema or upgrade script changes are needed.
+- Shipped schemas in the supported upgrade range provide the deferred
+  constraints required by pre-order insertion; P3.3 adds an explicit guard for
+  the current schema.
+- The accepted graph boundaries remain 10,000 nodes and depth 256. F1 changes
+  when excess work stops, not the accepted set.
+- Reversing `children` before extending the LIFO worklist preserves pre-order
+  DFS emission.
+- Owned raw child values represent a tree, so cycle and DAG detection is not
+  required.
+- Flattening completes before instance reservation and node insertion, so graph
+  validation cannot leave partial rows.
+- Materialization is not reachable from orchestrations and introduces no
+  durable replay ordering concern.
+- The iterative walker removes the previous recursive stack-growth risk.
+- Reserving the instance ID before inserting its pre-generated root fixes the
+  old unhandled root-ID collision path.
+
+The adversarial probes listed in the review do not identify additional work:
+input cannot forge generated node IDs; serde limits nested JSON inside query
+config; the rebased structural gates reject misplaced config children;
+transaction rollback prevents partial orphan writes; supported schemas permit
+pre-order insertion; and no validation rule was dropped. F1 remains necessary
+because those conclusions do not bound the amount of work performed before an
+oversized graph is rejected.

--- a/docs/nested-graph-design.md
+++ b/docs/nested-graph-design.md
@@ -49,6 +49,8 @@ Conditions for IF/LOOP and additional JOIN branches are first-class `condition_n
 `extra_nodes` fields. They do not live inside the escaped `query` string, so nested config graphs
 grow linearly and use the same traversal path as left and right children.
 
+`flatten_graph` is the single materialization and validation pass used by both `df.start()` and `df.explain()`. It walks the envelope iteratively, enforces node-type, depth, and node-count limits, and reports failures with paths such as `root.left.condition_node`. IDs are assigned when children are discovered, allowing the parent `FunctionNode` to be emitted before its children. Persisting that pre-order output is valid because the same-instance node foreign keys are `DEFERRABLE INITIALLY DEFERRED`; changing that constraint requires changing the materialization order too.
+
 The envelope is distinct from durable execution state. During `df.start()`, config children are
 materialized as node rows and `df.nodes.query` retains the worker-facing format with child IDs:
 

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -15,7 +15,7 @@ use crate::client::start_durable_function;
 use crate::types::{
     flatten_graph, get_max_new_transaction_starts, get_new_transaction_start_timeout,
     mark_non_future_helper_call, short_id, validate_result_name, Durofut, FunctionInput,
-    FunctionNode,
+    MaterializedNode,
 };
 
 /// Check if we're running inside a workflow context (background worker connection).
@@ -1034,7 +1034,7 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
     }
 
     fn insert_node(
-        node: &FunctionNode,
+        node: &MaterializedNode,
         instance_id: &str,
         current_user_oid: pgrx::pg_sys::Oid,
         database: Option<&str>,
@@ -1047,78 +1047,77 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
         // cannot run df.start() until it upgrades. That is fine: the supported
         // B1 floor is 0.2.2 (docs/upgrade-testing.md), so this legacy branch is
         // effectively dead code for every supported install.
-        let node_id = node.id.clone();
-        if let Err(e) = pick_id_with_retry(
-            || node_id.clone(),
-            |candidate| {
-                let query_arg: DatumWithOid = match &node.query {
-                    Some(q) => q.as_str().into(),
-                    None => DatumWithOid::null::<String>(),
-                };
-                let result_name_arg: DatumWithOid = match &node.result_name {
-                    Some(n) => n.as_str().into(),
-                    None => DatumWithOid::null::<String>(),
-                };
-                let left_node_arg: DatumWithOid = match &node.left_node {
-                    Some(id) => id.as_str().into(),
-                    None => DatumWithOid::null::<String>(),
-                };
-                let right_node_arg: DatumWithOid = match &node.right_node {
-                    Some(id) => id.as_str().into(),
-                    None => DatumWithOid::null::<String>(),
-                };
-                let database_arg: DatumWithOid = match database {
-                    Some(db) => db.into(),
-                    None => DatumWithOid::null::<String>(),
-                };
-                let (node_sql, node_args): (&str, Vec<DatumWithOid>) = if legacy_login_role {
-                    (
-                        "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, login_role, database)
-                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::oid::regrole, $9::oid::regrole, $10)
-                         ON CONFLICT (instance_id, id) DO NOTHING
-                         RETURNING id",
-                        vec![
-                            candidate.into(),
-                            instance_id.into(),
-                            node.node_type.as_str().into(),
-                            query_arg,
-                            result_name_arg,
-                            left_node_arg,
-                            right_node_arg,
-                            current_user_oid.into(),
-                            current_user_oid.into(), // login_role = submitted_by
-                            database_arg,
-                        ],
-                    )
-                } else {
-                    (
-                        "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database)
-                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::oid::regrole, $9)
-                         ON CONFLICT (instance_id, id) DO NOTHING
-                         RETURNING id",
-                        vec![
-                            candidate.into(),
-                            instance_id.into(),
-                            node.node_type.as_str().into(),
-                            query_arg,
-                            result_name_arg,
-                            left_node_arg,
-                            right_node_arg,
-                            current_user_oid.into(),
-                            database_arg,
-                        ],
-                    )
-                };
-                Spi::connect_mut(
-                    |client| match client.update(node_sql, Some(1), &node_args) {
-                        Ok(table) => Ok(!table.is_empty()),
-                        Err(e) => Err(format!("{e:?}")),
-                    },
-                )
+        let query_arg: DatumWithOid = match &node.query {
+            Some(q) => q.as_str().into(),
+            None => DatumWithOid::null::<String>(),
+        };
+        let result_name_arg: DatumWithOid = match &node.result_name {
+            Some(n) => n.as_str().into(),
+            None => DatumWithOid::null::<String>(),
+        };
+        let left_node_arg: DatumWithOid = match &node.left_node {
+            Some(id) => id.as_str().into(),
+            None => DatumWithOid::null::<String>(),
+        };
+        let right_node_arg: DatumWithOid = match &node.right_node {
+            Some(id) => id.as_str().into(),
+            None => DatumWithOid::null::<String>(),
+        };
+        let database_arg: DatumWithOid = match database {
+            Some(db) => db.into(),
+            None => DatumWithOid::null::<String>(),
+        };
+        let (node_sql, node_args): (&str, Vec<DatumWithOid>) = if legacy_login_role {
+            (
+                "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, login_role, database)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::oid::regrole, $9::oid::regrole, $10)
+                 ON CONFLICT (instance_id, id) DO NOTHING
+                 RETURNING id",
+                vec![
+                    node.id.as_str().into(),
+                    instance_id.into(),
+                    node.node_type.as_str().into(),
+                    query_arg,
+                    result_name_arg,
+                    left_node_arg,
+                    right_node_arg,
+                    current_user_oid.into(),
+                    current_user_oid.into(), // login_role = submitted_by
+                    database_arg,
+                ],
+            )
+        } else {
+            (
+                "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::oid::regrole, $9)
+                 ON CONFLICT (instance_id, id) DO NOTHING
+                 RETURNING id",
+                vec![
+                    node.id.as_str().into(),
+                    instance_id.into(),
+                    node.node_type.as_str().into(),
+                    query_arg,
+                    result_name_arg,
+                    left_node_arg,
+                    right_node_arg,
+                    current_user_oid.into(),
+                    database_arg,
+                ],
+            )
+        };
+        match Spi::connect_mut(
+            |client| match client.update(node_sql, Some(1), &node_args) {
+                Ok(table) => Ok(!table.is_empty()),
+                Err(e) => Err(format!("{e:?}")),
             },
-            1,
         ) {
-            pgrx::error!("Failed to insert node '{}': {}", node.id, e);
+            Ok(true) => {}
+            Ok(false) => pgrx::error!(
+                "Failed to insert node '{}': ID conflicts with an existing node in instance '{}'",
+                node.id,
+                instance_id
+            ),
+            Err(e) => pgrx::error!("Failed to insert node '{}': {}", node.id, e),
         }
     }
 
@@ -1127,11 +1126,16 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
     // Assign IDs as nodes are discovered. Per-graph uniqueness is required
     // because parent references are materialized before any rows are inserted.
     let mut assigned_ids = std::collections::HashSet::new();
-    let mut id_source = || loop {
-        let candidate = short_id();
-        if assigned_ids.insert(candidate.clone()) {
-            break candidate;
+    let mut id_source = || {
+        for _ in 0..MAX_ID_ATTEMPTS {
+            let candidate = short_id();
+            if assigned_ids.insert(candidate.clone()) {
+                return Ok(candidate);
+            }
         }
+        Err(format!(
+            "exhausted {MAX_ID_ATTEMPTS} attempts to generate a graph-unique node ID"
+        ))
     };
     let (root_id, nodes) = match flatten_graph(&durofut, &mut id_source) {
         Ok(flattened) => flattened,

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -13,8 +13,9 @@ use std::time::{Duration, Instant};
 
 use crate::client::start_durable_function;
 use crate::types::{
-    get_max_new_transaction_starts, get_new_transaction_start_timeout, mark_non_future_helper_call,
-    short_id, validate_result_name, Durofut, FunctionInput,
+    flatten_graph, get_max_new_transaction_starts, get_new_transaction_start_timeout,
+    mark_non_future_helper_call, short_id, validate_result_name, Durofut, FunctionInput,
+    FunctionNode,
 };
 
 /// Check if we're running inside a workflow context (background worker connection).
@@ -990,10 +991,6 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
         Err(e) => pgrx::error!("Invalid durable function: {}", e),
     };
 
-    // Validate the entire graph recursively before inserting
-    if let Err(e) = durofut.validate_recursive() {
-        pgrx::error!("Invalid durable function graph: {}", e);
-    }
     // The instance ID is reserved later (after identity validation), using an
     // INSERT ... ON CONFLICT (id) DO NOTHING retry so collisions — including
     // against other roles' instances invisible under RLS — re-roll instead of
@@ -1036,75 +1033,13 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
         }
     }
 
-    // Insert all nodes from the nested graph into df.nodes, returning root node ID
-    fn insert_nodes(
-        node: &Durofut,
+    fn insert_node(
+        node: &FunctionNode,
         instance_id: &str,
-        force_id: Option<&str>,
         current_user_oid: pgrx::pg_sys::Oid,
         database: Option<&str>,
         legacy_login_role: bool,
-        node_count: &mut usize,
-    ) -> String {
-        *node_count += 1;
-        if *node_count > crate::types::MAX_GRAPH_NODES {
-            pgrx::error!(
-                "Workflow exceeds maximum node count of {}. \
-                 Simplify the workflow or break it into multiple instances.",
-                crate::types::MAX_GRAPH_NODES
-            );
-        }
-        // Recursively insert children FIRST to get their IDs
-        let left_id = node.left_node.as_ref().map(|raw| {
-            let child = Durofut::child_from_raw(raw)
-                .unwrap_or_else(|e| pgrx::error!("Invalid left child in graph: {}", e));
-            insert_nodes(
-                &child,
-                instance_id,
-                None,
-                current_user_oid,
-                database,
-                legacy_login_role,
-                node_count,
-            )
-        });
-        let right_id = node.right_node.as_ref().map(|raw| {
-            let child = Durofut::child_from_raw(raw)
-                .unwrap_or_else(|e| pgrx::error!("Invalid right child in graph: {}", e));
-            insert_nodes(
-                &child,
-                instance_id,
-                None,
-                current_user_oid,
-                database,
-                legacy_login_role,
-                node_count,
-            )
-        });
-
-        // Process config JSON to recursively insert embedded nodes and get their IDs
-        let query_val: Option<String> = match node.transform_config_children(|child| {
-            Ok(insert_nodes(
-                child,
-                instance_id,
-                None,
-                current_user_oid,
-                database,
-                legacy_login_role,
-                node_count,
-            ))
-        }) {
-            Ok(updated_query) => updated_query,
-            Err(e) => pgrx::error!("Invalid config in {} node: {}", node.node_type, e),
-        };
-
-        // Claim a per-instance-unique node ID. Node IDs only need to be unique
-        // within their owning instance — the df.nodes composite PRIMARY KEY
-        // (instance_id, id) is the guard — so we INSERT ... ON CONFLICT
-        // (instance_id, id) DO NOTHING RETURNING id and re-roll on collision
-        // instead of surfacing a raw key violation (issue #129). Near the
-        // MAX_GRAPH_NODES ceiling the per-instance birthday-collision odds are
-        // small but non-trivial, so the retry keeps large graphs from flaking.
+    ) {
         // B1 backward compat: the v0.1.x schema has login_role NOT NULL on
         // df.nodes, so the legacy branch still sets it (= submitted_by).
         // Caveat: the ON CONFLICT (instance_id, id) clause below needs the
@@ -1112,25 +1047,11 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
         // cannot run df.start() until it upgrades. That is fine: the supported
         // B1 floor is 0.2.2 (docs/upgrade-testing.md), so this legacy branch is
         // effectively dead code for every supported install.
-        // The root node's ID is forced (force_id) to the value the instance row
-        // already points at via root_node, so the deferred same-instance FK is
-        // satisfied at commit without an UPDATE the caller isn't privileged to
-        // run. The instance is freshly reserved, so the only way the forced
-        // insert can conflict is a child node in this same graph randomly
-        // claiming the identical 8-hex value (~1 in 2^32): give it a single
-        // attempt and let the error abort the txn (the caller retries) rather
-        // than re-rolling away from the reserved ID. Non-root nodes generate a
-        // random ID and re-roll on collision.
-        let mut forced_id = force_id.map(str::to_string);
-        let max_attempts = if force_id.is_some() {
-            1
-        } else {
-            MAX_ID_ATTEMPTS
-        };
-        let node_id = match pick_id_with_retry(
-            move || forced_id.take().unwrap_or_else(short_id),
+        let node_id = node.id.clone();
+        if let Err(e) = pick_id_with_retry(
+            || node_id.clone(),
             |candidate| {
-                let query_arg: DatumWithOid = match &query_val {
+                let query_arg: DatumWithOid = match &node.query {
                     Some(q) => q.as_str().into(),
                     None => DatumWithOid::null::<String>(),
                 };
@@ -1138,11 +1059,11 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
                     Some(n) => n.as_str().into(),
                     None => DatumWithOid::null::<String>(),
                 };
-                let left_node_arg: DatumWithOid = match &left_id {
+                let left_node_arg: DatumWithOid = match &node.left_node {
                     Some(id) => id.as_str().into(),
                     None => DatumWithOid::null::<String>(),
                 };
-                let right_node_arg: DatumWithOid = match &right_id {
+                let right_node_arg: DatumWithOid = match &node.right_node {
                     Some(id) => id.as_str().into(),
                     None => DatumWithOid::null::<String>(),
                 };
@@ -1195,35 +1116,27 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
                     },
                 )
             },
-            max_attempts,
+            1,
         ) {
-            Ok(id) => id,
-            Err(e) => match force_id {
-                // The forced root id collided with an already-inserted child
-                // node id in this same graph (~1 in 2^32). The whole df.start()
-                // txn aborts cleanly (no orphan, no corruption) so the caller
-                // can simply retry df.start().
-                Some(forced) => pgrx::error!(
-                    "root node id '{}' collided with a child node id in the same graph \
-                     (~1 in 2^32); df.start() aborted safely, retry it ({})",
-                    forced,
-                    e
-                ),
-                None => pgrx::error!("Failed to insert node: {}", e),
-            },
-        };
-
-        // Return the generated ID for parent to reference
-        node_id
+            pgrx::error!("Failed to insert node '{}': {}", node.id, e);
+        }
     }
 
     let legacy_login_role = legacy_login_role_schema();
 
-    // Pre-generate the root node's ID so the instance row can point at it up
-    // front. The same-instance FK on root_node is DEFERRABLE INITIALLY
-    // DEFERRED, so the referenced node row need not exist yet — insert_nodes
-    // below inserts the root node with this exact ID before commit.
-    let root_id = short_id();
+    // Assign IDs as nodes are discovered. Per-graph uniqueness is required
+    // because parent references are materialized before any rows are inserted.
+    let mut assigned_ids = std::collections::HashSet::new();
+    let mut id_source = || loop {
+        let candidate = short_id();
+        if assigned_ids.insert(candidate.clone()) {
+            break candidate;
+        }
+    };
+    let (root_id, nodes) = match flatten_graph(&durofut, &mut id_source) {
+        Ok(flattened) => flattened,
+        Err(e) => pgrx::error!("Invalid durable function graph: {}", e),
+    };
 
     // Reserve the instance ID before inserting nodes so node rows can reference
     // it. Collisions on the 8-hex ID space are rare, but we reserve via
@@ -1291,21 +1204,17 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
         Err(e) => pgrx::error!("Failed to create instance: {}", e),
     };
 
-    // Insert the graph. The top-level (root) node's ID is forced to root_id —
-    // the value the instance row already points at via root_node — so the
-    // deferred same-instance FK is satisfied at commit with no UPDATE (df
-    // callers aren't granted UPDATE on root_node). Child node IDs are random
-    // with collision re-roll.
-    let mut node_count: usize = 0;
-    insert_nodes(
-        &durofut,
-        &instance_id,
-        Some(&root_id),
-        current_user_oid,
-        database,
-        legacy_login_role,
-        &mut node_count,
-    );
+    // The same-instance node references are DEFERRABLE INITIALLY DEFERRED, so
+    // pre-order insertion is valid even when a parent row precedes its child.
+    for node in &nodes {
+        insert_node(
+            node,
+            &instance_id,
+            current_user_oid,
+            database,
+            legacy_login_role,
+        );
+    }
 
     // Capture vars from df.vars using the installed extension version as the
     // compatibility boundary: pre-0.2.0 uses legacy global vars, 0.2.0+ uses

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -6,7 +6,7 @@
 use pgrx::prelude::*;
 use std::collections::HashMap;
 
-use crate::types::{flatten_graph, Durofut, FunctionNode};
+use crate::types::{flatten_graph, Durofut, MaterializedNode};
 
 /// Represents a node for visualization
 #[derive(Debug, Clone)]
@@ -271,7 +271,7 @@ fn explain_durofut(root: &Durofut) -> String {
     let mut id_counter = 0;
     let mut ids = || {
         id_counter += 1;
-        format!("N{id_counter}")
+        Ok(format!("N{id_counter}"))
     };
     let (root_id, flat_nodes) = match flatten_graph(root, &mut ids) {
         Ok(flattened) => flattened,
@@ -284,8 +284,8 @@ fn explain_durofut(root: &Durofut) -> String {
     build_tree_visualization(&root_id, &nodes, false)
 }
 
-impl From<FunctionNode> for ExplainNode {
-    fn from(node: FunctionNode) -> Self {
+impl From<MaterializedNode> for ExplainNode {
+    fn from(node: MaterializedNode) -> Self {
         Self {
             id: node.id,
             node_type: node.node_type,

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -6,6 +6,8 @@
 use pgrx::prelude::*;
 use std::collections::HashMap;
 
+use crate::types::{flatten_graph, Durofut, FunctionNode};
+
 /// Represents a node for visualization
 #[derive(Debug, Clone)]
 struct ExplainNode {
@@ -225,18 +227,9 @@ fn looks_like_dsl_expression(input: &str) -> bool {
 
 /// Explain a DSL expression without executing it
 fn explain_expression(expr: &str) -> String {
-    use crate::types::Durofut;
-
     // First try to parse as Durofut JSON
     if let Ok(root) = Durofut::try_from_json(expr) {
-        if let Err(e) = root.validate_recursive() {
-            return format!("Invalid durable function graph: {e}");
-        }
-        // Build in-memory node map from nested structure with generated IDs
-        let mut nodes = HashMap::new();
-        let mut id_counter = 0;
-        let root_id = collect_nodes(&root, &mut nodes, &mut id_counter);
-        return build_tree_visualization(&root_id, &nodes, false);
+        return explain_durofut(&root);
     }
 
     // Require DSL markers (df.* calls or operators like ~>, |=>) before evaluating via SPI.
@@ -251,10 +244,7 @@ fn explain_expression(expr: &str) -> String {
                 query: Some(expr.to_string()),
                 ..Default::default()
             };
-            let mut nodes = HashMap::new();
-            let mut id_counter = 0;
-            let root_id = collect_nodes(&sql_node, &mut nodes, &mut id_counter);
-            return build_tree_visualization(&root_id, &nodes, false);
+            return explain_durofut(&sql_node);
         }
         return "Cannot explain input: not a valid Durofut JSON, instance ID, SQL statement, or DSL expression.\n\
              Hint: DSL expressions use df.*() functions and operators like ~>, |=>, &, |.".to_string();
@@ -274,68 +264,40 @@ fn explain_expression(expr: &str) -> String {
         Ok(d) => d,
         Err(e) => return format!("Failed to parse Durofut JSON: {e}"),
     };
-    if let Err(e) = root.validate_recursive() {
-        return format!("Invalid durable function graph: {e}");
-    }
+    explain_durofut(&root)
+}
 
-    // Build in-memory node map from nested structure with generated IDs
-    let mut nodes = HashMap::new();
+fn explain_durofut(root: &Durofut) -> String {
     let mut id_counter = 0;
-    let root_id = collect_nodes(&root, &mut nodes, &mut id_counter);
-
-    // Visualize (existing visualization code)
+    let mut ids = || {
+        id_counter += 1;
+        format!("N{id_counter}")
+    };
+    let (root_id, flat_nodes) = match flatten_graph(root, &mut ids) {
+        Ok(flattened) => flattened,
+        Err(e) => return format!("Invalid durable function graph: {e}"),
+    };
+    let nodes = flat_nodes
+        .into_iter()
+        .map(|node| (node.id.clone(), ExplainNode::from(node)))
+        .collect();
     build_tree_visualization(&root_id, &nodes, false)
 }
 
-/// Collect all nodes from a nested Durofut structure into a flat HashMap
-/// Generates temporary IDs for visualization (e.g., "N1", "N2", ...)
-/// Returns the ID of the current node
-fn collect_nodes(
-    node: &crate::types::Durofut,
-    nodes: &mut HashMap<String, ExplainNode>,
-    id_counter: &mut i32,
-) -> String {
-    *id_counter += 1;
-    let node_id = format!("N{}", id_counter);
-
-    // Recursively collect children first to get their IDs
-    let left_id = node.left_node.as_ref().map(|raw| {
-        let child = crate::types::Durofut::child_from_raw(raw)
-            .unwrap_or_else(|e| pgrx::error!("Invalid left child in graph: {}", e));
-        collect_nodes(&child, nodes, id_counter)
-    });
-    let right_id = node.right_node.as_ref().map(|raw| {
-        let child = crate::types::Durofut::child_from_raw(raw)
-            .unwrap_or_else(|e| pgrx::error!("Invalid right child in graph: {}", e));
-        collect_nodes(&child, nodes, id_counter)
-    });
-
-    // Process config JSON to collect embedded nodes and replace Durofuts with IDs
-    let updated_query =
-        match node.transform_config_children(|child| Ok(collect_nodes(child, nodes, id_counter))) {
-            Ok(q) => q,
-            Err(e) => {
-                // In explain context, report errors as part of the visualization rather than panicking
-                Some(format!("ERROR: {e}"))
-            }
-        };
-
-    nodes.insert(
-        node_id.clone(),
-        ExplainNode {
-            id: node_id.clone(),
-            node_type: node.node_type.clone(),
-            query: updated_query,
-            result_name: node.result_name.clone(),
-            left_node: left_id,
-            right_node: right_id,
+impl From<FunctionNode> for ExplainNode {
+    fn from(node: FunctionNode) -> Self {
+        Self {
+            id: node.id,
+            node_type: node.node_type,
+            query: node.query,
+            result_name: node.result_name,
+            left_node: node.left_node,
+            right_node: node.right_node,
             status: None,
             result: None,
             status_details: None,
-        },
-    );
-
-    node_id
+        }
+    }
 }
 
 /// Load nodes from a table into a HashMap

--- a/src/types.rs
+++ b/src/types.rs
@@ -124,20 +124,15 @@ pub const MAX_GRAPH_NODES: usize = 10_000;
 /// Generate a short 8-character ID from a UUID.
 ///
 /// This serves two distinct uniqueness contracts (#129). Both keep the value
-/// `VARCHAR(8)` HEX (the maintainer-requested minimal change) and manage
-/// collision risk by retrying on conflict rather than by widening the value:
+/// `VARCHAR(8)` HEX (the maintainer-requested minimal change):
 /// - **Instance IDs** (`df.instances.id`) are global with no scoping column.
 ///   `df.start()` reserves the ID with `INSERT ... ON CONFLICT (id) DO NOTHING
 ///   RETURNING id` and re-rolls on collision; the primary key on `df.instances`
 ///   is the hard guarantee.
 /// - **Node IDs** (`df.nodes.id`) only need to be unique per instance. Node
-///   inserts use `INSERT ... ON CONFLICT (instance_id, id) DO NOTHING RETURNING
-///   id` and re-roll on collision; the composite primary key `(instance_id, id)`
-///   is the hard guarantee.
-///
-/// The mechanism is symmetric (re-roll on conflict); only the conflict target
-/// differs — the global `id` index for instances vs. the per-instance
-/// `(instance_id, id)` index for nodes.
+///   IDs are assigned uniquely while the graph is materialized, before parent
+///   references are fixed. The composite primary key `(instance_id, id)` is the
+///   final database guarantee; an unexpected insert conflict aborts the start.
 pub fn short_id() -> String {
     let uuid = Uuid::new_v4();
     uuid.to_string()
@@ -1027,19 +1022,25 @@ pub struct FunctionNode {
     pub database: Option<String>,
 }
 
+/// Supplies graph-local node IDs during materialization.
+///
+/// IDs must be unique within a graph. Callers that persist the result must also
+/// supply IDs matching the database's `^[0-9a-f]{8}$` constraint; non-persisting
+/// callers such as explain may use display-only IDs.
 pub(crate) trait IdSource {
-    fn next_id(&mut self) -> String;
+    fn next_id(&mut self) -> Result<String, String>;
 }
 
 impl<F> IdSource for F
 where
-    F: FnMut() -> String,
+    F: FnMut() -> Result<String, String>,
 {
-    fn next_id(&mut self) -> String {
+    fn next_id(&mut self) -> Result<String, String> {
         self()
     }
 }
 
+/// A graph-materialization error with the path of the offending node.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GraphError {
     pub path: String,
@@ -1059,11 +1060,34 @@ struct PendingGraphNode {
     path: String,
 }
 
+/// A node whose graph references and config children have been materialized.
+///
+/// Persistence metadata is intentionally absent because flattening does not
+/// know the submitting role, target database, or instance ID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MaterializedNode {
+    pub id: String,
+    pub node_type: String,
+    pub query: Option<String>,
+    pub result_name: Option<String>,
+    pub left_node: Option<String>,
+    pub right_node: Option<String>,
+}
+
+/// Materialize a Durofut tree into pre-order nodes with parent-before-child
+/// references.
+///
+/// For a valid graph, the returned root ID equals the first node's ID. The ID
+/// source is called once per discovered node and may reject generation before
+/// any persistence occurs.
 pub(crate) fn flatten_graph(
     root: &Durofut,
     ids: &mut impl IdSource,
-) -> Result<(String, Vec<FunctionNode>), GraphError> {
-    let root_id = ids.next_id();
+) -> Result<(String, Vec<MaterializedNode>), GraphError> {
+    let root_id = ids.next_id().map_err(|message| GraphError {
+        path: "root".to_string(),
+        message,
+    })?;
     let mut pending = vec![PendingGraphNode {
         node: root.clone(),
         id: root_id.clone(),
@@ -1071,17 +1095,11 @@ pub(crate) fn flatten_graph(
         path: "root".to_string(),
     }];
     let mut nodes = Vec::new();
+    let mut discovered_nodes = 1;
 
     while let Some(entry) = pending.pop() {
-        if nodes.len() >= MAX_GRAPH_NODES {
-            return Err(GraphError {
-                path: entry.path,
-                message: format!(
-                    "Workflow exceeds maximum node count of {}. Simplify the workflow or break it into multiple instances.",
-                    MAX_GRAPH_NODES
-                ),
-            });
-        }
+        #[cfg(not(test))]
+        pgrx::check_for_interrupts!();
         if entry.depth > MAX_GRAPH_DEPTH {
             return Err(GraphError {
                 path: entry.path,
@@ -1112,11 +1130,24 @@ pub(crate) fn flatten_graph(
         let mut children = Vec::new();
         let mut parse_child = |raw: &serde_json::value::RawValue, segment: String| {
             let path = format!("{}.{}", entry.path, segment);
+            if discovered_nodes >= MAX_GRAPH_NODES {
+                return Err(GraphError {
+                    path,
+                    message: format!(
+                        "Workflow exceeds maximum node count of {}. Simplify the workflow or break it into multiple instances.",
+                        MAX_GRAPH_NODES
+                    ),
+                });
+            }
             let node = Durofut::child_from_raw(raw).map_err(|message| GraphError {
                 path: path.clone(),
                 message,
             })?;
-            let id = ids.next_id();
+            let id = ids.next_id().map_err(|message| GraphError {
+                path: path.clone(),
+                message,
+            })?;
+            discovered_nodes += 1;
             children.push(PendingGraphNode {
                 node,
                 id: id.clone(),
@@ -1168,15 +1199,13 @@ pub(crate) fn flatten_graph(
                 message,
             })?;
 
-        nodes.push(FunctionNode {
+        nodes.push(MaterializedNode {
             id: entry.id,
             node_type: entry.node.node_type,
             query,
             result_name: entry.node.result_name,
             left_node,
             right_node,
-            submitted_by: String::new(),
-            database: None,
         });
 
         pending.extend(children.into_iter().rev());
@@ -1383,7 +1412,7 @@ where
 /// The Durofut type represents a "durable future" - a reference to a node in the function graph.
 /// Children are embedded as opaque JSON objects, not stored as ID references. Keeping them as
 /// `RawValue` lets each graph level deserialize independently without serde_json's recursion limit.
-/// Node IDs are generated during insertion into df.nodes, not during graph construction.
+/// Node IDs are generated when the graph is materialized, before insertion into df.nodes.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Durofut {
     pub node_type: String,
@@ -1571,7 +1600,11 @@ impl Durofut {
     /// Kept as a compatibility helper for callers that only need validation;
     /// graph entrypoints should consume `flatten_graph` directly.
     pub fn validate_recursive(&self) -> Result<(), String> {
-        let mut next_id = || String::new();
+        let mut counter = 0_u32;
+        let mut next_id = || {
+            counter += 1;
+            Ok(format!("{counter:08x}"))
+        };
         flatten_graph(self, &mut next_id)
             .map(|_| ())
             .map_err(|error| error.to_string())
@@ -2412,8 +2445,8 @@ mod tests {
             query: Some("SELECT 1".to_string()),
             ..Default::default()
         };
-        // MAX_GRAPH_DEPTH - 1 nestings (the root counts as depth 0)
-        for _ in 0..MAX_GRAPH_DEPTH - 1 {
+        // MAX_GRAPH_DEPTH nestings (the root counts as depth 0)
+        for _ in 0..MAX_GRAPH_DEPTH {
             node = Durofut {
                 node_type: "THEN".to_string(),
                 left_node: Some(node.into_raw()),
@@ -2453,23 +2486,27 @@ mod tests {
 
     #[test]
     fn test_flatten_graph_preserves_condition_nodes_query_format() {
-        let condition = Durofut {
-            node_type: "SQL".to_string(),
-            query: Some("SELECT true".to_string()),
-            ..Default::default()
-        };
-        let node = Durofut {
-            node_type: "IF".to_string(),
-            condition_node: Some(condition.into_raw()),
-            ..Default::default()
-        };
+        for node_type in ["IF", "LOOP"] {
+            let condition = Durofut {
+                node_type: "SQL".to_string(),
+                query: Some("SELECT true".to_string()),
+                ..Default::default()
+            };
+            let node = Durofut {
+                node_type: node_type.to_string(),
+                condition_node: Some(condition.into_raw()),
+                ..Default::default()
+            };
 
-        let mut ids = ["root", "condition-id"].into_iter().map(str::to_string);
-        let (_, nodes) = flatten_graph(&node, &mut || ids.next().unwrap()).unwrap();
-        assert_eq!(
-            nodes[0].query.as_deref(),
-            Some(r#"{"condition_node":"condition-id"}"#)
-        );
+            let mut ids = ["root", "condition-id"].into_iter().map(str::to_string);
+            let (root_id, nodes) = flatten_graph(&node, &mut || Ok(ids.next().unwrap())).unwrap();
+            assert_eq!(nodes[0].id, root_id);
+            assert_eq!(nodes[1].id, "condition-id");
+            assert_eq!(
+                nodes[0].query.as_deref(),
+                Some(r#"{"condition_node":"condition-id"}"#)
+            );
+        }
     }
 
     #[test]
@@ -2487,7 +2524,7 @@ mod tests {
         };
 
         let mut ids = ["root", "condition-id"].into_iter().map(str::to_string);
-        let (_, nodes) = flatten_graph(&node, &mut || ids.next().unwrap()).unwrap();
+        let (_, nodes) = flatten_graph(&node, &mut || Ok(ids.next().unwrap())).unwrap();
         assert_eq!(
             nodes[0].query.as_deref(),
             Some(r#"{"a":1,"condition_node":"condition-id"}"#)
@@ -2508,7 +2545,8 @@ mod tests {
         };
 
         let mut ids = ["root", "extra-id"].into_iter().map(str::to_string);
-        let (_, nodes) = flatten_graph(&node, &mut || ids.next().unwrap()).unwrap();
+        let (_, nodes) = flatten_graph(&node, &mut || Ok(ids.next().unwrap())).unwrap();
+        assert_eq!(nodes[1].id, "extra-id");
         assert_eq!(
             nodes[0].query.as_deref(),
             Some(r#"{"extra_nodes":["extra-id"]}"#)
@@ -2546,7 +2584,7 @@ mod tests {
             .validate_recursive()
             .unwrap_err()
             .contains("condition_node in LOOP must be a first-class Durofut field"));
-        let mut ids = || "unused".to_string();
+        let mut ids = || Ok("unused".to_string());
         assert!(flatten_graph(&legacy_join, &mut ids)
             .unwrap_err()
             .to_string()
@@ -2626,7 +2664,7 @@ mod tests {
     }
 
     #[test]
-    fn test_flatten_graph_assigns_preorder_ids_and_reports_error_path() {
+    fn test_flatten_graph_reports_invalid_child_path() {
         let invalid = Durofut {
             node_type: "NOT_A_NODE".to_string(),
             ..Default::default()
@@ -2647,12 +2685,80 @@ mod tests {
         let mut counter = 0;
         let error = flatten_graph(&root, &mut || {
             counter += 1;
-            format!("N{counter}")
+            Ok(format!("N{counter}"))
         })
         .unwrap_err();
 
         assert_eq!(error.path, "root.right");
         assert!(error.message.contains("Unknown node_type 'NOT_A_NODE'"));
+    }
+
+    #[test]
+    fn test_flatten_graph_assigns_unique_preorder_ids_and_forward_references() {
+        let root = Durofut {
+            node_type: "THEN".to_string(),
+            left_node: Some(
+                Durofut {
+                    node_type: "SQL".to_string(),
+                    query: Some("SELECT 1".to_string()),
+                    ..Default::default()
+                }
+                .into_raw(),
+            ),
+            right_node: Some(
+                Durofut {
+                    node_type: "THEN".to_string(),
+                    left_node: Some(
+                        Durofut {
+                            node_type: "SQL".to_string(),
+                            query: Some("SELECT 2".to_string()),
+                            ..Default::default()
+                        }
+                        .into_raw(),
+                    ),
+                    right_node: Some(
+                        Durofut {
+                            node_type: "SQL".to_string(),
+                            query: Some("SELECT 3".to_string()),
+                            ..Default::default()
+                        }
+                        .into_raw(),
+                    ),
+                    ..Default::default()
+                }
+                .into_raw(),
+            ),
+            ..Default::default()
+        };
+        let mut counter = 0;
+        let (root_id, nodes) = flatten_graph(&root, &mut || {
+            counter += 1;
+            Ok(format!("{counter:08x}"))
+        })
+        .unwrap();
+
+        assert_eq!(nodes[0].id, root_id);
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|node| node.node_type.as_str())
+                .collect::<Vec<_>>(),
+            ["THEN", "SQL", "THEN", "SQL", "SQL"]
+        );
+        let positions = nodes
+            .iter()
+            .enumerate()
+            .map(|(index, node)| (node.id.as_str(), index))
+            .collect::<std::collections::HashMap<_, _>>();
+        assert_eq!(positions.len(), nodes.len());
+        for (index, node) in nodes.iter().enumerate() {
+            for child_id in [node.left_node.as_deref(), node.right_node.as_deref()]
+                .into_iter()
+                .flatten()
+            {
+                assert!(positions[child_id] > index);
+            }
+        }
     }
 
     #[test]
@@ -2670,14 +2776,70 @@ mod tests {
     }
 
     #[test]
+    fn test_flatten_graph_bounds_id_generation_for_oversized_join() {
+        let join_node = build_wide_join(MAX_GRAPH_NODES);
+        let mut id_calls = 0;
+
+        let result = flatten_graph(&join_node, &mut || {
+            id_calls += 1;
+            Ok(format!("{id_calls:08x}"))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(id_calls, MAX_GRAPH_NODES);
+        assert_eq!(result.unwrap_err().path, "root.extra_nodes[9997]");
+    }
+
+    #[test]
+    fn test_flatten_graph_reports_id_source_failure_at_child_path() {
+        let root = Durofut {
+            node_type: "THEN".to_string(),
+            left_node: Some(
+                Durofut {
+                    node_type: "SQL".to_string(),
+                    query: Some("SELECT 1".to_string()),
+                    ..Default::default()
+                }
+                .into_raw(),
+            ),
+            right_node: Some(
+                Durofut {
+                    node_type: "SQL".to_string(),
+                    query: Some("SELECT 2".to_string()),
+                    ..Default::default()
+                }
+                .into_raw(),
+            ),
+            ..Default::default()
+        };
+        let mut calls = 0;
+        let result = flatten_graph(&root, &mut || {
+            calls += 1;
+            if calls == 2 {
+                Err("ID source exhausted".to_string())
+            } else {
+                Ok(format!("{calls:08x}"))
+            }
+        });
+
+        assert_eq!(
+            result.unwrap_err(),
+            GraphError {
+                path: "root.left".to_string(),
+                message: "ID source exhausted".to_string(),
+            }
+        );
+    }
+
+    #[test]
     fn test_validate_recursive_node_count_within_limit() {
-        // A graph with a moderate number of nodes should pass
-        let join_node = build_wide_join(50);
+        // Root + left + right + extra nodes totals exactly MAX_GRAPH_NODES.
+        let join_node = build_wide_join(MAX_GRAPH_NODES - 3);
 
         let result = join_node.validate_recursive();
         assert!(
             result.is_ok(),
-            "should accept graph within node count limit"
+            "should accept graph exactly at node count limit"
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1027,6 +1027,164 @@ pub struct FunctionNode {
     pub database: Option<String>,
 }
 
+pub(crate) trait IdSource {
+    fn next_id(&mut self) -> String;
+}
+
+impl<F> IdSource for F
+where
+    F: FnMut() -> String,
+{
+    fn next_id(&mut self) -> String {
+        self()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphError {
+    pub path: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for GraphError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.path, self.message)
+    }
+}
+
+struct PendingGraphNode {
+    node: Durofut,
+    id: String,
+    depth: usize,
+    path: String,
+}
+
+pub(crate) fn flatten_graph(
+    root: &Durofut,
+    ids: &mut impl IdSource,
+) -> Result<(String, Vec<FunctionNode>), GraphError> {
+    let root_id = ids.next_id();
+    let mut pending = vec![PendingGraphNode {
+        node: root.clone(),
+        id: root_id.clone(),
+        depth: 0,
+        path: "root".to_string(),
+    }];
+    let mut nodes = Vec::new();
+
+    while let Some(entry) = pending.pop() {
+        if nodes.len() >= MAX_GRAPH_NODES {
+            return Err(GraphError {
+                path: entry.path,
+                message: format!(
+                    "Workflow exceeds maximum node count of {}. Simplify the workflow or break it into multiple instances.",
+                    MAX_GRAPH_NODES
+                ),
+            });
+        }
+        if entry.depth > MAX_GRAPH_DEPTH {
+            return Err(GraphError {
+                path: entry.path,
+                message: format!(
+                    "Graph exceeds maximum nesting depth of {}. Simplify the workflow or break it into multiple instances.",
+                    MAX_GRAPH_DEPTH
+                ),
+            });
+        }
+        if !VALID_NODE_TYPES.contains(&entry.node.node_type.as_str()) {
+            return Err(GraphError {
+                path: entry.path,
+                message: format!(
+                    "Unknown node_type '{}'. Valid types: {}",
+                    entry.node.node_type,
+                    VALID_NODE_TYPES.join(", ")
+                ),
+            });
+        }
+        entry
+            .node
+            .validate_config_children()
+            .map_err(|message| GraphError {
+                path: entry.path.clone(),
+                message,
+            })?;
+
+        let mut children = Vec::new();
+        let mut parse_child = |raw: &serde_json::value::RawValue, segment: String| {
+            let path = format!("{}.{}", entry.path, segment);
+            let node = Durofut::child_from_raw(raw).map_err(|message| GraphError {
+                path: path.clone(),
+                message,
+            })?;
+            let id = ids.next_id();
+            children.push(PendingGraphNode {
+                node,
+                id: id.clone(),
+                depth: entry.depth + 1,
+                path,
+            });
+            Ok::<String, GraphError>(id)
+        };
+
+        let left_node = entry
+            .node
+            .left_node
+            .as_deref()
+            .map(|raw| parse_child(raw, "left".to_string()))
+            .transpose()?;
+        let right_node = entry
+            .node
+            .right_node
+            .as_deref()
+            .map(|raw| parse_child(raw, "right".to_string()))
+            .transpose()?;
+        let condition_node = if entry.node.node_type == "IF" || entry.node.node_type == "LOOP" {
+            entry
+                .node
+                .condition_node
+                .as_deref()
+                .map(|raw| parse_child(raw, "condition_node".to_string()))
+                .transpose()?
+        } else {
+            None
+        };
+        let extra_nodes = if entry.node.node_type == "JOIN" {
+            entry
+                .node
+                .extra_nodes
+                .iter()
+                .enumerate()
+                .map(|(index, raw)| parse_child(raw, format!("extra_nodes[{index}]")))
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            Vec::new()
+        };
+
+        let query = entry
+            .node
+            .materialized_query(condition_node.as_deref(), &extra_nodes)
+            .map_err(|message| GraphError {
+                path: entry.path.clone(),
+                message,
+            })?;
+
+        nodes.push(FunctionNode {
+            id: entry.id,
+            node_type: entry.node.node_type,
+            query,
+            result_name: entry.node.result_name,
+            left_node,
+            right_node,
+            submitted_by: String::new(),
+            database: None,
+        });
+
+        pending.extend(children.into_iter().rev());
+    }
+
+    Ok((root_id, nodes))
+}
+
 /// Represents the entire function graph for an instance
 /// Note: Uses BTreeMap for deterministic serialization order (required for Duroxide replay)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1410,12 +1568,13 @@ impl Durofut {
     }
 
     /// Validate a Durofut node and all its children have valid node_types.
-    /// Used during insertion in df.start() to catch invalid nested nodes.
-    /// Also enforces MAX_GRAPH_NODES so oversized graphs fail fast without
-    /// needing a second traversal during insertion.
+    /// Kept as a compatibility helper for callers that only need validation;
+    /// graph entrypoints should consume `flatten_graph` directly.
     pub fn validate_recursive(&self) -> Result<(), String> {
-        let mut node_count = 0;
-        self.validate_recursive_inner(0, &mut node_count)
+        let mut next_id = || String::new();
+        flatten_graph(self, &mut next_id)
+            .map(|_| ())
+            .map_err(|error| error.to_string())
     }
 
     fn reject_embedded_config_children(&self) -> Result<(), String> {
@@ -1457,115 +1616,16 @@ impl Durofut {
         }
 
         self.reject_embedded_config_children()?;
-
-        let has_config_children = (supports_condition && self.condition_node.is_some())
-            || (self.node_type == "JOIN" && !self.extra_nodes.is_empty());
-        let Some(query) = self.query.as_ref().filter(|_| has_config_children) else {
-            return Ok(());
-        };
-        let config = serde_json::from_str::<serde_json::Value>(query).map_err(|e| {
-            format!(
-                "query in {} must be valid JSON config: {}",
-                self.node_type, e
-            )
-        })?;
-        if !config.is_object() {
-            return Err(format!(
-                "query in {} must be a JSON config object",
-                self.node_type
-            ));
-        }
-
         Ok(())
     }
 
-    fn validate_recursive_inner(&self, depth: usize, node_count: &mut usize) -> Result<(), String> {
-        *node_count += 1;
-        if *node_count > MAX_GRAPH_NODES {
-            return Err(format!(
-                "Workflow exceeds maximum node count of {}. \
-                 Simplify the workflow or break it into multiple instances.",
-                MAX_GRAPH_NODES
-            ));
-        }
-        if depth > MAX_GRAPH_DEPTH {
-            return Err(format!(
-                "Graph exceeds maximum nesting depth of {}. \
-                 Simplify the workflow or break it into multiple instances.",
-                MAX_GRAPH_DEPTH
-            ));
-        }
-        if !VALID_NODE_TYPES.contains(&self.node_type.as_str()) {
-            return Err(format!(
-                "Unknown node_type '{}'. Valid types: {}",
-                self.node_type,
-                VALID_NODE_TYPES.join(", ")
-            ));
-        }
-        self.validate_config_children()?;
-        if let Some(ref left) = self.left_node {
-            Self::child_from_raw(left)?.validate_recursive_inner(depth + 1, node_count)?;
-        }
-        if let Some(ref right) = self.right_node {
-            Self::child_from_raw(right)?.validate_recursive_inner(depth + 1, node_count)?;
-        }
-        // Validate config children (condition_node, extra_nodes)
-        let d = depth + 1;
-        self.for_each_config_child(|child| child.validate_recursive_inner(d, node_count))?;
-        Ok(())
-    }
-
-    /// Parse each opaque config child and apply a callback to it.
-    ///
-    /// The callback receives each embedded child and returns `Result<(), String>`.
-    /// Parsing failures are always treated as errors — a `condition_node` or `extra_nodes`
-    /// entry that cannot be deserialized as a valid Durofut is rejected.
-    pub fn for_each_config_child<F>(&self, mut f: F) -> Result<(), String>
-    where
-        F: FnMut(&Durofut) -> Result<(), String>,
-    {
-        // IF/LOOP nodes: condition_node
-        if self.node_type == "IF" || self.node_type == "LOOP" {
-            if let Some(cond) = self.condition_node.as_ref() {
-                let cond_node = Self::child_from_raw(cond).map_err(|e| {
-                    format!(
-                        "condition_node in {} must be a valid Durofut object: {}",
-                        self.node_type, e
-                    )
-                })?;
-                f(&cond_node)?;
-            }
-        }
-
-        // JOIN nodes: extra_nodes array
-        if self.node_type == "JOIN" {
-            for (i, extra) in self.extra_nodes.iter().enumerate() {
-                let extra_node = Self::child_from_raw(extra).map_err(|e| {
-                    format!(
-                        "extra_nodes[{}] in {} must be a valid Durofut object: {}",
-                        i, self.node_type, e
-                    )
-                })?;
-                f(&extra_node)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Transform config children into string IDs via a callback, returning the
-    /// `df.nodes.query` JSON string used by `insert_nodes` and `collect_nodes`.
-    ///
-    /// The callback receives each embedded child and returns the generated ID string.
-    /// Parsing failures are always treated as errors.
-    pub fn transform_config_children<F>(&self, mut f: F) -> Result<Option<String>, String>
-    where
-        F: FnMut(&Durofut) -> Result<String, String>,
-    {
-        self.validate_config_children()?;
-        let has_condition =
-            (self.node_type == "IF" || self.node_type == "LOOP") && self.condition_node.is_some();
-        let has_extras = self.node_type == "JOIN" && !self.extra_nodes.is_empty();
+    fn materialized_query(
+        &self,
+        condition_node: Option<&str>,
+        extra_nodes: &[String],
+    ) -> Result<Option<String>, String> {
+        let has_condition = condition_node.is_some();
+        let has_extras = !extra_nodes.is_empty();
         if !has_condition && !has_extras {
             return Ok(self.query.clone());
         }
@@ -1586,33 +1646,12 @@ impl Durofut {
             ));
         }
 
-        // IF/LOOP nodes: condition_node
-        if has_condition {
-            if let Some(cond) = self.condition_node.as_ref() {
-                let cond_node = Self::child_from_raw(cond).map_err(|e| {
-                    format!(
-                        "condition_node in {} must be a valid Durofut object: {}",
-                        self.node_type, e
-                    )
-                })?;
-                let cond_id = f(&cond_node)?;
-                config["condition_node"] = serde_json::json!(cond_id);
-            }
+        if let Some(condition_node) = condition_node {
+            config["condition_node"] = serde_json::json!(condition_node);
         }
 
-        // JOIN nodes: extra_nodes array
         if has_extras {
-            let mut extra_ids: Vec<String> = Vec::with_capacity(self.extra_nodes.len());
-            for (i, extra) in self.extra_nodes.iter().enumerate() {
-                let extra_node = Self::child_from_raw(extra).map_err(|e| {
-                    format!(
-                        "extra_nodes[{}] in {} must be a valid Durofut object: {}",
-                        i, self.node_type, e
-                    )
-                })?;
-                extra_ids.push(f(&extra_node)?);
-            }
-            config["extra_nodes"] = serde_json::json!(extra_ids);
+            config["extra_nodes"] = serde_json::json!(extra_nodes);
         }
 
         Ok(Some(serde_json::to_string(&config).unwrap()))
@@ -2413,7 +2452,7 @@ mod tests {
     }
 
     #[test]
-    fn test_transform_config_children_preserves_nodes_query_format() {
+    fn test_flatten_graph_preserves_condition_nodes_query_format() {
         let condition = Durofut {
             node_type: "SQL".to_string(),
             query: Some("SELECT true".to_string()),
@@ -2425,15 +2464,16 @@ mod tests {
             ..Default::default()
         };
 
-        let query = node
-            .transform_config_children(|_| Ok("condition-id".to_string()))
-            .unwrap()
-            .unwrap();
-        assert_eq!(query, r#"{"condition_node":"condition-id"}"#);
+        let mut ids = ["root", "condition-id"].into_iter().map(str::to_string);
+        let (_, nodes) = flatten_graph(&node, &mut || ids.next().unwrap()).unwrap();
+        assert_eq!(
+            nodes[0].query.as_deref(),
+            Some(r#"{"condition_node":"condition-id"}"#)
+        );
     }
 
     #[test]
-    fn test_transform_config_children_preserves_existing_query() {
+    fn test_flatten_graph_preserves_existing_query() {
         let condition = Durofut {
             node_type: "SQL".to_string(),
             query: Some("SELECT true".to_string()),
@@ -2446,15 +2486,16 @@ mod tests {
             ..Default::default()
         };
 
-        let query = node
-            .transform_config_children(|_| Ok("condition-id".to_string()))
-            .unwrap()
-            .unwrap();
-        assert_eq!(query, r#"{"a":1,"condition_node":"condition-id"}"#);
+        let mut ids = ["root", "condition-id"].into_iter().map(str::to_string);
+        let (_, nodes) = flatten_graph(&node, &mut || ids.next().unwrap()).unwrap();
+        assert_eq!(
+            nodes[0].query.as_deref(),
+            Some(r#"{"a":1,"condition_node":"condition-id"}"#)
+        );
     }
 
     #[test]
-    fn test_transform_extra_nodes_preserves_nodes_query_format() {
+    fn test_flatten_graph_preserves_extra_nodes_query_format() {
         let extra = Durofut {
             node_type: "SQL".to_string(),
             query: Some("SELECT 3".to_string()),
@@ -2466,11 +2507,12 @@ mod tests {
             ..Default::default()
         };
 
-        let query = node
-            .transform_config_children(|_| Ok("extra-id".to_string()))
-            .unwrap()
-            .unwrap();
-        assert_eq!(query, r#"{"extra_nodes":["extra-id"]}"#);
+        let mut ids = ["root", "extra-id"].into_iter().map(str::to_string);
+        let (_, nodes) = flatten_graph(&node, &mut || ids.next().unwrap()).unwrap();
+        assert_eq!(
+            nodes[0].query.as_deref(),
+            Some(r#"{"extra_nodes":["extra-id"]}"#)
+        );
     }
 
     #[test]
@@ -2500,17 +2542,14 @@ mod tests {
             .validate_recursive()
             .unwrap_err()
             .contains("condition_node in IF must be a first-class Durofut field"));
-        assert!(legacy_join
-            .validate_recursive()
-            .unwrap_err()
-            .contains("extra_nodes in JOIN must be a first-class Durofut field"));
         assert!(legacy_loop
             .validate_recursive()
             .unwrap_err()
             .contains("condition_node in LOOP must be a first-class Durofut field"));
-        assert!(legacy_join
-            .transform_config_children(|_| Ok("unused".to_string()))
+        let mut ids = || "unused".to_string();
+        assert!(flatten_graph(&legacy_join, &mut ids)
             .unwrap_err()
+            .to_string()
             .contains("extra_nodes in JOIN must be a first-class Durofut field"));
     }
 
@@ -2584,6 +2623,36 @@ mod tests {
             Durofut::try_from_json(non_array).is_err(),
             "should reject non-array extra_nodes"
         );
+    }
+
+    #[test]
+    fn test_flatten_graph_assigns_preorder_ids_and_reports_error_path() {
+        let invalid = Durofut {
+            node_type: "NOT_A_NODE".to_string(),
+            ..Default::default()
+        };
+        let root = Durofut {
+            node_type: "THEN".to_string(),
+            left_node: Some(
+                Durofut {
+                    node_type: "SQL".to_string(),
+                    query: Some("SELECT 1".to_string()),
+                    ..Default::default()
+                }
+                .into_raw(),
+            ),
+            right_node: Some(invalid.into_raw()),
+            ..Default::default()
+        };
+        let mut counter = 0;
+        let error = flatten_graph(&root, &mut || {
+            counter += 1;
+            format!("N{counter}")
+        })
+        .unwrap_err();
+
+        assert_eq!(error.path, "root.right");
+        assert!(error.message.contains("Unknown node_type 'NOT_A_NODE'"));
     }
 
     #[test]

--- a/tests/e2e/sql/09_graph_and_validation.sql
+++ b/tests/e2e/sql/09_graph_and_validation.sql
@@ -118,19 +118,26 @@ DROP TABLE test_graph_reuse;
 -- === Test: 32_invalid_node_type ===
 
 DO $body$
+DECLARE
+    explanation TEXT;
 BEGIN
     BEGIN
         PERFORM df.start('{"node_type":"NOT_A_NODE"}');
         RAISE EXCEPTION 'TEST FAILED: df.start should have rejected invalid node_type';
     EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM LIKE 'TEST FAILED:%' THEN
+            RAISE;
+        END IF;
+        IF SQLERRM NOT LIKE '%Unknown node_type ''NOT_A_NODE''%' THEN
+            RAISE EXCEPTION 'TEST FAILED: df.start returned the wrong error: %', SQLERRM;
+        END IF;
         RAISE NOTICE 'Caught expected error: %', SQLERRM;
     END;
 
-    BEGIN
-        PERFORM df.explain('{"node_type":"NOT_A_NODE"}');
-    EXCEPTION WHEN OTHERS THEN
-        RAISE EXCEPTION 'TEST FAILED: df.explain should not raise on invalid node_type';
-    END;
+    explanation := df.explain('{"node_type":"NOT_A_NODE"}');
+    IF explanation NOT LIKE 'Invalid durable function graph: root: Unknown node_type ''NOT_A_NODE''%' THEN
+        RAISE EXCEPTION 'TEST FAILED: df.explain returned the wrong error: %', explanation;
+    END IF;
 
     RAISE NOTICE 'TEST PASSED: invalid node_type handling';
 END $body$;

--- a/tests/e2e/sql/51_node_composite_pk.sql
+++ b/tests/e2e/sql/51_node_composite_pk.sql
@@ -16,8 +16,9 @@ SET SESSION AUTHORIZATION df_e2e_user;
 -- === Part 1: schema contract — composite primary key ===
 DO $$
 DECLARE
-    pk_def        TEXT;
-    legacy_unique BOOLEAN;
+    pk_def                   TEXT;
+    legacy_unique            BOOLEAN;
+    deferred_reference_count INT;
 BEGIN
     SELECT pg_get_constraintdef(c.oid) INTO pk_def
     FROM pg_constraint c
@@ -49,7 +50,24 @@ BEGIN
         RAISE EXCEPTION 'TEST FAILED: legacy nodes_instance_node_key UNIQUE still present';
     END IF;
 
-    RAISE NOTICE 'PASSED: df.nodes composite primary key (instance_id, id)';
+    SELECT count(*) INTO deferred_reference_count
+    FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace ns ON ns.oid = t.relnamespace
+        WHERE ns.nspname = 'df'
+            AND (t.relname, c.conname) IN (
+                    ('nodes', 'nodes_left_node_same_instance_fkey'),
+                    ('nodes', 'nodes_right_node_same_instance_fkey'),
+                    ('instances', 'instances_root_node_same_instance_fkey')
+            )
+      AND c.condeferrable
+      AND c.condeferred;
+
+    IF deferred_reference_count != 3 THEN
+        RAISE EXCEPTION 'TEST FAILED: expected all three graph-reference foreign keys to be DEFERRABLE INITIALLY DEFERRED, found %', deferred_reference_count;
+    END IF;
+
+    RAISE NOTICE 'PASSED: df.nodes composite primary key and deferred graph references';
 END $$;
 
 -- === Part 2: regression — multi-node workflow under instance_id scoping ===


### PR DESCRIPTION
## Summary

- add a shared iterative `flatten_graph` pass for validation and materialization
- use the same flat `FunctionNode` representation in `df.start()` and `df.explain()`
- report graph errors with child paths and preserve the existing `df.nodes.query` format
- document pre-order ID assignment and its deferred-foreign-key requirement

## Validation

- `cargo test --features pg17 types::tests --lib` (69 passed)
- `./scripts/test-unit.sh` (274 passed, 16 ignored)
- `./scripts/test-e2e-local.sh 09_graph_and_validation`
- `./scripts/test-upgrade.sh` (70 passed across supported schemas 0.2.2 through 0.2.5)
- `cargo clippy --features pg17 --lib -- -D warnings`
- `cargo fmt -p pg_durable -- --check`
- `cargo check --features pg17`