### PR TITLE
Validate function graph operands once

### DIFF
--- a/docs/nested-graph-design.md
+++ b/docs/nested-graph-design.md
@@ -49,6 +49,8 @@ Conditions for IF/LOOP and additional JOIN branches are first-class `condition_n
 `extra_nodes` fields. They do not live inside the escaped `query` string, so nested config graphs
 grow linearly and use the same traversal path as left and right children.
 
+`flatten_graph` is the single materialization and validation pass used by both `df.start()` and `df.explain()`. It walks the envelope iteratively, enforces node-type, depth, and node-count limits, and reports failures with paths such as `root.left.condition_node`. IDs are assigned when children are discovered, allowing the parent `FunctionNode` to be emitted before its children. Persisting that pre-order output is valid because the same-instance node foreign keys are `DEFERRABLE INITIALLY DEFERRED`; changing that constraint requires changing the materialization order too.
+
 The envelope is distinct from durable execution state. During `df.start()`, config children are
 materialized as node rows and `df.nodes.query` retains the worker-facing format with child IDs:
 

--- a/docs/nested-graph-design.md
+++ b/docs/nested-graph-design.md
@@ -49,6 +49,13 @@ Conditions for IF/LOOP and additional JOIN branches are first-class `condition_n
 `extra_nodes` fields. They do not live inside the escaped `query` string, so nested config graphs
 grow linearly and use the same traversal path as left and right children.
 
+The left-fold composers `df.seq()`, `df.join()`, and `df.race()` remember their most recent output
+in backend-local state. When that exact output is the next call's left operand, they embed it
+verbatim and validate only the newly arrived right operand. Other left operands pass through normal
+`Durofut` parsing or SQL wrapping. This avoids rescanning an increasingly large left-deep graph at
+every composition step without trusting caller-crafted text; `flatten_graph` remains the path-aware
+validation boundary for the complete graph.
+
 `flatten_graph` is the single materialization and validation pass used by both `df.start()` and `df.explain()`. It walks the envelope iteratively, enforces node-type, depth, and node-count limits, and reports failures with paths such as `root.left.condition_node`. IDs are assigned when children are discovered, allowing the parent `FunctionNode` to be emitted before its children. Persisting that pre-order output is valid because the same-instance node foreign keys are `DEFERRABLE INITIALLY DEFERRED`; changing that constraint requires changing the materialization order too.
 
 The envelope is distinct from durable execution state. During `df.start()`, config children are

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -6,6 +6,7 @@
 use cron::Schedule as CronSchedule;
 use pgrx::datum::DatumWithOid;
 use pgrx::prelude::*;
+use serde::ser::SerializeStruct;
 use std::str::FromStr;
 
 use std::cell::RefCell;
@@ -215,6 +216,65 @@ pub fn clearvars() -> String {
 // Node Creation Functions
 // ============================================================================
 
+struct PreviouslyComposed<'a>(&'a str);
+
+impl serde::Serialize for PreviouslyComposed<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // serde_json uses this token to copy a RawValue's bytes without parsing them again.
+        const RAW_VALUE_TOKEN: &str = "$serde_json::private::RawValue";
+
+        let mut raw = serializer.serialize_struct(RAW_VALUE_TOKEN, 1)?;
+        raw.serialize_field(RAW_VALUE_TOKEN, self.0)?;
+        raw.end()
+    }
+}
+
+#[derive(serde::Serialize)]
+struct BinaryComposition<'a> {
+    node_type: &'static str,
+    left_node: PreviouslyComposed<'a>,
+    right_node: Box<serde_json::value::RawValue>,
+}
+
+thread_local! {
+    static LAST_BINARY_COMPOSITION: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+fn remember_binary_composition(composition: String) -> String {
+    LAST_BINARY_COMPOSITION.with(|last| *last.borrow_mut() = Some(composition.clone()));
+    composition
+}
+
+fn compose_binary(node_type: &'static str, left: &str, right: &str) -> String {
+    let left_was_composed =
+        LAST_BINARY_COMPOSITION.with(|last| last.borrow().as_deref() == Some(left));
+
+    let composition = if left_was_composed {
+        let right_fut = Durofut::ensure(right);
+        serde_json::to_string(&BinaryComposition {
+            node_type,
+            left_node: PreviouslyComposed(left),
+            right_node: right_fut.into_raw(),
+        })
+        .expect("failed to serialize binary composition")
+    } else {
+        let left_fut = Durofut::ensure(left);
+        let right_fut = Durofut::ensure(right);
+        Durofut {
+            node_type: node_type.to_string(),
+            left_node: Some(left_fut.into_raw()),
+            right_node: Some(right_fut.into_raw()),
+            ..Default::default()
+        }
+        .to_json()
+    };
+
+    remember_binary_composition(composition)
+}
+
 /// Creates a SQL node in the function graph.
 #[pg_extern(schema = "df")]
 pub fn sql(query: &str) -> String {
@@ -231,16 +291,7 @@ pub fn sql(query: &str) -> String {
 /// Arguments can be either Durofut JSON or plain SQL strings (auto-wrapped).
 #[pg_extern(name = "seq", schema = "df")]
 pub fn then_fn(a: &str, b: &str) -> String {
-    let a_fut = Durofut::ensure(a);
-    let b_fut = Durofut::ensure(b);
-
-    Durofut {
-        node_type: "THEN".to_string(),
-        left_node: Some(a_fut.into_raw()),
-        right_node: Some(b_fut.into_raw()),
-        ..Default::default()
-    }
-    .to_json()
+    compose_binary("THEN", a, b)
 }
 
 /// Names a result for later reference.
@@ -413,16 +464,7 @@ pub fn if_rows_fn(result_name: &str, then_branch: &str, else_branch: &str) -> St
 /// Arguments can be either Durofut JSON or plain SQL strings (auto-wrapped).
 #[pg_extern(schema = "df")]
 pub fn join(a: &str, b: &str) -> String {
-    let a_fut = Durofut::ensure(a);
-    let b_fut = Durofut::ensure(b);
-
-    Durofut {
-        node_type: "JOIN".to_string(),
-        left_node: Some(a_fut.into_raw()),
-        right_node: Some(b_fut.into_raw()),
-        ..Default::default()
-    }
-    .to_json()
+    compose_binary("JOIN", a, b)
 }
 
 /// Creates a parallel join node for 3 branches.
@@ -447,16 +489,7 @@ pub fn join3(a: &str, b: &str, c: &str) -> String {
 /// Arguments can be either Durofut JSON or plain SQL strings (auto-wrapped).
 #[pg_extern(schema = "df")]
 pub fn race(a: &str, b: &str) -> String {
-    let a_fut = Durofut::ensure(a);
-    let b_fut = Durofut::ensure(b);
-
-    Durofut {
-        node_type: "RACE".to_string(),
-        left_node: Some(a_fut.into_raw()),
-        right_node: Some(b_fut.into_raw()),
-        ..Default::default()
-    }
-    .to_json()
+    compose_binary("RACE", a, b)
 }
 
 /// Creates an HTTP request node.

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -725,6 +725,11 @@ pub fn signal(instance_id: &str, signal_name: &str, signal_data: default!(&str, 
 /// rather than an unverified ID.
 const MAX_ID_ATTEMPTS: usize = 10;
 
+/// Keep each node INSERT comfortably below PostgreSQL's 65,535 bind-parameter
+/// limit. The legacy schema uses ten parameters per row, so this caps a batch
+/// at 10,000 parameters and a maximum-size graph at ten INSERT statements.
+const NODE_INSERT_BATCH_SIZE: usize = 1_000;
+
 /// Generate a random ID and claim it, retrying on collision (issue #129).
 ///
 /// `generate` produces a fresh candidate ID; `try_claim` attempts to durably
@@ -749,6 +754,56 @@ fn pick_id_with_retry(
     Err(format!(
         "exhausted {max_attempts} attempts to generate a collision-free ID"
     ))
+}
+
+fn node_insert_sql(row_count: usize, legacy_login_role: bool) -> String {
+    let (columns, parameters_per_row) = if legacy_login_role {
+        (
+            "id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, login_role, database",
+            10,
+        )
+    } else {
+        (
+            "id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database",
+            9,
+        )
+    };
+    let mut sql = format!("INSERT INTO df.nodes ({columns}) VALUES ");
+
+    for row_index in 0..row_count {
+        if row_index > 0 {
+            sql.push_str(", ");
+        }
+        let first = row_index * parameters_per_row + 1;
+        if legacy_login_role {
+            sql.push_str(&format!(
+                "(${first}, ${}, ${}, ${}, ${}, ${}, ${}, ${}::oid::regrole, ${}::oid::regrole, ${})",
+                first + 1,
+                first + 2,
+                first + 3,
+                first + 4,
+                first + 5,
+                first + 6,
+                first + 7,
+                first + 8,
+                first + 9,
+            ));
+        } else {
+            sql.push_str(&format!(
+                "(${first}, ${}, ${}, ${}, ${}, ${}, ${}, ${}::oid::regrole, ${})",
+                first + 1,
+                first + 2,
+                first + 3,
+                first + 4,
+                first + 5,
+                first + 6,
+                first + 7,
+                first + 8,
+            ));
+        }
+    }
+
+    sql
 }
 
 /// Capture the effective role identity (after `SET ROLE` / `SECURITY DEFINER`)
@@ -1033,8 +1088,8 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
         }
     }
 
-    fn insert_node(
-        node: &FunctionNode,
+    fn insert_nodes(
+        nodes: &[FunctionNode],
         instance_id: &str,
         current_user_oid: pgrx::pg_sys::Oid,
         database: Option<&str>,
@@ -1042,15 +1097,10 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
     ) {
         // B1 backward compat: the v0.1.x schema has login_role NOT NULL on
         // df.nodes, so the legacy branch still sets it (= submitted_by).
-        // Caveat: the ON CONFLICT (instance_id, id) clause below needs the
-        // composite key that 0.1.1->0.2.0 adds, so a true pre-0.2.0 runtime
-        // cannot run df.start() until it upgrades. That is fine: the supported
-        // B1 floor is 0.2.2 (docs/upgrade-testing.md), so this legacy branch is
-        // effectively dead code for every supported install.
-        let node_id = node.id.clone();
-        if let Err(e) = pick_id_with_retry(
-            || node_id.clone(),
-            |candidate| {
+        for batch in nodes.chunks(NODE_INSERT_BATCH_SIZE) {
+            let mut node_args =
+                Vec::with_capacity(batch.len() * if legacy_login_role { 10 } else { 9 });
+            for node in batch {
                 let query_arg: DatumWithOid = match &node.query {
                     Some(q) => q.as_str().into(),
                     None => DatumWithOid::null::<String>(),
@@ -1071,54 +1121,33 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
                     Some(db) => db.into(),
                     None => DatumWithOid::null::<String>(),
                 };
-                let (node_sql, node_args): (&str, Vec<DatumWithOid>) = if legacy_login_role {
-                    (
-                        "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, login_role, database)
-                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::oid::regrole, $9::oid::regrole, $10)
-                         ON CONFLICT (instance_id, id) DO NOTHING
-                         RETURNING id",
-                        vec![
-                            candidate.into(),
-                            instance_id.into(),
-                            node.node_type.as_str().into(),
-                            query_arg,
-                            result_name_arg,
-                            left_node_arg,
-                            right_node_arg,
-                            current_user_oid.into(),
-                            current_user_oid.into(), // login_role = submitted_by
-                            database_arg,
-                        ],
-                    )
-                } else {
-                    (
-                        "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database)
-                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::oid::regrole, $9)
-                         ON CONFLICT (instance_id, id) DO NOTHING
-                         RETURNING id",
-                        vec![
-                            candidate.into(),
-                            instance_id.into(),
-                            node.node_type.as_str().into(),
-                            query_arg,
-                            result_name_arg,
-                            left_node_arg,
-                            right_node_arg,
-                            current_user_oid.into(),
-                            database_arg,
-                        ],
-                    )
-                };
-                Spi::connect_mut(
-                    |client| match client.update(node_sql, Some(1), &node_args) {
-                        Ok(table) => Ok(!table.is_empty()),
-                        Err(e) => Err(format!("{e:?}")),
-                    },
-                )
-            },
-            1,
-        ) {
-            pgrx::error!("Failed to insert node '{}': {}", node.id, e);
+                node_args.extend([
+                    node.id.as_str().into(),
+                    instance_id.into(),
+                    node.node_type.as_str().into(),
+                    query_arg,
+                    result_name_arg,
+                    left_node_arg,
+                    right_node_arg,
+                    current_user_oid.into(),
+                ]);
+                if legacy_login_role {
+                    node_args.push(current_user_oid.into()); // login_role = submitted_by
+                }
+                node_args.push(database_arg);
+            }
+
+            let node_sql = node_insert_sql(batch.len(), legacy_login_role);
+            if let Err(e) = Spi::run_with_args(&node_sql, &node_args) {
+                let first_id = batch.first().map(|node| node.id.as_str()).unwrap_or("");
+                let last_id = batch.last().map(|node| node.id.as_str()).unwrap_or("");
+                pgrx::error!(
+                    "Failed to insert node batch '{}..{}': {:?}",
+                    first_id,
+                    last_id,
+                    e
+                );
+            }
         }
     }
 
@@ -1206,15 +1235,13 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
 
     // The same-instance node references are DEFERRABLE INITIALLY DEFERRED, so
     // pre-order insertion is valid even when a parent row precedes its child.
-    for node in &nodes {
-        insert_node(
-            node,
-            &instance_id,
-            current_user_oid,
-            database,
-            legacy_login_role,
-        );
-    }
+    insert_nodes(
+        &nodes,
+        &instance_id,
+        current_user_oid,
+        database,
+        legacy_login_role,
+    );
 
     // Capture vars from df.vars using the installed extension version as the
     // compatibility boundary: pre-0.2.0 uses legacy global vars, 0.2.0+ uses
@@ -1456,7 +1483,34 @@ pub fn wait_for_completion(
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_semver, pick_id_with_retry};
+    use super::{node_insert_sql, parse_semver, pick_id_with_retry};
+
+    #[test]
+    fn test_node_insert_sql_uses_current_schema_columns_and_numbered_parameters() {
+        let sql = node_insert_sql(2, false);
+
+        assert!(sql.starts_with(
+            "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, database) VALUES "
+        ));
+        assert!(sql.contains("($1, $2, $3, $4, $5, $6, $7, $8::oid::regrole, $9)"));
+        assert!(sql.contains("($10, $11, $12, $13, $14, $15, $16, $17::oid::regrole, $18)"));
+        assert!(!sql.contains("login_role"));
+    }
+
+    #[test]
+    fn test_node_insert_sql_uses_legacy_schema_columns_and_numbered_parameters() {
+        let sql = node_insert_sql(2, true);
+
+        assert!(sql.starts_with(
+            "INSERT INTO df.nodes (id, instance_id, node_type, query, result_name, left_node, right_node, submitted_by, login_role, database) VALUES "
+        ));
+        assert!(
+            sql.contains("($1, $2, $3, $4, $5, $6, $7, $8::oid::regrole, $9::oid::regrole, $10)")
+        );
+        assert!(sql.contains(
+            "($11, $12, $13, $14, $15, $16, $17, $18::oid::regrole, $19::oid::regrole, $20)"
+        ));
+    }
 
     #[test]
     fn test_parse_semver_basic() {

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -13,8 +13,9 @@ use std::time::{Duration, Instant};
 
 use crate::client::start_durable_function;
 use crate::types::{
-    get_max_new_transaction_starts, get_new_transaction_start_timeout, mark_non_future_helper_call,
-    short_id, validate_result_name, Durofut, FunctionInput,
+    flatten_graph, get_max_new_transaction_starts, get_new_transaction_start_timeout,
+    mark_non_future_helper_call, short_id, validate_result_name, Durofut, FunctionInput,
+    FunctionNode,
 };
 
 /// Check if we're running inside a workflow context (background worker connection).
@@ -990,10 +991,6 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
         Err(e) => pgrx::error!("Invalid durable function: {}", e),
     };
 
-    // Validate the entire graph recursively before inserting
-    if let Err(e) = durofut.validate_recursive() {
-        pgrx::error!("Invalid durable function graph: {}", e);
-    }
     // The instance ID is reserved later (after identity validation), using an
     // INSERT ... ON CONFLICT (id) DO NOTHING retry so collisions — including
     // against other roles' instances invisible under RLS — re-roll instead of
@@ -1036,75 +1033,13 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
         }
     }
 
-    // Insert all nodes from the nested graph into df.nodes, returning root node ID
-    fn insert_nodes(
-        node: &Durofut,
+    fn insert_node(
+        node: &FunctionNode,
         instance_id: &str,
-        force_id: Option<&str>,
         current_user_oid: pgrx::pg_sys::Oid,
         database: Option<&str>,
         legacy_login_role: bool,
-        node_count: &mut usize,
-    ) -> String {
-        *node_count += 1;
-        if *node_count > crate::types::MAX_GRAPH_NODES {
-            pgrx::error!(
-                "Workflow exceeds maximum node count of {}. \
-                 Simplify the workflow or break it into multiple instances.",
-                crate::types::MAX_GRAPH_NODES
-            );
-        }
-        // Recursively insert children FIRST to get their IDs
-        let left_id = node.left_node.as_ref().map(|raw| {
-            let child = Durofut::child_from_raw(raw)
-                .unwrap_or_else(|e| pgrx::error!("Invalid left child in graph: {}", e));
-            insert_nodes(
-                &child,
-                instance_id,
-                None,
-                current_user_oid,
-                database,
-                legacy_login_role,
-                node_count,
-            )
-        });
-        let right_id = node.right_node.as_ref().map(|raw| {
-            let child = Durofut::child_from_raw(raw)
-                .unwrap_or_else(|e| pgrx::error!("Invalid right child in graph: {}", e));
-            insert_nodes(
-                &child,
-                instance_id,
-                None,
-                current_user_oid,
-                database,
-                legacy_login_role,
-                node_count,
-            )
-        });
-
-        // Process config JSON to recursively insert embedded nodes and get their IDs
-        let query_val: Option<String> = match node.transform_config_children(|child| {
-            Ok(insert_nodes(
-                child,
-                instance_id,
-                None,
-                current_user_oid,
-                database,
-                legacy_login_role,
-                node_count,
-            ))
-        }) {
-            Ok(updated_query) => updated_query,
-            Err(e) => pgrx::error!("Invalid config in {} node: {}", node.node_type, e),
-        };
-
-        // Claim a per-instance-unique node ID. Node IDs only need to be unique
-        // within their owning instance — the df.nodes composite PRIMARY KEY
-        // (instance_id, id) is the guard — so we INSERT ... ON CONFLICT
-        // (instance_id, id) DO NOTHING RETURNING id and re-roll on collision
-        // instead of surfacing a raw key violation (issue #129). Near the
-        // MAX_GRAPH_NODES ceiling the per-instance birthday-collision odds are
-        // small but non-trivial, so the retry keeps large graphs from flaking.
+    ) {
         // B1 backward compat: the v0.1.x schema has login_role NOT NULL on
         // df.nodes, so the legacy branch still sets it (= submitted_by).
         // Caveat: the ON CONFLICT (instance_id, id) clause below needs the
@@ -1112,25 +1047,11 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
         // cannot run df.start() until it upgrades. That is fine: the supported
         // B1 floor is 0.2.2 (docs/upgrade-testing.md), so this legacy branch is
         // effectively dead code for every supported install.
-        // The root node's ID is forced (force_id) to the value the instance row
-        // already points at via root_node, so the deferred same-instance FK is
-        // satisfied at commit without an UPDATE the caller isn't privileged to
-        // run. The instance is freshly reserved, so the only way the forced
-        // insert can conflict is a child node in this same graph randomly
-        // claiming the identical 8-hex value (~1 in 2^32): give it a single
-        // attempt and let the error abort the txn (the caller retries) rather
-        // than re-rolling away from the reserved ID. Non-root nodes generate a
-        // random ID and re-roll on collision.
-        let mut forced_id = force_id.map(str::to_string);
-        let max_attempts = if force_id.is_some() {
-            1
-        } else {
-            MAX_ID_ATTEMPTS
-        };
-        let node_id = match pick_id_with_retry(
-            move || forced_id.take().unwrap_or_else(short_id),
+        let node_id = node.id.clone();
+        if let Err(e) = pick_id_with_retry(
+            || node_id.clone(),
             |candidate| {
-                let query_arg: DatumWithOid = match &query_val {
+                let query_arg: DatumWithOid = match &node.query {
                     Some(q) => q.as_str().into(),
                     None => DatumWithOid::null::<String>(),
                 };
@@ -1138,11 +1059,11 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
                     Some(n) => n.as_str().into(),
                     None => DatumWithOid::null::<String>(),
                 };
-                let left_node_arg: DatumWithOid = match &left_id {
+                let left_node_arg: DatumWithOid = match &node.left_node {
                     Some(id) => id.as_str().into(),
                     None => DatumWithOid::null::<String>(),
                 };
-                let right_node_arg: DatumWithOid = match &right_id {
+                let right_node_arg: DatumWithOid = match &node.right_node {
                     Some(id) => id.as_str().into(),
                     None => DatumWithOid::null::<String>(),
                 };
@@ -1195,35 +1116,27 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
                     },
                 )
             },
-            max_attempts,
+            1,
         ) {
-            Ok(id) => id,
-            Err(e) => match force_id {
-                // The forced root id collided with an already-inserted child
-                // node id in this same graph (~1 in 2^32). The whole df.start()
-                // txn aborts cleanly (no orphan, no corruption) so the caller
-                // can simply retry df.start().
-                Some(forced) => pgrx::error!(
-                    "root node id '{}' collided with a child node id in the same graph \
-                     (~1 in 2^32); df.start() aborted safely, retry it ({})",
-                    forced,
-                    e
-                ),
-                None => pgrx::error!("Failed to insert node: {}", e),
-            },
-        };
-
-        // Return the generated ID for parent to reference
-        node_id
+            pgrx::error!("Failed to insert node '{}': {}", node.id, e);
+        }
     }
 
     let legacy_login_role = legacy_login_role_schema();
 
-    // Pre-generate the root node's ID so the instance row can point at it up
-    // front. The same-instance FK on root_node is DEFERRABLE INITIALLY
-    // DEFERRED, so the referenced node row need not exist yet — insert_nodes
-    // below inserts the root node with this exact ID before commit.
-    let root_id = short_id();
+    // Assign IDs as nodes are discovered. Per-graph uniqueness is required
+    // because parent references are materialized before any rows are inserted.
+    let mut assigned_ids = std::collections::HashSet::new();
+    let mut id_source = || loop {
+        let candidate = short_id();
+        if assigned_ids.insert(candidate.clone()) {
+            break candidate;
+        }
+    };
+    let (root_id, nodes) = match flatten_graph(&durofut, &mut id_source) {
+        Ok(flattened) => flattened,
+        Err(e) => pgrx::error!("Invalid durable function graph: {}", e),
+    };
 
     // Reserve the instance ID before inserting nodes so node rows can reference
     // it. Collisions on the 8-hex ID space are rare, but we reserve via
@@ -1291,21 +1204,17 @@ fn start_in_caller_transaction(fut: &str, label: Option<&str>, database: Option<
         Err(e) => pgrx::error!("Failed to create instance: {}", e),
     };
 
-    // Insert the graph. The top-level (root) node's ID is forced to root_id —
-    // the value the instance row already points at via root_node — so the
-    // deferred same-instance FK is satisfied at commit with no UPDATE (df
-    // callers aren't granted UPDATE on root_node). Child node IDs are random
-    // with collision re-roll.
-    let mut node_count: usize = 0;
-    insert_nodes(
-        &durofut,
-        &instance_id,
-        Some(&root_id),
-        current_user_oid,
-        database,
-        legacy_login_role,
-        &mut node_count,
-    );
+    // The same-instance node references are DEFERRABLE INITIALLY DEFERRED, so
+    // pre-order insertion is valid even when a parent row precedes its child.
+    for node in &nodes {
+        insert_node(
+            node,
+            &instance_id,
+            current_user_oid,
+            database,
+            legacy_login_role,
+        );
+    }
 
     // Capture vars from df.vars using the installed extension version as the
     // compatibility boundary: pre-0.2.0 uses legacy global vars, 0.2.0+ uses

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -6,6 +6,8 @@
 use pgrx::prelude::*;
 use std::collections::HashMap;
 
+use crate::types::{flatten_graph, Durofut, FunctionNode};
+
 /// Represents a node for visualization
 #[derive(Debug, Clone)]
 struct ExplainNode {
@@ -225,18 +227,9 @@ fn looks_like_dsl_expression(input: &str) -> bool {
 
 /// Explain a DSL expression without executing it
 fn explain_expression(expr: &str) -> String {
-    use crate::types::Durofut;
-
     // First try to parse as Durofut JSON
     if let Ok(root) = Durofut::try_from_json(expr) {
-        if let Err(e) = root.validate_recursive() {
-            return format!("Invalid durable function graph: {e}");
-        }
-        // Build in-memory node map from nested structure with generated IDs
-        let mut nodes = HashMap::new();
-        let mut id_counter = 0;
-        let root_id = collect_nodes(&root, &mut nodes, &mut id_counter);
-        return build_tree_visualization(&root_id, &nodes, false);
+        return explain_durofut(&root);
     }
 
     // Require DSL markers (df.* calls or operators like ~>, |=>) before evaluating via SPI.
@@ -251,10 +244,7 @@ fn explain_expression(expr: &str) -> String {
                 query: Some(expr.to_string()),
                 ..Default::default()
             };
-            let mut nodes = HashMap::new();
-            let mut id_counter = 0;
-            let root_id = collect_nodes(&sql_node, &mut nodes, &mut id_counter);
-            return build_tree_visualization(&root_id, &nodes, false);
+            return explain_durofut(&sql_node);
         }
         return "Cannot explain input: not a valid Durofut JSON, instance ID, SQL statement, or DSL expression.\n\
              Hint: DSL expressions use df.*() functions and operators like ~>, |=>, &, |.".to_string();
@@ -274,68 +264,40 @@ fn explain_expression(expr: &str) -> String {
         Ok(d) => d,
         Err(e) => return format!("Failed to parse Durofut JSON: {e}"),
     };
-    if let Err(e) = root.validate_recursive() {
-        return format!("Invalid durable function graph: {e}");
-    }
+    explain_durofut(&root)
+}
 
-    // Build in-memory node map from nested structure with generated IDs
-    let mut nodes = HashMap::new();
+fn explain_durofut(root: &Durofut) -> String {
     let mut id_counter = 0;
-    let root_id = collect_nodes(&root, &mut nodes, &mut id_counter);
-
-    // Visualize (existing visualization code)
+    let mut ids = || {
+        id_counter += 1;
+        format!("N{id_counter}")
+    };
+    let (root_id, flat_nodes) = match flatten_graph(root, &mut ids) {
+        Ok(flattened) => flattened,
+        Err(e) => return format!("Invalid durable function graph: {e}"),
+    };
+    let nodes = flat_nodes
+        .into_iter()
+        .map(|node| (node.id.clone(), ExplainNode::from(node)))
+        .collect();
     build_tree_visualization(&root_id, &nodes, false)
 }
 
-/// Collect all nodes from a nested Durofut structure into a flat HashMap
-/// Generates temporary IDs for visualization (e.g., "N1", "N2", ...)
-/// Returns the ID of the current node
-fn collect_nodes(
-    node: &crate::types::Durofut,
-    nodes: &mut HashMap<String, ExplainNode>,
-    id_counter: &mut i32,
-) -> String {
-    *id_counter += 1;
-    let node_id = format!("N{}", id_counter);
-
-    // Recursively collect children first to get their IDs
-    let left_id = node.left_node.as_ref().map(|raw| {
-        let child = crate::types::Durofut::child_from_raw(raw)
-            .unwrap_or_else(|e| pgrx::error!("Invalid left child in graph: {}", e));
-        collect_nodes(&child, nodes, id_counter)
-    });
-    let right_id = node.right_node.as_ref().map(|raw| {
-        let child = crate::types::Durofut::child_from_raw(raw)
-            .unwrap_or_else(|e| pgrx::error!("Invalid right child in graph: {}", e));
-        collect_nodes(&child, nodes, id_counter)
-    });
-
-    // Process config JSON to collect embedded nodes and replace Durofuts with IDs
-    let updated_query =
-        match node.transform_config_children(|child| Ok(collect_nodes(child, nodes, id_counter))) {
-            Ok(q) => q,
-            Err(e) => {
-                // In explain context, report errors as part of the visualization rather than panicking
-                Some(format!("ERROR: {e}"))
-            }
-        };
-
-    nodes.insert(
-        node_id.clone(),
-        ExplainNode {
-            id: node_id.clone(),
-            node_type: node.node_type.clone(),
-            query: updated_query,
-            result_name: node.result_name.clone(),
-            left_node: left_id,
-            right_node: right_id,
+impl From<FunctionNode> for ExplainNode {
+    fn from(node: FunctionNode) -> Self {
+        Self {
+            id: node.id,
+            node_type: node.node_type,
+            query: node.query,
+            result_name: node.result_name,
+            left_node: node.left_node,
+            right_node: node.right_node,
             status: None,
             result: None,
             status_details: None,
-        },
-    );
-
-    node_id
+        }
+    }
 }
 
 /// Load nodes from a table into a HashMap

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1019,6 +1019,51 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_seq_preserves_previously_composed_left_operand() {
+        let left = crate::dsl::then_fn("SELECT 1", "SELECT 2");
+        let result = crate::dsl::then_fn(&left, "SELECT 3");
+        let parent = Durofut::from_json(&result);
+
+        assert_eq!(parent.left_node.unwrap().get(), left);
+    }
+
+    #[pg_test]
+    fn test_seq_quotes_sibling_key_injection_in_new_operand() {
+        let injection = r#"{"node_type":"SQL"},"result_name":"injected""#;
+        let result = crate::dsl::then_fn(&crate::dsl::sql("SELECT 1"), injection);
+        let parent = Durofut::from_json(&result);
+        let right = Durofut::child_from_raw(parent.right_node.as_deref().unwrap()).unwrap();
+
+        assert_eq!(parent.result_name, None);
+        assert_eq!(right.node_type, "SQL");
+        assert_eq!(right.query.as_deref(), Some(injection));
+    }
+
+    #[pg_test]
+    fn test_seq_corrupt_accumulator_reports_graph_path() {
+        let corrupt = r#"{"node_type":"THEN","left_node":{"node_type":"BOGUS"},"right_node":{"node_type":"SQL","query":"SELECT 1"}}"#;
+        let accumulator = crate::dsl::then_fn(corrupt, "SELECT 2");
+        let graph = crate::dsl::then_fn(&accumulator, "SELECT 3");
+        let explanation = crate::explain::explain(&graph);
+
+        assert!(
+            explanation.contains("root.left.left.left: Unknown node_type 'BOGUS'"),
+            "expected corrupt accumulator path, got: {explanation}"
+        );
+    }
+
+    #[pg_test]
+    fn test_binary_fold_composers_preserve_left_accumulator() {
+        let left = crate::dsl::then_fn("SELECT 1", "SELECT 2");
+
+        for compose in [crate::dsl::join, crate::dsl::race] {
+            let result = compose(&left, "SELECT 3");
+            let parent = Durofut::from_json(&result);
+            assert_eq!(parent.left_node.unwrap().get(), left);
+        }
+    }
+
+    #[pg_test]
     fn test_as_named_sets_result_name() {
         let sql_json = crate::dsl::sql("SELECT 1");
         let named_json = crate::dsl::as_named(&sql_json, "my_result");
@@ -1928,6 +1973,31 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_non_future_helper_rejected_as_new_seq_operand() {
+        Spi::run(
+            "CREATE OR REPLACE FUNCTION pg_temp.capture_error(sql_text text) RETURNS text
+             LANGUAGE plpgsql AS $$
+             BEGIN
+               EXECUTE sql_text;
+               RETURN NULL;
+             EXCEPTION WHEN OTHERS THEN
+               RETURN SQLERRM;
+             END;
+             $$;",
+        )
+        .unwrap();
+        let msg = Spi::get_one::<String>(
+            "SELECT pg_temp.capture_error($$SELECT df.seq(df.sql('SELECT 1'), df.clearvars())$$)",
+        )
+        .unwrap()
+        .unwrap();
+        assert!(
+            msg.contains("df.clearvars cannot be used as a workflow step"),
+            "Unexpected error: {msg}"
+        );
+    }
+
+    #[pg_test]
     fn test_unsetvar_cannot_be_used_in_seq_composition() {
         Spi::run(
             "CREATE OR REPLACE FUNCTION pg_temp.capture_error(sql_text text) RETURNS text
@@ -2245,7 +2315,7 @@ mod tests {
         .unwrap();
         let msg = Spi::get_one::<String>(
             r#"SELECT pg_temp.capture_error($$
-                 SELECT df.seq('{"node_type":"THEN","left_node":123}', df.sql('SELECT 1'))
+                 SELECT df.seq(df.sql('SELECT 1'), '{"node_type":"THEN","left_node":123}')
              $$)"#,
         )
         .unwrap()

--- a/src/types.rs
+++ b/src/types.rs
@@ -1027,6 +1027,164 @@ pub struct FunctionNode {
     pub database: Option<String>,
 }
 
+pub(crate) trait IdSource {
+    fn next_id(&mut self) -> String;
+}
+
+impl<F> IdSource for F
+where
+    F: FnMut() -> String,
+{
+    fn next_id(&mut self) -> String {
+        self()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphError {
+    pub path: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for GraphError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.path, self.message)
+    }
+}
+
+struct PendingGraphNode {
+    node: Durofut,
+    id: String,
+    depth: usize,
+    path: String,
+}
+
+pub(crate) fn flatten_graph(
+    root: &Durofut,
+    ids: &mut impl IdSource,
+) -> Result<(String, Vec<FunctionNode>), GraphError> {
+    let root_id = ids.next_id();
+    let mut pending = vec![PendingGraphNode {
+        node: root.clone(),
+        id: root_id.clone(),
+        depth: 0,
+        path: "root".to_string(),
+    }];
+    let mut nodes = Vec::new();
+
+    while let Some(entry) = pending.pop() {
+        if nodes.len() >= MAX_GRAPH_NODES {
+            return Err(GraphError {
+                path: entry.path,
+                message: format!(
+                    "Workflow exceeds maximum node count of {}. Simplify the workflow or break it into multiple instances.",
+                    MAX_GRAPH_NODES
+                ),
+            });
+        }
+        if entry.depth > MAX_GRAPH_DEPTH {
+            return Err(GraphError {
+                path: entry.path,
+                message: format!(
+                    "Graph exceeds maximum nesting depth of {}. Simplify the workflow or break it into multiple instances.",
+                    MAX_GRAPH_DEPTH
+                ),
+            });
+        }
+        if !VALID_NODE_TYPES.contains(&entry.node.node_type.as_str()) {
+            return Err(GraphError {
+                path: entry.path,
+                message: format!(
+                    "Unknown node_type '{}'. Valid types: {}",
+                    entry.node.node_type,
+                    VALID_NODE_TYPES.join(", ")
+                ),
+            });
+        }
+        entry
+            .node
+            .validate_config_children()
+            .map_err(|message| GraphError {
+                path: entry.path.clone(),
+                message,
+            })?;
+
+        let mut children = Vec::new();
+        let mut parse_child = |raw: &serde_json::value::RawValue, segment: String| {
+            let path = format!("{}.{}", entry.path, segment);
+            let node = Durofut::child_from_raw(raw).map_err(|message| GraphError {
+                path: path.clone(),
+                message,
+            })?;
+            let id = ids.next_id();
+            children.push(PendingGraphNode {
+                node,
+                id: id.clone(),
+                depth: entry.depth + 1,
+                path,
+            });
+            Ok::<String, GraphError>(id)
+        };
+
+        let left_node = entry
+            .node
+            .left_node
+            .as_deref()
+            .map(|raw| parse_child(raw, "left".to_string()))
+            .transpose()?;
+        let right_node = entry
+            .node
+            .right_node
+            .as_deref()
+            .map(|raw| parse_child(raw, "right".to_string()))
+            .transpose()?;
+        let condition_node = if entry.node.node_type == "IF" || entry.node.node_type == "LOOP" {
+            entry
+                .node
+                .condition_node
+                .as_deref()
+                .map(|raw| parse_child(raw, "condition_node".to_string()))
+                .transpose()?
+        } else {
+            None
+        };
+        let extra_nodes = if entry.node.node_type == "JOIN" {
+            entry
+                .node
+                .extra_nodes
+                .iter()
+                .enumerate()
+                .map(|(index, raw)| parse_child(raw, format!("extra_nodes[{index}]")))
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            Vec::new()
+        };
+
+        let query = entry
+            .node
+            .materialized_query(condition_node.as_deref(), &extra_nodes)
+            .map_err(|message| GraphError {
+                path: entry.path.clone(),
+                message,
+            })?;
+
+        nodes.push(FunctionNode {
+            id: entry.id,
+            node_type: entry.node.node_type,
+            query,
+            result_name: entry.node.result_name,
+            left_node,
+            right_node,
+            submitted_by: String::new(),
+            database: None,
+        });
+
+        pending.extend(children.into_iter().rev());
+    }
+
+    Ok((root_id, nodes))
+}
+
 /// Represents the entire function graph for an instance
 /// Note: Uses BTreeMap for deterministic serialization order (required for Duroxide replay)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1410,12 +1568,13 @@ impl Durofut {
     }
 
     /// Validate a Durofut node and all its children have valid node_types.
-    /// Used during insertion in df.start() to catch invalid nested nodes.
-    /// Also enforces MAX_GRAPH_NODES so oversized graphs fail fast without
-    /// needing a second traversal during insertion.
+    /// Kept as a compatibility helper for callers that only need validation;
+    /// graph entrypoints should consume `flatten_graph` directly.
     pub fn validate_recursive(&self) -> Result<(), String> {
-        let mut node_count = 0;
-        self.validate_recursive_inner(0, &mut node_count)
+        let mut next_id = || String::new();
+        flatten_graph(self, &mut next_id)
+            .map(|_| ())
+            .map_err(|error| error.to_string())
     }
 
     fn reject_embedded_config_children(&self) -> Result<(), String> {
@@ -1457,115 +1616,16 @@ impl Durofut {
         }
 
         self.reject_embedded_config_children()?;
-
-        let has_config_children = (supports_condition && self.condition_node.is_some())
-            || (self.node_type == "JOIN" && !self.extra_nodes.is_empty());
-        let Some(query) = self.query.as_ref().filter(|_| has_config_children) else {
-            return Ok(());
-        };
-        let config = serde_json::from_str::<serde_json::Value>(query).map_err(|e| {
-            format!(
-                "query in {} must be valid JSON config: {}",
-                self.node_type, e
-            )
-        })?;
-        if !config.is_object() {
-            return Err(format!(
-                "query in {} must be a JSON config object",
-                self.node_type
-            ));
-        }
-
         Ok(())
     }
 
-    fn validate_recursive_inner(&self, depth: usize, node_count: &mut usize) -> Result<(), String> {
-        *node_count += 1;
-        if *node_count > MAX_GRAPH_NODES {
-            return Err(format!(
-                "Workflow exceeds maximum node count of {}. \
-                 Simplify the workflow or break it into multiple instances.",
-                MAX_GRAPH_NODES
-            ));
-        }
-        if depth > MAX_GRAPH_DEPTH {
-            return Err(format!(
-                "Graph exceeds maximum nesting depth of {}. \
-                 Simplify the workflow or break it into multiple instances.",
-                MAX_GRAPH_DEPTH
-            ));
-        }
-        if !VALID_NODE_TYPES.contains(&self.node_type.as_str()) {
-            return Err(format!(
-                "Unknown node_type '{}'. Valid types: {}",
-                self.node_type,
-                VALID_NODE_TYPES.join(", ")
-            ));
-        }
-        self.validate_config_children()?;
-        if let Some(ref left) = self.left_node {
-            Self::child_from_raw(left)?.validate_recursive_inner(depth + 1, node_count)?;
-        }
-        if let Some(ref right) = self.right_node {
-            Self::child_from_raw(right)?.validate_recursive_inner(depth + 1, node_count)?;
-        }
-        // Validate config children (condition_node, extra_nodes)
-        let d = depth + 1;
-        self.for_each_config_child(|child| child.validate_recursive_inner(d, node_count))?;
-        Ok(())
-    }
-
-    /// Parse each opaque config child and apply a callback to it.
-    ///
-    /// The callback receives each embedded child and returns `Result<(), String>`.
-    /// Parsing failures are always treated as errors — a `condition_node` or `extra_nodes`
-    /// entry that cannot be deserialized as a valid Durofut is rejected.
-    pub fn for_each_config_child<F>(&self, mut f: F) -> Result<(), String>
-    where
-        F: FnMut(&Durofut) -> Result<(), String>,
-    {
-        // IF/LOOP nodes: condition_node
-        if self.node_type == "IF" || self.node_type == "LOOP" {
-            if let Some(cond) = self.condition_node.as_ref() {
-                let cond_node = Self::child_from_raw(cond).map_err(|e| {
-                    format!(
-                        "condition_node in {} must be a valid Durofut object: {}",
-                        self.node_type, e
-                    )
-                })?;
-                f(&cond_node)?;
-            }
-        }
-
-        // JOIN nodes: extra_nodes array
-        if self.node_type == "JOIN" {
-            for (i, extra) in self.extra_nodes.iter().enumerate() {
-                let extra_node = Self::child_from_raw(extra).map_err(|e| {
-                    format!(
-                        "extra_nodes[{}] in {} must be a valid Durofut object: {}",
-                        i, self.node_type, e
-                    )
-                })?;
-                f(&extra_node)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Transform config children into string IDs via a callback, returning the
-    /// `df.nodes.query` JSON string used by `insert_nodes` and `collect_nodes`.
-    ///
-    /// The callback receives each embedded child and returns the generated ID string.
-    /// Parsing failures are always treated as errors.
-    pub fn transform_config_children<F>(&self, mut f: F) -> Result<Option<String>, String>
-    where
-        F: FnMut(&Durofut) -> Result<String, String>,
-    {
-        self.validate_config_children()?;
-        let has_condition =
-            (self.node_type == "IF" || self.node_type == "LOOP") && self.condition_node.is_some();
-        let has_extras = self.node_type == "JOIN" && !self.extra_nodes.is_empty();
+    fn materialized_query(
+        &self,
+        condition_node: Option<&str>,
+        extra_nodes: &[String],
+    ) -> Result<Option<String>, String> {
+        let has_condition = condition_node.is_some();
+        let has_extras = !extra_nodes.is_empty();
         if !has_condition && !has_extras {
             return Ok(self.query.clone());
         }
@@ -1586,33 +1646,12 @@ impl Durofut {
             ));
         }
 
-        // IF/LOOP nodes: condition_node
-        if has_condition {
-            if let Some(cond) = self.condition_node.as_ref() {
-                let cond_node = Self::child_from_raw(cond).map_err(|e| {
-                    format!(
-                        "condition_node in {} must be a valid Durofut object: {}",
-                        self.node_type, e
-                    )
-                })?;
-                let cond_id = f(&cond_node)?;
-                config["condition_node"] = serde_json::json!(cond_id);
-            }
+        if let Some(condition_node) = condition_node {
+            config["condition_node"] = serde_json::json!(condition_node);
         }
 
-        // JOIN nodes: extra_nodes array
         if has_extras {
-            let mut extra_ids: Vec<String> = Vec::with_capacity(self.extra_nodes.len());
-            for (i, extra) in self.extra_nodes.iter().enumerate() {
-                let extra_node = Self::child_from_raw(extra).map_err(|e| {
-                    format!(
-                        "extra_nodes[{}] in {} must be a valid Durofut object: {}",
-                        i, self.node_type, e
-                    )
-                })?;
-                extra_ids.push(f(&extra_node)?);
-            }
-            config["extra_nodes"] = serde_json::json!(extra_ids);
+            config["extra_nodes"] = serde_json::json!(extra_nodes);
         }
 
         Ok(Some(serde_json::to_string(&config).unwrap()))
@@ -2413,7 +2452,7 @@ mod tests {
     }
 
     #[test]
-    fn test_transform_config_children_preserves_nodes_query_format() {
+    fn test_flatten_graph_preserves_condition_nodes_query_format() {
         let condition = Durofut {
             node_type: "SQL".to_string(),
             query: Some("SELECT true".to_string()),
@@ -2425,15 +2464,16 @@ mod tests {
             ..Default::default()
         };
 
-        let query = node
-            .transform_config_children(|_| Ok("condition-id".to_string()))
-            .unwrap()
-            .unwrap();
-        assert_eq!(query, r#"{"condition_node":"condition-id"}"#);
+        let mut ids = ["root", "condition-id"].into_iter().map(str::to_string);
+        let (_, nodes) = flatten_graph(&node, &mut || ids.next().unwrap()).unwrap();
+        assert_eq!(
+            nodes[0].query.as_deref(),
+            Some(r#"{"condition_node":"condition-id"}"#)
+        );
     }
 
     #[test]
-    fn test_transform_config_children_preserves_existing_query() {
+    fn test_flatten_graph_preserves_existing_query() {
         let condition = Durofut {
             node_type: "SQL".to_string(),
             query: Some("SELECT true".to_string()),
@@ -2446,15 +2486,16 @@ mod tests {
             ..Default::default()
         };
 
-        let query = node
-            .transform_config_children(|_| Ok("condition-id".to_string()))
-            .unwrap()
-            .unwrap();
-        assert_eq!(query, r#"{"a":1,"condition_node":"condition-id"}"#);
+        let mut ids = ["root", "condition-id"].into_iter().map(str::to_string);
+        let (_, nodes) = flatten_graph(&node, &mut || ids.next().unwrap()).unwrap();
+        assert_eq!(
+            nodes[0].query.as_deref(),
+            Some(r#"{"a":1,"condition_node":"condition-id"}"#)
+        );
     }
 
     #[test]
-    fn test_transform_extra_nodes_preserves_nodes_query_format() {
+    fn test_flatten_graph_preserves_extra_nodes_query_format() {
         let extra = Durofut {
             node_type: "SQL".to_string(),
             query: Some("SELECT 3".to_string()),
@@ -2466,11 +2507,12 @@ mod tests {
             ..Default::default()
         };
 
-        let query = node
-            .transform_config_children(|_| Ok("extra-id".to_string()))
-            .unwrap()
-            .unwrap();
-        assert_eq!(query, r#"{"extra_nodes":["extra-id"]}"#);
+        let mut ids = ["root", "extra-id"].into_iter().map(str::to_string);
+        let (_, nodes) = flatten_graph(&node, &mut || ids.next().unwrap()).unwrap();
+        assert_eq!(
+            nodes[0].query.as_deref(),
+            Some(r#"{"extra_nodes":["extra-id"]}"#)
+        );
     }
 
     #[test]
@@ -2500,17 +2542,14 @@ mod tests {
             .validate_recursive()
             .unwrap_err()
             .contains("condition_node in IF must be a first-class Durofut field"));
-        assert!(legacy_join
-            .validate_recursive()
-            .unwrap_err()
-            .contains("extra_nodes in JOIN must be a first-class Durofut field"));
         assert!(legacy_loop
             .validate_recursive()
             .unwrap_err()
             .contains("condition_node in LOOP must be a first-class Durofut field"));
-        assert!(legacy_join
-            .transform_config_children(|_| Ok("unused".to_string()))
+        let mut ids = || "unused".to_string();
+        assert!(flatten_graph(&legacy_join, &mut ids)
             .unwrap_err()
+            .to_string()
             .contains("extra_nodes in JOIN must be a first-class Durofut field"));
     }
 
@@ -2584,6 +2623,36 @@ mod tests {
             Durofut::try_from_json(non_array).is_err(),
             "should reject non-array extra_nodes"
         );
+    }
+
+    #[test]
+    fn test_flatten_graph_assigns_preorder_ids_and_reports_error_path() {
+        let invalid = Durofut {
+            node_type: "NOT_A_NODE".to_string(),
+            ..Default::default()
+        };
+        let root = Durofut {
+            node_type: "THEN".to_string(),
+            left_node: Some(
+                Durofut {
+                    node_type: "SQL".to_string(),
+                    query: Some("SELECT 1".to_string()),
+                    ..Default::default()
+                }
+                .into_raw(),
+            ),
+            right_node: Some(invalid.into_raw()),
+            ..Default::default()
+        };
+        let mut counter = 0;
+        let error = flatten_graph(&root, &mut || {
+            counter += 1;
+            format!("N{counter}")
+        })
+        .unwrap_err();
+
+        assert_eq!(error.path, "root.right");
+        assert!(error.message.contains("Unknown node_type 'NOT_A_NODE'"));
     }
 
     #[test]

--- a/tests/e2e/sql/09_graph_and_validation.sql
+++ b/tests/e2e/sql/09_graph_and_validation.sql
@@ -294,5 +294,43 @@ END $$;
 
 DROP TABLE _deep_graph_execution;
 
+-- Exercise the node INSERT chunk boundary without committing a workflow that
+-- would schedule 1,001 parallel SQL activities.
+BEGIN;
+CREATE TEMP TABLE _batched_graph_execution (instance_id TEXT);
+
+INSERT INTO _batched_graph_execution
+SELECT df.start(
+    pg_catalog.jsonb_build_object(
+        'node_type', 'JOIN',
+        'left_node', pg_catalog.jsonb_build_object('node_type', 'SQL', 'query', 'SELECT 1'),
+        'right_node', pg_catalog.jsonb_build_object('node_type', 'SQL', 'query', 'SELECT 1'),
+        'extra_nodes', (
+            SELECT pg_catalog.jsonb_agg(
+                pg_catalog.jsonb_build_object('node_type', 'SQL', 'query', 'SELECT 1')
+            )
+            FROM pg_catalog.generate_series(1, 999)
+        )
+    )::TEXT,
+    'test-batched-node-insert'
+);
+
+DO $$
+DECLARE
+    inst_id TEXT;
+    node_total BIGINT;
+BEGIN
+    SELECT instance_id INTO inst_id FROM _batched_graph_execution;
+    SELECT count(*) INTO node_total FROM df.nodes WHERE instance_id = inst_id;
+
+    IF node_total != 1002 THEN
+        RAISE EXCEPTION 'TEST FAILED: batched graph materialized % nodes instead of 1002', node_total;
+    END IF;
+
+    RAISE NOTICE 'TEST PASSED: df.start inserts nodes across the batch boundary';
+END $$;
+
+ROLLBACK;
+
 RESET SESSION AUTHORIZATION;
 SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
## Stacked PR

**This PR is not intended to merge as-is.** It is temporarily based on #337 (`pinodeca/batch-node-inserts`) so Step 5 can be reviewed while Step 4 is still in review.

After #337 merges, this branch will be rebased onto `main` and the PR's base branch will be changed to `main`.

## Summary

- avoid reparsing an increasingly large left accumulator in `df.seq()`, `df.join()`, and `df.race()` when it is the exact output of the previous binary composition in the same backend
- continue validating and normalizing newly arrived operands, including non-future-helper misuse and malformed Durofut envelopes
- retain path-aware whole-graph validation in `flatten_graph` for corrupt accumulators
- add regression coverage for sibling-key injection, helper attribution, accumulator error paths, and join/race folds
- document the validate-on-entry boundary in `docs/nested-graph-design.md`

## Decision Gate

This is the experimental Step 5 branch. It should be accepted only if Step 4-to-Step 5 measurements show a repeatable, material end-to-end improvement under realistic graph sizes. If the improvement is not material, Step 5 should not merge.

## Validation

- `cargo fmt -p pg_durable -- --check`
- `cargo clippy --features pg17`
- `./scripts/test-unit.sh` (285 passed, 16 ignored)
- `./scripts/test-e2e-local.sh 09_graph_and_validation` (1 passed)