### PR TITLE
Remove obsolete httpbin test domain

### DIFF
--- a/docs/spec-http-support.md
+++ b/docs/spec-http-support.md
@@ -723,11 +723,11 @@ fn test_http_invalid_method() {
 ```sql
 -- tests/e2e/sql/XX_http.sql
 
--- Test basic HTTP GET (use httpbin.org for testing)
+-- Test basic HTTP GET (use httpbingo.org for testing)
 CREATE TEMP TABLE _http_test (instance_id TEXT);
 
 INSERT INTO _http_test SELECT df.start(
-    df.http('https://httpbin.org/get', 'GET') |=> 'response'
+    df.http('https://httpbingo.org/get', 'GET') |=> 'response'
     ~> 'SELECT ($response::jsonb->>''url'') as url',
     'test-http-get'
 );

--- a/docs/spec-security-model.md
+++ b/docs/spec-security-model.md
@@ -1574,14 +1574,14 @@ GRANT EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) TO sec_test_
 GRANT sec_test_http_denied TO duroxide;
 GRANT sec_test_http_allowed TO duroxide;
 
--- Build with a feature set that allows httpbin.org.
+-- Build with a feature set that allows httpbingo.org.
 
 -- Test 1: User WITHOUT df.http permission should fail
 SET ROLE sec_test_http_denied;
 DO $$
 BEGIN
     PERFORM df.start(
-        df.http('https://httpbin.org/get', 'GET'),
+        df.http('https://httpbingo.org/get', 'GET'),
         'http-test-denied'
     );
     RAISE EXCEPTION 'SECURITY FAILURE: User without df.http permission could use it!';
@@ -1600,7 +1600,7 @@ RESET ROLE;
 SET ROLE sec_test_http_allowed;
 CREATE TEMP TABLE _test_http_allowed (instance_id TEXT);
 INSERT INTO _test_http_allowed SELECT df.start(
-    df.http('https://httpbin.org/get', 'GET'),
+    df.http('https://httpbingo.org/get', 'GET'),
     'http-test-allowed'
 );
 RESET ROLE;
@@ -1653,13 +1653,13 @@ GRANT EXECUTE ON FUNCTION df.status TO sec_test_allowlist_user;
 GRANT SELECT ON df.instances TO sec_test_allowlist_user;
 GRANT sec_test_allowlist_user TO duroxide;
 
--- Build with a feature set that allows httpbin.org but not evil.com.
+-- Build with a feature set that allows httpbingo.org but not evil.com.
 
 -- Test 1: Allowlisted host should succeed
 SET ROLE sec_test_allowlist_user;
 CREATE TEMP TABLE _test_allowed (instance_id TEXT);
 INSERT INTO _test_allowed SELECT df.start(
-    df.http('https://httpbin.org/get', 'GET'),
+    df.http('https://httpbingo.org/get', 'GET'),
     'allowlist-test-allowed'
 );
 RESET ROLE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1304,7 +1304,7 @@ mod tests {
         use crate::types::HttpConfig;
 
         let json = crate::dsl::http(
-            "https://httpbin.org/post",
+            "https://example.azurewebsites.net/post",
             "POST",
             Some(r#"{"test": true}"#),
             None,
@@ -1313,7 +1313,7 @@ mod tests {
         let fut = Durofut::from_json(&json);
         let config: HttpConfig = serde_json::from_str(fut.query.as_ref().unwrap()).unwrap();
 
-        assert_eq!(config.url, "https://httpbin.org/post");
+        assert_eq!(config.url, "https://example.azurewebsites.net/post");
         assert_eq!(config.method, "POST");
         assert_eq!(config.body, Some(r#"{"test": true}"#.to_string()));
         assert_eq!(config.timeout_seconds, 45);

--- a/src/ssrf.rs
+++ b/src/ssrf.rs
@@ -68,7 +68,7 @@ pub(crate) const AZURE_DOMAIN_SUFFIXES: &[&str] = &[
 
 /// Fully-qualified test domains (exact match, not suffix).
 #[cfg(feature = "http-allow-test-domains")]
-pub(crate) const TEST_EXACT_DOMAINS: &[&str] = &["api.github.com", "httpbin.org", "httpbingo.org"];
+pub(crate) const TEST_EXACT_DOMAINS: &[&str] = &["api.github.com", "httpbingo.org"];
 
 // ---------------------------------------------------------------------------
 // IP blocklist

--- a/tests/e2e/sql/06_http_and_ssrf.sql
+++ b/tests/e2e/sql/06_http_and_ssrf.sql
@@ -948,8 +948,7 @@ END $$;
 DROP TABLE _test_ssrf7;
 
 -- Test 8: Redirects are not followed
--- Uses httpbingo.org (maintained Go reimplementation) rather than httpbin.org,
--- which is frequently unavailable and was the dominant source of CI flakiness.
+-- Uses the maintained httpbingo.org echo service to avoid CI flakiness.
 CREATE TEMP TABLE _test_ssrf8 (instance_id TEXT);
 
 INSERT INTO _test_ssrf8 SELECT df.start(


### PR DESCRIPTION
## Summary
- remove `httpbin.org` from the test-only HTTP allowlist
- replace stale documentation and parser fixtures with currently supported endpoints
- remove the retired service reference from the E2E reliability note

## Validation
- `cargo test --lib ssrf::tests --no-default-features --features pg17,http-allow-test-domains`
- `cargo fmt -p pg_durable -- --check`
- `cargo clippy --no-default-features --features pg17,http-allow-test-domains -- -D warnings`
- verified no tracked `httpbin.org` references remain