### PR TITLE
Allow api.github.com under http-allow-azure-domains

### DIFF
--- a/docs/http-security.md
+++ b/docs/http-security.md
@@ -29,8 +29,8 @@ or SQL.
 | Feature | What is allowed | Use case |
 |---------|-----------------|----------|
 | *(none)* | Nothing — `df.http()` errors immediately at DSL time **and** at execution time | Deployments that don't need HTTP |
-| `http-allow-azure-domains` | Subdomains of the Azure allow-list only; bare IPs blocked; redirects blocked | Production |
-| `http-allow-test-domains` | Everything in `http-allow-azure-domains` **plus** `api.github.com` and `httpbingo.org` | E2E testing; implies `http-allow-azure-domains` |
+| `http-allow-azure-domains` | Subdomains of the Azure allow-list plus `api.github.com`; bare IPs blocked; redirects blocked | Production |
+| `http-allow-test-domains` | Everything in `http-allow-azure-domains` **plus** `httpbingo.org` | E2E testing; implies `http-allow-azure-domains` |
 | `http-allow-all` | All URLs; SSRF IP blocklist and allow-list are both disabled | Local development only |
 
 The scripts and CI use `http-allow-test-domains` so that the HTTP E2E tests
@@ -269,14 +269,21 @@ Only subdomains of the following suffixes are permitted.  Apex domains (e.g.
 | `.trafficmanager.net` | Azure Traffic Manager |
 | `.cloudapp.azure.com` | Azure Cloud App |
 
-### 5.2 Test domains (additional with `http-allow-test-domains`)
+### 5.2 Exact-match domains (always present with `http-allow-azure-domains`)
+
+Matched exactly — subdomains and lookalikes are rejected.
 
 | Domain | Purpose |
 |--------|---------|
-| `api.github.com` | GitHub API (used in HTTP E2E tests) |
+| `api.github.com` | GitHub API |
+
+### 5.3 Test domains (additional with `http-allow-test-domains`)
+
+| Domain | Purpose |
+|--------|---------|
 | `httpbingo.org` | HTTP echo service (used in HTTP E2E tests) |
 
-### 5.3 Bare IP rejection
+### 5.4 Bare IP rejection
 
 All bare IPv4 and IPv6 addresses are rejected by `validate_url_allowlist`
 regardless of feature flag — even under `http-allow-azure-domains`.

--- a/src/activities/execute_http.rs
+++ b/src/activities/execute_http.rs
@@ -4,8 +4,9 @@
 //! ExecuteHTTP activity - makes HTTP requests
 //!
 //! Cargo features control what outbound HTTP(S) is allowed:
-//! - `http-allow-azure-domains`: Azure endpoints only (+ IP blocklist, no redirects).
-//! - `http-allow-test-domains`: same + api.github.com / httpbingo.org.
+//! - `http-allow-azure-domains`: Azure endpoints + api.github.com only
+//!   (+ IP blocklist, no redirects).
+//! - `http-allow-test-domains`: same + httpbingo.org.
 //! - `http-allow-all`: no restrictions (development only).
 //! - *(none)*: all HTTP calls fail at execution time.
 //!

--- a/src/ssrf.rs
+++ b/src/ssrf.rs
@@ -9,8 +9,8 @@
 //! | Feature | Behaviour |
 //! |---------|-----------|
 //! | *(none)* | **All** outbound HTTP is blocked — at DSL time and at execution time. |
-//! | `http-allow-azure-domains` | SSRF IP blocklist active, bare IPs blocked, redirects blocked, only Azure suffixes allowed. |
-//! | `http-allow-test-domains` | Same as `http-allow-azure-domains` **plus** `api.github.com` and `httpbingo.org` (for E2E tests). Implies `http-allow-azure-domains`. |
+//! | `http-allow-azure-domains` | SSRF IP blocklist active, bare IPs blocked, redirects blocked, only Azure suffixes plus `api.github.com` allowed. |
+//! | `http-allow-test-domains` | Same as `http-allow-azure-domains` **plus** `httpbingo.org` (for E2E tests). Implies `http-allow-azure-domains`. |
 //! | `http-allow-all` | All SSRF protections disabled — any URL is allowed (development only). |
 //!
 //! The blocklist and allow-list are hardcoded and cannot be bypassed by any
@@ -66,9 +66,20 @@ pub(crate) const AZURE_DOMAIN_SUFFIXES: &[&str] = &[
     ".cloudapp.azure.com",
 ];
 
+/// Fully-qualified non-Azure domains allowed alongside the Azure suffixes
+/// (exact match, not suffix).
+///
+/// Available whenever `http-allow-azure-domains` (or `http-allow-test-domains`,
+/// which implies it) is enabled.
+#[cfg(any(
+    feature = "http-allow-azure-domains",
+    feature = "http-allow-test-domains"
+))]
+pub(crate) const EXACT_DOMAINS: &[&str] = &["api.github.com"];
+
 /// Fully-qualified test domains (exact match, not suffix).
 #[cfg(feature = "http-allow-test-domains")]
-pub(crate) const TEST_EXACT_DOMAINS: &[&str] = &["api.github.com", "httpbingo.org"];
+pub(crate) const TEST_EXACT_DOMAINS: &[&str] = &["httpbingo.org"];
 
 // ---------------------------------------------------------------------------
 // IP blocklist
@@ -162,9 +173,10 @@ pub fn validate_url_scheme(url: &str) -> Result<(), String> {
 /// Behaviour depends on Cargo features (most to least restrictive):
 ///
 /// * *(none)* — all requests blocked, regardless of domain.
-/// * `http-allow-azure-domains` — bare IPs blocked; only Azure suffixes allowed.
-/// * `http-allow-test-domains` — same as above **plus** `api.github.com` and
-///   `httpbingo.org` (for E2E tests).
+/// * `http-allow-azure-domains` — bare IPs blocked; only Azure suffixes and
+///   `api.github.com` allowed.
+/// * `http-allow-test-domains` — same as above **plus** `httpbingo.org`
+///   (for E2E tests).
 /// * `http-allow-all` — allow-list check is skipped entirely; all domains pass.
 pub fn validate_url_allowlist(url: &str) -> Result<(), String> {
     // http-allow-all: skip all domain checks.
@@ -209,6 +221,13 @@ pub fn validate_url_allowlist(url: &str) -> Result<(), String> {
             // Check Azure suffixes (always present when either azure or test feature is on).
             for suffix in AZURE_DOMAIN_SUFFIXES {
                 if host_lower.ends_with(suffix) {
+                    return Ok(());
+                }
+            }
+
+            // Exact-match non-Azure domains allowed in the same tier.
+            for exact in EXACT_DOMAINS {
+                if host_lower == *exact {
                     return Ok(());
                 }
             }
@@ -665,9 +684,23 @@ mod tests {
     fn allowlist_blocks_non_azure_domains() {
         assert!(validate_url_allowlist("https://example.com/path").is_err());
         assert!(validate_url_allowlist("https://httpbingo.org/get").is_err());
-        assert!(validate_url_allowlist("https://api.github.com/repos").is_err());
         assert!(validate_url_allowlist("https://evil.com/steal").is_err());
         assert!(validate_url_allowlist("https://management.azure.com/sub").is_err());
+    }
+
+    // api.github.com is allowed in the azure-domains tier (and above).
+    #[cfg(any(
+        feature = "http-allow-azure-domains",
+        feature = "http-allow-test-domains"
+    ))]
+    #[test]
+    fn allowlist_allows_api_github_com() {
+        assert!(validate_url_allowlist("https://api.github.com/repos").is_ok());
+        assert!(validate_url_allowlist("https://API.GITHUB.COM/repos").is_ok());
+        // Exact match only — subdomains and lookalikes stay blocked.
+        assert!(validate_url_allowlist("https://evil.api.github.com/repos").is_err());
+        assert!(validate_url_allowlist("https://api.github.com.evil.com/repos").is_err());
+        assert!(validate_url_allowlist("https://github.com/repos").is_err());
     }
 
     #[cfg(any(
@@ -858,7 +891,6 @@ mod tests {
     #[cfg(feature = "http-allow-test-domains")]
     #[test]
     fn allowlist_allows_test_domains() {
-        assert!(validate_url_allowlist("https://api.github.com/repos").is_ok());
         assert!(validate_url_allowlist("https://httpbingo.org/get").is_ok());
     }
 


### PR DESCRIPTION
## Summary

Promotes `api.github.com` from the test-only tier (`http-allow-test-domains`) to the production tier (`http-allow-azure-domains`), so released builds can call the GitHub API.

Previously `api.github.com` lived in `TEST_EXACT_DOMAINS`, which meant it was only reachable in CI/dev builds. The released Debian package and published Docker image are built with `http-allow-azure-domains`, so any workflow using `df.http()` against the GitHub API worked locally but failed in production.

## Changes

- Add a new `EXACT_DOMAINS` constant containing `api.github.com`, gated on `http-allow-azure-domains` (or `http-allow-test-domains`, which implies it).
- Add an exact-match loop in `validate_url_allowlist`, between the Azure suffix check and the test-domain check.
- Remove `api.github.com` from `TEST_EXACT_DOMAINS` (it is now covered by the broader tier); `httpbingo.org` remains the only test-only domain.
- Update the feature tables and doc comments in `src/ssrf.rs`, `src/activities/execute_http.rs`, and `docs/http-security.md`.

## Why exact match, not a suffix

Azure entries use `ends_with` against a leading-dot suffix. Applying that to GitHub would allow every `*.github.com` subdomain, which is a much wider surface than intended. `EXACT_DOMAINS` compares the full lowercased host for equality, so only `api.github.com` itself passes.

## Tests

New `allowlist_allows_api_github_com` asserts the domain resolves in the azure tier and that near-misses stay blocked:

- `https://api.github.com/repos` — allowed
- `https://API.GITHUB.COM/repos` — allowed (case-insensitive)
- `https://evil.api.github.com/repos` — blocked (subdomain)
- `https://api.github.com.evil.com/repos` — blocked (suffix lookalike)
- `https://github.com/repos` — blocked (apex)

`allowlist_blocks_non_azure_domains` and `allowlist_allows_test_domains` updated accordingly.

Verified: `cargo fmt --check`, `cargo clippy -D warnings`, ssrf unit tests under both `http-allow-azure-domains` (56 passed) and `http-allow-test-domains` (57 passed), plus `cargo check` with no HTTP feature and with `http-allow-all`.

This change was also validated end-to-end against a live `http-allow-azure-domains`-only build: a durable function calling `https://api.github.com/repos/microsoft/pg_durable` completed with HTTP 200, while `httpbingo.org`, `github.com`, `evil.api.github.com`, and `api.github.com.evil.com` were all rejected by the allow-list.

## Upgrade & Migration

No schema changes, no upgrade script needed. The allow-list is a compile-time constant, so this only affects the behaviour of newly built binaries. The change is purely additive — no previously allowed URL becomes blocked.

Ported from internal PR !2242744.