### PR TITLE
Set PostgreSQL application names

### DIFF
--- a/scripts/test-e2e-local.sh
+++ b/scripts/test-e2e-local.sh
@@ -47,6 +47,7 @@ SETUP_PLAYGROUND_APPLIED=false
 E2E_ROLE_ENSURED=false
 VERSION_SHOWN=false
 CURRENT_FEATURES=""  # tracks what Cargo features the installed .so was built with
+PHASE_LOG_MARK=0
 
 declare -a REQUESTED_PHASES=()
 declare -a MATCHED_TESTS=()
@@ -461,6 +462,7 @@ configure_phase() {
     : > "$DATA_DIR/postgresql.auto.conf"
     set_conf_line "port" "$PG_PORT"
     clear_connlimit_gucs
+    remove_conf_key "log_connections"
 
     case "$phase" in
         no-preload)
@@ -471,6 +473,7 @@ configure_phase() {
             set_conf_line "pg_durable.worker_role" "'postgres'"
             set_conf_line "pg_durable.database" "'postgres'"
             set_conf_line "pg_durable.enable_superuser_instances" "on"
+            set_conf_line "log_connections" "on"
             ;;
         superuser-guc-off)
             set_conf_line "shared_preload_libraries" "'pg_durable'"
@@ -569,6 +572,12 @@ prepare_phase() {
     "$PSQL" -h localhost -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" \
         -c "DROP EXTENSION IF EXISTS pg_durable CASCADE; DROP SCHEMA IF EXISTS duroxide CASCADE;" \
         >/dev/null 2>&1 || true
+
+    if [ -f "$LOG_FILE" ]; then
+        PHASE_LOG_MARK=$(wc -l < "$LOG_FILE")
+    else
+        PHASE_LOG_MARK=0
+    fi
 
     restart_server
 
@@ -714,6 +723,43 @@ check_expected_warning_fragments() {
     return 0
 }
 
+assert_application_names_logged() {
+    local expected_names=(
+        "pg_durable:worker:management"
+        "pg_durable:worker:poll"
+        "pg_durable:worker:duroxide"
+        "pg_durable:worker:workflow-sql"
+        "pg_durable:backend:duroxide"
+        "pg_durable:backend:monitoring"
+        "pg_durable:backend:new-transaction"
+    )
+    local missing_names=()
+    local application_name
+    local needle
+
+    for application_name in "${expected_names[@]}"; do
+        needle="application_name=$application_name"
+        if ! awk -v start="$PHASE_LOG_MARK" -v needle="$needle" \
+            'NR > start && index($0, needle) { found = 1 } END { exit(found ? 0 : 1) }' \
+            "$LOG_FILE"; then
+            missing_names+=("$application_name")
+        fi
+    done
+
+    if [ "${#missing_names[@]}" -eq 0 ]; then
+        return 0
+    fi
+
+    echo ""
+    echo "    Missing connection log application names:"
+    printf '      %s\n' "${missing_names[@]}"
+    echo "    pg_durable connection authorization entries for this phase:"
+    awk -v start="$PHASE_LOG_MARK" \
+        'NR > start && /connection authorized:/ && /application_name=pg_durable:/ { print "      " $0 }' \
+        "$LOG_FILE" | tail -20
+    return 1
+}
+
 run_test_file() {
     local test_file="$1"
     local test_name
@@ -792,6 +838,17 @@ run_phase() {
             phase_failed=$((phase_failed + 1))
         fi
     done
+
+    if [ "$phase" = "standard" ] && [ -z "$TEST_FILTER" ]; then
+        printf "  %-45s ... " "application_name_connection_logs"
+        if assert_application_names_logged; then
+            echo -e "${GREEN}PASS${NC}"
+            phase_passed=$((phase_passed + 1))
+        else
+            echo -e "${RED}FAIL${NC}"
+            phase_failed=$((phase_failed + 1))
+        fi
+    fi
 
     TOTAL_PASSED=$((TOTAL_PASSED + phase_passed))
     TOTAL_FAILED=$((TOTAL_FAILED + phase_failed))

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,8 @@ use pgrx::prelude::*;
 use tokio::runtime::Runtime;
 
 use crate::types::{
-    backend_duroxide_schema, connect_as_user, new_backend_provider, postgres_connection_string,
+    backend_duroxide_schema, connect_as_user_for_new_transaction, new_backend_provider,
+    postgres_connection_string,
 };
 
 /// Cached tokio runtime for client operations.
@@ -278,11 +279,6 @@ async fn start_on_new_session(
         .await
         .map_err(|e| format!("failed to clear df.in_workflow on new-transaction session: {e}"))?;
 
-    sqlx::query("SET application_name = 'pg_durable:new-transaction-start'")
-        .execute(&mut *conn)
-        .await
-        .map_err(|e| format!("failed to tag new-transaction start session: {e}"))?;
-
     // Bound both the lock wait and the statement itself. See
     // NEW_TRANSACTION_START_STATEMENT_TIMEOUT_MS for why this is not optional. Two
     // statements because sqlx prepares every query, and the extended protocol
@@ -353,7 +349,7 @@ pub fn start_in_new_transaction(
         // holding the `df` tables this backend writes through SPI. The `database`
         // argument is forwarded to the inner `df.start()`, which records it as an
         // instance property for the worker to execute against.
-        let mut conn = connect_as_user(&user, None).await?;
+        let mut conn = connect_as_user_for_new_transaction(&user).await?;
 
         let result = start_on_new_session(&mut conn, &fut, &label, &database).await;
 

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -10,7 +10,10 @@ use pgrx::datum::TimestampWithTimeZone;
 use pgrx::prelude::*;
 use std::collections::HashMap;
 
-use crate::types::{backend_duroxide_schema, new_backend_provider, postgres_connection_string};
+use crate::types::{
+    backend_duroxide_schema, connection_url_with_application_name, new_backend_provider,
+    postgres_connection_string, BACKEND_MONITORING_APPLICATION_NAME,
+};
 
 // ============================================================================
 // Monitoring Functions
@@ -164,9 +167,11 @@ fn fetch_instance_info_map(
 
         let mut info_by_id: HashMap<String, (String, i64, Option<String>)> = HashMap::new();
 
+        let monitoring_conn_str =
+            connection_url_with_application_name(pg_conn_str, BACKEND_MONITORING_APPLICATION_NAME);
         let pool = match PgPoolOptions::new()
             .max_connections(1)
-            .connect(pg_conn_str)
+            .connect(&monitoring_conn_str)
             .await
         {
             Ok(p) => p,

--- a/src/node_status.rs
+++ b/src/node_status.rs
@@ -26,7 +26,7 @@ impl<'a> InstanceLineage<'a> {
 
         let mut generations = Vec::new();
         let mut node_ids = Vec::new();
-        for pair in tokens[1..].chunks_exact(2) {
+        for pair in tokens[1..].as_chunks::<2>().0 {
             generations.push(pair[0].parse::<i64>().ok()?);
             if pair[1].is_empty() {
                 return None;

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,6 +16,15 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use uuid::Uuid;
 
+pub(crate) const WORKER_MANAGEMENT_APPLICATION_NAME: &str = "pg_durable:worker:management";
+pub(crate) const WORKER_POLL_APPLICATION_NAME: &str = "pg_durable:worker:poll";
+pub(crate) const WORKER_DUROXIDE_APPLICATION_NAME: &str = "pg_durable:worker:duroxide";
+pub(crate) const WORKER_WORKFLOW_SQL_APPLICATION_NAME: &str = "pg_durable:worker:workflow-sql";
+pub(crate) const BACKEND_DUROXIDE_APPLICATION_NAME: &str = "pg_durable:backend:duroxide";
+pub(crate) const BACKEND_MONITORING_APPLICATION_NAME: &str = "pg_durable:backend:monitoring";
+pub(crate) const BACKEND_NEW_TRANSACTION_APPLICATION_NAME: &str =
+    "pg_durable:backend:new-transaction";
+
 // ============================================================================
 // Configuration Functions
 // ============================================================================
@@ -155,6 +164,19 @@ pub fn postgres_connection_string() -> String {
     build_connection_url(&user, &host, port, &database)
 }
 
+pub(crate) fn postgres_connection_string_with_application_name(application_name: &str) -> String {
+    connection_url_with_application_name(&postgres_connection_string(), application_name)
+}
+
+pub(crate) fn connection_url_with_application_name(
+    database_url: &str,
+    application_name: &str,
+) -> String {
+    let separator = if database_url.contains('?') { '&' } else { '?' };
+    let encoded = utf8_percent_encode(application_name, NON_ALPHANUMERIC);
+    format!("{database_url}{separator}application_name={encoded}")
+}
+
 /// Build the worker's `postgres://` connection URL.
 ///
 /// A Unix-socket `host` (one starting with `/`) is percent-encoded so the URL
@@ -234,6 +256,22 @@ pub async fn connect_as_user(
     user: &str,
     database: Option<&str>,
 ) -> Result<sqlx::postgres::PgConnection, String> {
+    connect_as_user_with_application_name(user, database, WORKER_WORKFLOW_SQL_APPLICATION_NAME)
+        .await
+}
+
+pub(crate) async fn connect_as_user_for_new_transaction(
+    user: &str,
+) -> Result<sqlx::postgres::PgConnection, String> {
+    connect_as_user_with_application_name(user, None, BACKEND_NEW_TRANSACTION_APPLICATION_NAME)
+        .await
+}
+
+async fn connect_as_user_with_application_name(
+    user: &str,
+    database: Option<&str>,
+    application_name: &str,
+) -> Result<sqlx::postgres::PgConnection, String> {
     use sqlx::postgres::PgConnectOptions;
     use sqlx::Connection;
 
@@ -246,7 +284,8 @@ pub async fn connect_as_user(
     let mut options = PgConnectOptions::new()
         .username(normalized_user.as_ref())
         .database(db)
-        .port(get_port());
+        .port(get_port())
+        .application_name(application_name);
 
     let host = get_host();
     if !host.is_empty() {
@@ -364,7 +403,10 @@ pub fn backend_provider_config(
     database_url: &str,
     schema_name: &str,
 ) -> duroxide_pg::ProviderConfig {
-    let mut config = duroxide_pg::ProviderConfig::url(database_url);
+    let mut config = duroxide_pg::ProviderConfig::url(connection_url_with_application_name(
+        database_url,
+        BACKEND_DUROXIDE_APPLICATION_NAME,
+    ));
     config.schema_name = Some(schema_name.to_string());
     config.migration_policy = duroxide_pg::MigrationPolicy::VerifyOnly;
     config
@@ -394,7 +436,10 @@ pub fn worker_provider_config(
     database_url: &str,
     schema_name: &str,
 ) -> duroxide_pg::ProviderConfig {
-    let mut config = duroxide_pg::ProviderConfig::url(database_url);
+    let mut config = duroxide_pg::ProviderConfig::url(connection_url_with_application_name(
+        database_url,
+        WORKER_DUROXIDE_APPLICATION_NAME,
+    ));
     config.schema_name = Some(schema_name.to_string());
     config.migration_policy = duroxide_pg::MigrationPolicy::ApplyAll;
     config
@@ -2021,6 +2066,77 @@ mod tests {
             Some(path.to_string()),
         );
         assert_ne!(opts.get_host(), "evil.com");
+    }
+
+    #[test]
+    fn connection_url_application_name_is_encoded() {
+        let url = connection_url_with_application_name(
+            "postgres://worker@localhost/app",
+            WORKER_DUROXIDE_APPLICATION_NAME,
+        );
+        let opts = sqlx::postgres::PgConnectOptions::from_str(&url)
+            .expect("URL with application_name should parse");
+
+        assert_eq!(
+            opts.get_application_name(),
+            Some(WORKER_DUROXIDE_APPLICATION_NAME)
+        );
+    }
+
+    #[test]
+    fn connection_url_application_name_preserves_existing_parameters() {
+        let url = connection_url_with_application_name(
+            "postgres://worker@localhost/app?sslmode=disable",
+            BACKEND_DUROXIDE_APPLICATION_NAME,
+        );
+        let opts = sqlx::postgres::PgConnectOptions::from_str(&url)
+            .expect("URL with existing parameters should parse");
+
+        assert_eq!(
+            opts.get_application_name(),
+            Some(BACKEND_DUROXIDE_APPLICATION_NAME)
+        );
+    }
+
+    #[test]
+    fn application_names_are_valid_postgresql_names() {
+        for application_name in [
+            WORKER_MANAGEMENT_APPLICATION_NAME,
+            WORKER_POLL_APPLICATION_NAME,
+            WORKER_DUROXIDE_APPLICATION_NAME,
+            WORKER_WORKFLOW_SQL_APPLICATION_NAME,
+            BACKEND_DUROXIDE_APPLICATION_NAME,
+            BACKEND_MONITORING_APPLICATION_NAME,
+            BACKEND_NEW_TRANSACTION_APPLICATION_NAME,
+        ] {
+            assert!(application_name.is_ascii());
+            assert!(application_name.len() < 64);
+        }
+    }
+
+    fn assert_provider_application_name(config: duroxide_pg::ProviderConfig, expected: &str) {
+        let duroxide_pg::ConnectionConfig::Url(url) = config.connection else {
+            panic!("provider should use URL connection configuration");
+        };
+        let opts =
+            sqlx::postgres::PgConnectOptions::from_str(&url).expect("provider URL should parse");
+        assert_eq!(opts.get_application_name(), Some(expected));
+    }
+
+    #[test]
+    fn backend_provider_uses_backend_application_name() {
+        assert_provider_application_name(
+            backend_provider_config("postgres://worker@localhost/app", "_duroxide"),
+            BACKEND_DUROXIDE_APPLICATION_NAME,
+        );
+    }
+
+    #[test]
+    fn worker_provider_uses_worker_application_name() {
+        assert_provider_application_name(
+            worker_provider_config("postgres://worker@localhost/app", "_duroxide"),
+            WORKER_DUROXIDE_APPLICATION_NAME,
+        );
     }
 
     // ============================================================================

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -20,7 +20,8 @@ use crate::registry::{create_activity_registry, create_orchestration_registry};
 use crate::types::{
     get_max_duroxide_connections, get_max_management_connections, get_max_user_connections,
     get_reconcile_interval, get_retention_days, postgres_connection_string,
-    resolve_duroxide_schema_pool, worker_provider_config,
+    postgres_connection_string_with_application_name, resolve_duroxide_schema_pool,
+    worker_provider_config, WORKER_MANAGEMENT_APPLICATION_NAME, WORKER_POLL_APPLICATION_NAME,
 };
 
 // Retention policy for terminal ('completed'/'failed'/'cancelled') instances.
@@ -133,6 +134,10 @@ async fn run_duroxide_runtime() {
     const STALE_RUNTIME_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
     let pg_conn_str = postgres_connection_string();
+    let management_conn_str =
+        postgres_connection_string_with_application_name(WORKER_MANAGEMENT_APPLICATION_NAME);
+    let poll_conn_str =
+        postgres_connection_string_with_application_name(WORKER_POLL_APPLICATION_NAME);
     log!(
         "pg_durable: background worker connected to PostgreSQL at {}",
         pg_conn_str,
@@ -181,7 +186,7 @@ async fn run_duroxide_runtime() {
         match sqlx::postgres::PgPoolOptions::new()
             .max_connections(mgmt_conns)
             .acquire_timeout(Duration::from_secs(5))
-            .connect(&pg_conn_str)
+            .connect(&management_conn_str)
             .await
         {
             Ok(pool) => break pool,
@@ -214,7 +219,7 @@ async fn run_duroxide_runtime() {
         match sqlx::postgres::PgPoolOptions::new()
             .max_connections(1)
             .acquire_timeout(Duration::from_secs(5))
-            .connect(&pg_conn_str)
+            .connect(&poll_conn_str)
             .await
         {
             Ok(pool) => break pool,


### PR DESCRIPTION
## Summary

- assign stable startup-time `application_name` values to pg_durable worker and backend connections
- distinguish management, polling, workflow SQL, monitoring, new-transaction, and duroxide connection roles
- pass encoded application names through duroxide-pg connection URLs without waiting for an upstream API change
- replace the post-connect new-transaction tag with a startup parameter
- enable connection logging for the standard local E2E phase and assert that PostgreSQL authorization logs contain all seven application names

## Application names

- `pg_durable:worker:management`
- `pg_durable:worker:poll`
- `pg_durable:worker:duroxide`
- `pg_durable:worker:workflow-sql`
- `pg_durable:backend:duroxide`
- `pg_durable:backend:monitoring`
- `pg_durable:backend:new-transaction`

## Testing

- `cargo fmt -p pg_durable -- --check`
- `cargo clippy --features pg17 -- -D warnings`
- `USER=vscode ./scripts/test-unit.sh` — 288 passed, 16 ignored
- `USER=vscode ./scripts/test-e2e-local.sh --clean --default-build-phases --pg-version 17` — 52 passed, 0 failed
- the local standard E2E phase records its starting log position, exercises all connection paths through the existing suite, and verifies all seven names appear in PostgreSQL `connection authorized` entries

The log assertion is intentionally local-harness-only; the Docker E2E harness is unchanged.