### PR TITLE
Improve secrets handling

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1054,6 +1054,10 @@ Durable function variables allow you to configure durable functions with externa
 
 > **Important**: `df.setvar()`, `df.unsetvar()`, and `df.clearvars()` cannot be called from within a running durable function. They are for configuration only.
 
+> **Variables are not secrets.** `df.vars` stores values as plaintext, and the value is copied
+> into durable execution history when `df.start()` runs. See
+> [Variables and secrets](#variables-and-secrets) before putting a credential in one.
+
 ### System Variables
 
 These read-only variables are automatically available during durable function execution:
@@ -1062,6 +1066,39 @@ These read-only variables are automatically available during durable function ex
 |----------|-------------|
 | `{sys_instance_id}` | Current durable function instance ID |
 | `{sys_label}` | Durable function label (if provided) |
+
+### Variables and secrets
+
+Reaching for `df.setvar()` to hold an API key is a natural move, and it is only a partial
+mitigation. Here is exactly what it does and does not protect, so you can make an informed
+choice.
+
+Given this pattern:
+
+```sql
+SELECT df.setvar('api_key', '<credential>');
+SELECT df.start(df.http('https://api.example.com/users', 'GET', NULL,
+                        '{"Authorization": "Bearer {api_key}"}'::jsonb), 'fetch-users');
+```
+
+| Location | Holds the credential? | Notes |
+|----------|----------------------|-------|
+| `df.nodes.query` | No — stores the literal `{api_key}` | This is the one thing `{var}` genuinely buys you. Substitution happens at execution time, not when the node is created. |
+| `df.vars.value` | **Yes, plaintext** | RLS isolates it from other users. It is *not* encrypted, and it is not hidden from a superuser or the table owner. |
+| Durable execution history | **Yes, plaintext** | `df.start()` snapshots every variable you own into the orchestration input, and the substituted header is recorded as the HTTP step's input. Parallel branches and each loop iteration re-record it. |
+| WAL, backups, replicas | **Yes** | Follows every write above, typically with a longer retention than `pg_durable.retention_days`. |
+| Server log | URLs are redacted; SQL text depends on `pg_durable.log_workflow_sql` | See [What reaches the server log](#what-reaches-the-server-log). |
+| `pg_stat_activity`, `pg_stat_statements` | Only if you inline the literal | `SELECT df.setvar('api_key', '<credential>')` is itself a statement. Bind it as a parameter, or use `\getenv` in psql, rather than typing the value into SQL. |
+
+Writing the credential directly into `df.http(...)` instead of using a variable is strictly
+worse: it adds `df.nodes.query` to that list without removing anything from it.
+
+Practical guidance today:
+
+- Prefer credentials that are short-lived and narrowly scoped, so history exposure is bounded.
+- Treat `df.vars` as configuration — hostnames, table names, batch sizes, API versions.
+- Treat a database backup as containing every credential any workflow has used.
+- Set `pg_durable.retention_days` to the shortest value your operations allow.
 
 ### Variable Substitution
 
@@ -1072,11 +1109,11 @@ Use `{varname}` in SQL queries to substitute variable values:
 ```sql
 -- Set up configuration
 SELECT df.setvar('api_base', 'https://api.example.com');
-SELECT df.setvar('api_key', 'secret123');
+SELECT df.setvar('page_size', '50');
 
 -- Start durable function using variables
 SELECT df.start(
-    df.http('{api_base}/users', 'GET', NULL, '{"Authorization": "Bearer {api_key}"}'::jsonb)
+    df.http('{api_base}/users?per_page={page_size}', 'GET')
     ~> 'INSERT INTO playground.logs (msg) VALUES (''Fetched users'')',
     'fetch-users'
 );
@@ -2072,10 +2109,38 @@ Row-level security (RLS) restricts each user to their own instances and nodes:
 - `df.cancel()` and `df.signal()` check ownership before acting — attempts on other users' instances return "Instance not found or access denied"
 - Superusers bypass RLS and can see all instances (standard PostgreSQL behavior)
 
+### What reaches the server log
+
+The background worker writes an execution trace to the PostgreSQL server log. That log is a
+different security boundary from the database: RLS does not apply to it, it is not bound by
+`pg_durable.retention_days`, and it is often shipped and backed up separately.
+
+| Trace | Contents |
+|-------|----------|
+| HTTP and multipart requests | Method, scheme, host, port and path. **Query-string values, userinfo and the URL fragment are redacted**, so an Azure SAS token or `?api-key=` does not reach the log. Parameter *names* are kept so the line stays diagnosable. |
+| HTTP request errors | Same redaction, applied to the message text as well, since the HTTP client interpolates the request URL into its own errors. |
+| HTTP and multipart request headers and bodies | Never logged. |
+| SQL nodes | The submitting role and target database, plus the fully-substituted SQL text when `pg_durable.log_workflow_sql` is on. |
+| Workflow result | The final return value is logged on completion. For a workflow ending in an HTTP step this includes the response body. |
+
+`pg_durable.log_workflow_sql` (default `on`) controls the last of these. SQL cannot be
+redacted heuristically — a variable value spliced into a query is indistinguishable from the
+query itself — so this is an on/off switch rather than a masking rule. It is read by the
+background worker, so like the other worker GUCs it is Postmaster-context and needs a restart:
+
+```ini
+# postgresql.conf — omit workflow SQL text from the log
+pg_durable.log_workflow_sql = off
+```
+
+Turning it off also removes the primary record of what workflows actually executed, which is the
+first thing an incident investigation looks for. Leave it on unless the server log is less well
+protected than the database, and prefer keeping credentials out of SQL in the first place.
+
 ### Security Best Practices
 
 1. **Worker role must be superuser** — The background worker role (`pg_durable.worker_role`) must be a superuser to bypass RLS and manage all instances
-2. **Review df.vars usage** — Variables are scoped per-user via RLS, but avoid storing secrets in plain text
+2. **Do not put credentials in `df.vars`** — Variables are scoped per-user via RLS, but they are stored as plaintext and are copied into durable execution history. See [Variables and secrets](#variables-and-secrets)
 3. **Use labels carefully** — Instance labels are visible only to the submitting user (RLS-filtered) and superusers
 4. **Monitor instances** — Superusers can use `df.list_instances()` to see all users' instances; regular users see only their own
 5. **Avoid unsafe `SECURITY DEFINER` wrappers around `df.start()`** — Never allow untrusted callers to supply SQL or futures to `df.start()` from a `SECURITY DEFINER` context unless definer-level execution is intentional.
@@ -2178,7 +2243,7 @@ GRANT pg_durable_user TO app_backend, etl_service;
 
 Users get `SELECT` and `INSERT` on `df.instances` and `df.nodes` (required for `df.start()`, `df.status()`, `df.result()`). Column-level `UPDATE` on `(status, updated_at)` allows `df.cancel()` to set status. No full `UPDATE` or `DELETE` — the identity column (`submitted_by`) and structural columns are protected.
 
-> **Note:** `df.vars` uses per-user scoping via an `owner` column and RLS — each user can only read and write their own variables. Superusers bypass RLS but the DSL functions (`df.setvar()`, `df.getvar()`, etc.) still scope to the calling user via explicit filters. Avoid storing secrets in plain text.
+> **Note:** `df.vars` uses per-user scoping via an `owner` column and RLS — each user can only read and write their own variables. Superusers bypass RLS but the DSL functions (`df.setvar()`, `df.getvar()`, etc.) still scope to the calling user via explicit filters. Values are stored as plaintext and are copied into durable execution history — see [Variables and secrets](#variables-and-secrets).
 
 ### Revoking Privileges
 
@@ -2271,7 +2336,7 @@ pg_durable.max_new_transaction_starts = 2
 pg_durable.new_transaction_start_timeout = 5
 ```
 
-> **Other GUCs:** `pg_durable.list_instances_max_limit` (SUSET context, default `1000`) caps the per-call page size of `df.list_instances()`. Unlike the connection-limit GUCs above, it is superuser-settable at runtime (no restart) and is not loaded from `postgresql.conf` at startup only. See [docs/api-reference.md](docs/api-reference.md#pg_durablelist_instances_max_limit).
+> **Other GUCs:** `pg_durable.list_instances_max_limit` (SUSET context, default `1000`) caps the per-call page size of `df.list_instances()`. Unlike the connection-limit GUCs above, it is superuser-settable at runtime (no restart) and is not loaded from `postgresql.conf` at startup only. See [docs/api-reference.md](docs/api-reference.md#pg_durablelist_instances_max_limit). `pg_durable.log_workflow_sql` (Postmaster context, default `on`) controls whether workflow SQL text is written to the server log — see [What reaches the server log](#what-reaches-the-server-log).
 
 ### Connection Budget Formula
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1069,8 +1069,8 @@ These read-only variables are automatically available during durable function ex
 
 ### Variables and secrets
 
-Reaching for `df.setvar()` to hold an API key is a natural move, and it is only a partial
-mitigation. Here is exactly what it does and does not protect, so you can make an informed
+Using `df.setvar()` to hold an API key is a natural move, and it genuinely helps — but only in
+one place. Here is exactly what it does and does not protect, so you can make an informed
 choice.
 
 Given this pattern:
@@ -1093,7 +1093,7 @@ SELECT df.start(df.http('https://api.example.com/users', 'GET', NULL,
 Writing the credential directly into `df.http(...)` instead of using a variable is strictly
 worse: it adds `df.nodes.query` to that list without removing anything from it.
 
-Practical guidance today:
+Practical guidance:
 
 - Prefer credentials that are short-lived and narrowly scoped, so history exposure is bounded.
 - Treat `df.vars` as configuration — hostnames, table names, batch sizes, API versions.
@@ -2123,7 +2123,7 @@ different security boundary from the database: RLS does not apply to it, it is n
 | SQL nodes | The submitting role and target database, plus the fully-substituted SQL text when `pg_durable.log_workflow_sql` is on. |
 | Workflow result | The final return value is logged on completion. For a workflow ending in an HTTP step this includes the response body. |
 
-`pg_durable.log_workflow_sql` (default `on`) controls the last of these. SQL cannot be
+`pg_durable.log_workflow_sql` (default `on`) is what gates the SQL text. SQL cannot be
 redacted heuristically — a variable value spliced into a query is indistinguishable from the
 query itself — so this is an on/off switch rather than a masking rule. It is read by the
 background worker, so like the other worker GUCs it is Postmaster-context and needs a restart:

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -2114,7 +2114,7 @@ different security boundary from the database: RLS does not apply to it, it is n
 
 | Trace | Contents |
 |-------|----------|
-| HTTP and multipart requests | Method, scheme, host, port and path. **Query-string values, userinfo and the URL fragment are redacted** in request diagnostics. Parameter *names* are kept. Do not put credentials in paths or parameter names. |
+| HTTP and multipart requests | Method, scheme, host, port and path. **Query-string values, userinfo and the URL fragment are redacted** in request diagnostics. Bare tokens and pairs with empty or padding-only values are redacted whole; other parameter *names* are kept. Do not put credentials in paths or parameter names. |
 | HTTP request errors | Request URLs are removed from HTTP client errors; explicitly reported URLs are redacted as above. Response bodies included in 5xx errors are not redacted. |
 | HTTP and multipart request headers and bodies | Not directly included in request traces. An endpoint can echo them in its response. |
 | SQL nodes | The submitting role and any explicit target database, plus the fully-substituted SQL text when `pg_durable.log_workflow_sql` is on. |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1069,11 +1069,8 @@ These read-only variables are automatically available during durable function ex
 
 ### Variables and secrets
 
-Using `df.setvar()` to hold an API key is a natural move, and it genuinely helps — but only in
-one place. Here is exactly what it does and does not protect, so you can make an informed
-choice.
-
-Given this pattern:
+Variables keep credentials out of node templates, but do not provide secret storage.
+For example:
 
 ```sql
 SELECT df.setvar('api_key', '<credential>');
@@ -1083,15 +1080,15 @@ SELECT df.start(df.http('https://api.example.com/users', 'GET', NULL,
 
 | Location | Holds the credential? | Notes |
 |----------|----------------------|-------|
-| `df.nodes.query` | No — stores the literal `{api_key}` | This is the one thing `{var}` genuinely buys you. Substitution happens at execution time, not when the node is created. |
+| `df.nodes.query` | No — stores the literal `{api_key}` | Substitution happens at execution time, not when the node is created. |
 | `df.vars.value` | **Yes, plaintext** | RLS isolates it from other users. It is *not* encrypted, and it is not hidden from a superuser or the table owner. |
 | Durable execution history | **Yes, plaintext** | `df.start()` snapshots every variable you own into the orchestration input, and the substituted header is recorded as the HTTP step's input. Parallel branches and each loop iteration re-record it. |
 | WAL, backups, replicas | **Yes** | Follows every write above, typically with a longer retention than `pg_durable.retention_days`. |
-| Server log | URLs are redacted; SQL text depends on `pg_durable.log_workflow_sql` | See [What reaches the server log](#what-reaches-the-server-log). |
-| `pg_stat_activity`, `pg_stat_statements` | Only if you inline the literal | `SELECT df.setvar('api_key', '<credential>')` is itself a statement. Bind it as a parameter, or use `\getenv` in psql, rather than typing the value into SQL. |
+| Server log | May contain it | Request diagnostics redact URLs, but SQL, errors and results can still expose values. See [What reaches the server log](#what-reaches-the-server-log). |
+| Query monitoring and PostgreSQL logs | Depends on the statement and server settings | Bind parameters avoid inlining the value in the `df.setvar()` statement. Client-side `psql` variable expansion, including values read with `\getenv`, does not provide that protection. Values later substituted into workflow SQL become literal query text. |
 
-Writing the credential directly into `df.http(...)` instead of using a variable is strictly
-worse: it adds `df.nodes.query` to that list without removing anything from it.
+Inlining a credential in `df.http(...)` also stores it in `df.nodes.query`; it does not
+avoid exposure in that workflow's execution history.
 
 Practical guidance:
 
@@ -2117,25 +2114,24 @@ different security boundary from the database: RLS does not apply to it, it is n
 
 | Trace | Contents |
 |-------|----------|
-| HTTP and multipart requests | Method, scheme, host, port and path. **Query-string values, userinfo and the URL fragment are redacted**, so an Azure SAS token or `?api-key=` does not reach the log. Parameter *names* are kept so the line stays diagnosable. |
-| HTTP request errors | Same redaction, applied to the message text as well, since the HTTP client interpolates the request URL into its own errors. |
-| HTTP and multipart request headers and bodies | Never logged. |
-| SQL nodes | The submitting role and target database, plus the fully-substituted SQL text when `pg_durable.log_workflow_sql` is on. |
-| Workflow result | The final return value is logged on completion. For a workflow ending in an HTTP step this includes the response body. |
+| HTTP and multipart requests | Method, scheme, host, port and path. **Query-string values, userinfo and the URL fragment are redacted** in request diagnostics. Parameter *names* are kept. Do not put credentials in paths or parameter names. |
+| HTTP request errors | Request URLs are removed from HTTP client errors; explicitly reported URLs are redacted as above. Response bodies included in 5xx errors are not redacted. |
+| HTTP and multipart request headers and bodies | Not directly included in request traces. An endpoint can echo them in its response. |
+| SQL nodes | The submitting role and any explicit target database, plus the fully-substituted SQL text when `pg_durable.log_workflow_sql` is on. |
+| Workflow result | The final return value is logged on completion. For a workflow ending in an HTTP step this includes response headers and body, without redaction. |
 
-`pg_durable.log_workflow_sql` (default `on`) is what gates the SQL text. SQL cannot be
-redacted heuristically — a variable value spliced into a query is indistinguishable from the
-query itself — so this is an on/off switch rather than a masking rule. It is read by the
-background worker, so like the other worker GUCs it is Postmaster-context and needs a restart:
+`pg_durable.log_workflow_sql` (default `on`) controls SQL text in the worker's execution
+trace. SQL cannot be reliably redacted after substitution, so this is an on/off switch.
+It requires a server restart:
 
 ```ini
 # postgresql.conf — omit workflow SQL text from the log
 pg_durable.log_workflow_sql = off
 ```
 
-Turning it off also removes the primary record of what workflows actually executed, which is the
-first thing an incident investigation looks for. Leave it on unless the server log is less well
-protected than the database, and prefer keeping credentials out of SQL in the first place.
+Turning it off keeps the submitting role and any explicit target database in the trace, but removes
+statement text. It does not suppress workflow results, error messages, or PostgreSQL's
+own statement logging. Keep credentials out of SQL even when this setting is off.
 
 ### Security Best Practices
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -588,6 +588,11 @@ Sets a workflow variable for the current user (before `df.start()`). Each user h
 SELECT df.setvar('api_url', 'https://api.example.com');
 ```
 
+> **Not for credentials.** Values are stored as plaintext in `df.vars`, and `df.start()` copies
+> every variable you own into durable execution history. Using `{varname}` keeps the value out of
+> `df.nodes.query` but not out of history. See
+> [Variables and secrets](../USER_GUIDE.md#variables-and-secrets).
+
 ---
 
 ### df.getvar(name)
@@ -684,7 +689,7 @@ SELECT df.revoke_usage('app_role');
 
 ## Server Configuration (GUCs)
 
-These settings are configured via `ALTER SYSTEM SET` or `postgresql.conf` and take effect after `SELECT pg_reload_conf()` (no restart required).
+These settings are configured via `ALTER SYSTEM SET` or `postgresql.conf`. When they take effect depends on the context listed for each one: `SUSET` settings apply after `SELECT pg_reload_conf()`, while `POSTMASTER` settings require a server restart. GUCs read by the background worker are `POSTMASTER`, because the worker does not process a configuration reload.
 
 ---
 
@@ -749,3 +754,28 @@ SELECT pg_reload_conf();
 ```
 
 > **Behavior change (v0.2.4):** prior to v0.2.4, `df.list_instances()` silently truncated `limit_count` to 10000. It now raises an error when `limit_count` exceeds this GUC (default 1000). Callers that previously requested very large pages should lower `limit_count` or use the paginated overload (`after_cursor`/`next_cursor`).
+
+---
+
+### pg_durable.log_workflow_sql
+
+Controls whether the background worker writes the SQL text of an executed workflow node to the PostgreSQL server log.
+
+| Property | Value |
+|----------|-------|
+| Type | `boolean` |
+| Default | `on` |
+| Context | `POSTMASTER` (set in `postgresql.conf`; requires restart) |
+
+The SQL is logged *after* variable substitution, so a credential held in a `df.vars` variable and spliced into a query reaches the server log in cleartext. Unlike a URL query string — which pg_durable redacts unconditionally — SQL cannot be masked heuristically, because a substituted value is indistinguishable from the surrounding statement. This GUC is therefore an on/off switch.
+
+```ini
+# postgresql.conf
+pg_durable.log_workflow_sql = off
+```
+
+The value is read by the background worker, which does not process a configuration reload, so a restart is required — the same as `pg_durable.retention_days` and the connection-limit GUCs.
+
+Turning it off keeps the role, database and node identity in the log but drops the statement text. That also removes the primary record of what workflows executed, which is usually the first thing an incident investigation looks for — prefer keeping credentials out of SQL over disabling the log. See [Variables and secrets](../USER_GUIDE.md#variables-and-secrets).
+
+The trace runs on the worker's own connections, so it is independent of `log_statement`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -689,7 +689,7 @@ SELECT df.revoke_usage('app_role');
 
 ## Server Configuration (GUCs)
 
-These settings are configured via `ALTER SYSTEM SET` or `postgresql.conf`. When they take effect depends on the context listed for each one: `SUSET` settings apply after `SELECT pg_reload_conf()`, while `POSTMASTER` settings require a server restart. GUCs read by the background worker are `POSTMASTER`, because the worker does not process a configuration reload.
+These settings are configured via `ALTER SYSTEM SET` or `postgresql.conf`. Each one lists its context: `SUSET` settings take effect after `SELECT pg_reload_conf()`, while `POSTMASTER` settings require a restart. Every GUC read by the background worker is `POSTMASTER`, because the worker does not process a configuration reload.
 
 ---
 
@@ -776,6 +776,6 @@ pg_durable.log_workflow_sql = off
 
 The value is read by the background worker, which does not process a configuration reload, so a restart is required — the same as `pg_durable.retention_days` and the connection-limit GUCs.
 
-Turning it off keeps the role, database and node identity in the log but drops the statement text. That also removes the primary record of what workflows executed, which is usually the first thing an incident investigation looks for — prefer keeping credentials out of SQL over disabling the log. See [Variables and secrets](../USER_GUIDE.md#variables-and-secrets).
+Turning it off keeps the submitting role and target database in the log but drops the statement text. That also removes the primary record of what workflows executed, which is usually the first thing an incident investigation looks for — prefer keeping credentials out of SQL over disabling the log. See [Variables and secrets](../USER_GUIDE.md#variables-and-secrets).
 
-The trace runs on the worker's own connections, so it is independent of `log_statement`.
+This trace is written by the background worker's own logging, not by PostgreSQL statement logging, so `log_statement` neither enables nor suppresses it.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -767,15 +767,13 @@ Controls whether the background worker writes the SQL text of an executed workfl
 | Default | `on` |
 | Context | `POSTMASTER` (set in `postgresql.conf`; requires restart) |
 
-The SQL is logged *after* variable substitution, so a credential held in a `df.vars` variable and spliced into a query reaches the server log in cleartext. Unlike a URL query string — which pg_durable redacts unconditionally — SQL cannot be masked heuristically, because a substituted value is indistinguishable from the surrounding statement. This GUC is therefore an on/off switch.
+The SQL is logged *after* variable substitution, so credentials substituted into a query reach the server log in cleartext. SQL cannot be reliably redacted after substitution, so this is an on/off switch.
 
 ```ini
 # postgresql.conf
 pg_durable.log_workflow_sql = off
 ```
 
-The value is read by the background worker, which does not process a configuration reload, so a restart is required — the same as `pg_durable.retention_days` and the connection-limit GUCs.
+Turning it off keeps the submitting role and any explicit target database in the worker trace but drops the statement text. It does not suppress workflow results or error messages, which can also contain sensitive data.
 
-Turning it off keeps the submitting role and target database in the log but drops the statement text. That also removes the primary record of what workflows executed, which is usually the first thing an incident investigation looks for — prefer keeping credentials out of SQL over disabling the log. See [Variables and secrets](../USER_GUIDE.md#variables-and-secrets).
-
-This trace is written by the background worker's own logging, not by PostgreSQL statement logging, so `log_statement` neither enables nor suppresses it.
+PostgreSQL's own statement logging is independent: settings such as `log_statement` and `log_min_duration_statement` can still log executed SQL when this GUC is off. Keep credentials out of SQL even with this setting disabled. See [What reaches the server log](../USER_GUIDE.md#what-reaches-the-server-log) and [Variables and secrets](../USER_GUIDE.md#variables-and-secrets).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -689,7 +689,7 @@ SELECT df.revoke_usage('app_role');
 
 ## Server Configuration (GUCs)
 
-These settings are configured via `ALTER SYSTEM SET` or `postgresql.conf`. Each one lists its context: `SUSET` settings take effect after `SELECT pg_reload_conf()`, while `POSTMASTER` settings require a restart. Every GUC read by the background worker is `POSTMASTER`, because the worker does not process a configuration reload.
+These settings are configured via `ALTER SYSTEM SET` or `postgresql.conf`. See each setting for reload or restart requirements.
 
 ---
 
@@ -701,7 +701,7 @@ Controls whether pg_durable allows durable function instances whose `submitted_b
 |----------|-------|
 | Type | `boolean` |
 | Default | `off` |
-| Context | `POSTMASTER` (requires server restart) |
+| Context | `SUSET` (superuser can change at runtime; no restart needed) |
 | Visibility | Hidden from `SHOW ALL` and `pg_settings` for non-superusers |
 
 **When `off` (default):**
@@ -715,11 +715,11 @@ Controls whether pg_durable allows durable function instances whose `submitted_b
 ```sql
 -- Enable (requires superuser)
 ALTER SYSTEM SET pg_durable.enable_superuser_instances = on;
--- Restart PostgreSQL to apply the change.
+SELECT pg_reload_conf();
 
 -- Disable (default; recommended for multi-tenant)
 ALTER SYSTEM SET pg_durable.enable_superuser_instances = off;
--- Restart PostgreSQL to apply the change.
+SELECT pg_reload_conf();
 
 -- Check current value (superuser only)
 SHOW pg_durable.enable_superuser_instances;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -701,7 +701,7 @@ Controls whether pg_durable allows durable function instances whose `submitted_b
 |----------|-------|
 | Type | `boolean` |
 | Default | `off` |
-| Context | `SUSET` (superuser can change at runtime; no restart needed) |
+| Context | `POSTMASTER` (requires server restart) |
 | Visibility | Hidden from `SHOW ALL` and `pg_settings` for non-superusers |
 
 **When `off` (default):**
@@ -715,11 +715,11 @@ Controls whether pg_durable allows durable function instances whose `submitted_b
 ```sql
 -- Enable (requires superuser)
 ALTER SYSTEM SET pg_durable.enable_superuser_instances = on;
-SELECT pg_reload_conf();
+-- Restart PostgreSQL to apply the change.
 
 -- Disable (default; recommended for multi-tenant)
 ALTER SYSTEM SET pg_durable.enable_superuser_instances = off;
-SELECT pg_reload_conf();
+-- Restart PostgreSQL to apply the change.
 
 -- Check current value (superuser only)
 SHOW pg_durable.enable_superuser_instances;

--- a/docs/http-security.md
+++ b/docs/http-security.md
@@ -360,13 +360,20 @@ is applied before any URL reaches a log line or an error string.
 
 | Component | Treatment |
 |-----------|-----------|
-| Scheme, host, port, path | Preserved |
+| Scheme, host, port, path | Preserved, normalized per the WHATWG URL spec (host lowercased, default port dropped, empty path rendered as `/`) |
 | Query parameter *names* | Preserved — `sig` and `code` are not themselves secret, and keeping them makes a redacted line diagnosable |
 | Query parameter *values* | Replaced with `<redacted>`, except an allowlist of benign parameters (`api-version`, `comp`, `restype`) |
 | Bare query token with no `=` | Replaced whole — indistinguishable from a name |
 | `userinfo@` | Replaced with `<redacted>@`, keeping the host |
 | Fragment | Replaced whole |
 | Unparseable input | Replaced whole — redaction fails closed and never echoes back a string it could not parse |
+
+Parsing uses the `url` crate rather than hand-rolled string splitting, so IPv6
+authorities, percent-encoding, default ports and userinfo edge cases follow the
+spec. The query string is the one part still split on `&` and `=` directly:
+`Url::query_pairs` follows the form-urlencoded rules and reports a bare token
+(`?SEKRIT`) as the *name* of a valueless parameter, so rebuilding the query from
+those pairs would publish the token verbatim.
 
 The same redaction is applied to the HTTP client's own error text, which
 interpolates the request URL into messages such as

--- a/docs/http-security.md
+++ b/docs/http-security.md
@@ -174,17 +174,17 @@ issues a `REVOKE`. Call `df.revoke_usage()` first to downgrade a role.
 
 `df.grant_usage()` and `df.revoke_usage()` are admin-only functions.
 `EXECUTE` is revoked from `PUBLIC` at `CREATE EXTENSION` time, so only
-superusers — and roles granted `with_grant => true` — can call them.
+superusers can call them — plus any role an admin delegated to with
+`df.grant_usage(role, with_grant => true)`.
 
 `df.grant_usage()` issues a specific set of grants: `USAGE ON SCHEMA df`,
-column-scoped table privileges, and `EXECUTE` on `df.http()` /
-`df.http_multipart()` only when `include_http => true`. Every other `df.*`
-function keeps PostgreSQL's default `EXECUTE` to `PUBLIC`, so **schema `USAGE`
-is the real access gate**. Granting `USAGE ON SCHEMA df` by hand therefore
-exposes the whole DSL surface at once; prefer `df.grant_usage()`.
-
-> **Note:** prior to v0.2.4 this helper ran a per-function grant loop over an
-> allowlist. That loop was removed in v0.2.4 (#242) as redundant.
+column-scoped table privileges, `EXECUTE` on `df.http()` / `df.http_multipart()`
+when `include_http => true`, and `EXECUTE` on `df.grant_usage()`,
+`df.revoke_usage()` and `df.metrics()` when `with_grant => true`. Those five
+functions are the only ones with `PUBLIC` `EXECUTE` revoked at install; every
+other `df.*` function keeps PostgreSQL's default, so **schema `USAGE` is the
+real access gate**. Granting `USAGE ON SCHEMA df` by hand therefore exposes the
+whole DSL surface at once; prefer `df.grant_usage()`.
 
 ### 3.5 Feature-flag interaction
 
@@ -360,20 +360,16 @@ is applied before any URL reaches a log line or an error string.
 
 | Component | Treatment |
 |-----------|-----------|
-| Scheme, host, port, path | Preserved, normalized per the WHATWG URL spec (host lowercased, default port dropped, empty path rendered as `/`) |
+| Scheme, host, port, path | Preserved. The URL is reparsed, so a logged line may be normalized (host lowercased, default port dropped) relative to what the workflow supplied. |
 | Query parameter *names* | Preserved — `sig` and `code` are not themselves secret, and keeping them makes a redacted line diagnosable |
-| Query parameter *values* | Replaced with `<redacted>`, except an allowlist of benign parameters (`api-version`, `comp`, `restype`) |
+| Query parameter *values* | Replaced with `<redacted>`, except an allowlist of benign parameters (`api-version`, `apiversion`, `comp`, `restype`) |
 | Bare query token with no `=` | Replaced whole — indistinguishable from a name |
 | `userinfo@` | Replaced with `<redacted>@`, keeping the host |
 | Fragment | Replaced whole |
 | Unparseable input | Replaced whole — redaction fails closed and never echoes back a string it could not parse |
 
-Parsing uses the `url` crate rather than hand-rolled string splitting, so IPv6
-authorities, percent-encoding, default ports and userinfo edge cases follow the
-spec. The query string is the one part still split on `&` and `=` directly:
-`Url::query_pairs` follows the form-urlencoded rules and reports a bare token
-(`?SEKRIT`) as the *name* of a valueless parameter, so rebuilding the query from
-those pairs would publish the token verbatim.
+Parsing uses the `url` crate, so IPv6 authorities, percent-encoding, default
+ports and userinfo follow the spec rather than ad-hoc string splitting.
 
 The same redaction is applied to the HTTP client's own error text, which
 interpolates the request URL into messages such as

--- a/docs/http-security.md
+++ b/docs/http-security.md
@@ -166,22 +166,25 @@ REVOKE EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) FROM PUBLIC
 ```
 
 When `df.grant_usage(role, include_http => false)` is called and the role still
-has effective HTTP access via the PUBLIC grant (or another inherited grant), a
-`WARNING` is emitted to signal that the revocation had no net effect.
+has effective HTTP access via the PUBLIC grant (or another inherited grant),
+that grant is left intact — `df.grant_usage()` is purely additive and never
+issues a `REVOKE`. Call `df.revoke_usage()` first to downgrade a role.
 
 ### 3.4 Admin function protection
 
 `df.grant_usage()` and `df.revoke_usage()` are admin-only functions.
 `EXECUTE` is revoked from `PUBLIC` at `CREATE EXTENSION` time, so only
-superusers can call them.
+superusers — and roles granted `with_grant => true` — can call them.
 
-> **Caution:** `df.grant_usage()` internally runs
-> `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df`, which temporarily includes
-> `df.grant_usage()` and `df.revoke_usage()` themselves before the function
-> immediately revokes them from the target role.  If an admin replicates the
-> blanket `GRANT` manually without the matching `REVOKE`s, the target role
-> will gain access to these admin helpers.  Always use `df.grant_usage()`
-> rather than hand-crafting the equivalent `GRANT` statements.
+`df.grant_usage()` issues a specific set of grants: `USAGE ON SCHEMA df`,
+column-scoped table privileges, and `EXECUTE` on `df.http()` /
+`df.http_multipart()` only when `include_http => true`. Every other `df.*`
+function keeps PostgreSQL's default `EXECUTE` to `PUBLIC`, so **schema `USAGE`
+is the real access gate**. Granting `USAGE ON SCHEMA df` by hand therefore
+exposes the whole DSL surface at once; prefer `df.grant_usage()`.
+
+> **Note:** prior to v0.2.4 this helper ran a per-function grant loop over an
+> allowlist. That loop was removed in v0.2.4 (#242) as redundant.
 
 ### 3.5 Feature-flag interaction
 
@@ -341,11 +344,43 @@ Every HTTP attempt (allowed or blocked) is logged via `ctx.trace_info` with:
 
 - `submitted_by` — the role that called `df.start()` at the time the node was
   created (captured as `current_user` in the DSL and stored in `FunctionNode`)
-- `url` — the requested URL
+- `url` — the requested URL, **redacted** (see below)
 - Block reason tag — `(scheme)`, `(allowlist)`, or `(ip)` in the log prefix
 
 Resolved IP addresses are **not** included in error messages or logs to avoid
 leaking internal network topology to potentially malicious users.
+
+### 7.1 URL redaction
+
+A URL is a credential carrier: an Azure SAS token lives entirely in the query
+string, and `?api-key=` / `?code=` are common elsewhere. The server log is a
+weaker boundary than the database — no RLS, no `pg_durable.retention_days`, and
+frequently a separate shipping and backup path — so `crate::redact::redact_url`
+is applied before any URL reaches a log line or an error string.
+
+| Component | Treatment |
+|-----------|-----------|
+| Scheme, host, port, path | Preserved |
+| Query parameter *names* | Preserved — `sig` and `code` are not themselves secret, and keeping them makes a redacted line diagnosable |
+| Query parameter *values* | Replaced with `<redacted>`, except an allowlist of benign parameters (`api-version`, `comp`, `restype`) |
+| Bare query token with no `=` | Replaced whole — indistinguishable from a name |
+| `userinfo@` | Replaced with `<redacted>@`, keeping the host |
+| Fragment | Replaced whole |
+| Unparseable input | Replaced whole — redaction fails closed and never echoes back a string it could not parse |
+
+The same redaction is applied to the HTTP client's own error text, which
+interpolates the request URL into messages such as
+`error sending request for url (...)`. This matters because activity errors are
+persisted to `df.nodes.error` and recorded in durable execution history, not
+just written to the log.
+
+Request headers and bodies are never logged.
+
+> **Not covered:** the response body. A workflow's final result is traced on
+> completion, and the full response envelope is stored in `df.nodes.result`. A
+> request whose *response* is a credential — reading a secret from Key Vault, or
+> an OAuth token endpoint — still persists that value. Response-side redaction
+> is tracked separately.
 
 ---
 

--- a/docs/http-security.md
+++ b/docs/http-security.md
@@ -358,9 +358,9 @@ shipping and backup path.
 | Component | Treatment |
 |-----------|-----------|
 | Scheme, host, port, path | Preserved. The URL is reparsed, so a logged line may be normalized (host lowercased, default port dropped) relative to what the workflow supplied. |
-| Query parameter *names* | Preserved — `sig` and `code` are not themselves secret, and keeping them makes a redacted line diagnosable |
-| Query parameter *values* | Nonempty values replaced with `<redacted>` |
-| Bare query token with no `=` | Replaced whole — indistinguishable from a name |
+| Query parameter *names* | Preserved except for ambiguous pairs below |
+| Query parameter *values* | Replaced with `<redacted>` |
+| Bare query tokens and pairs with empty or padding-only values | Replaced whole: `token`, `token=`, and `token==` can all be opaque credentials |
 | `userinfo@` | Replaced with `<redacted>@`, keeping the host |
 | Fragment | Replaced whole |
 | Unparseable input | Replaced whole — redaction fails closed and never echoes back a string it could not parse |
@@ -373,7 +373,7 @@ including response-body read failures. Explicitly reported request URLs are
 redacted as above. This matters because failed nodes store their error in
 `df.nodes.result` and durable execution history, not just in the log.
 
-Do not put credentials in paths or parameter names: those remain visible.
+Do not put credentials in paths or parameter names: those can remain visible.
 Request headers and bodies are not directly included in request traces, but an
 endpoint can echo them in its response.
 

--- a/docs/http-security.md
+++ b/docs/http-security.md
@@ -353,16 +353,16 @@ leaking internal network topology to potentially malicious users.
 ### 7.1 URL redaction
 
 A URL is a credential carrier: an Azure SAS token lives entirely in the query
-string, and `?api-key=` / `?code=` are common elsewhere. The server log is a
-weaker boundary than the database — no RLS, no `pg_durable.retention_days`, and
-frequently a separate shipping and backup path — so `crate::redact::redact_url`
-is applied before any URL reaches a log line or an error string.
+string, and `?api-key=` / `?code=` are common elsewhere. Worker request diagnostics
+redact these values before logging URLs or including them in errors. The server
+log has no RLS or `pg_durable.retention_days`, and frequently has a separate
+shipping and backup path.
 
 | Component | Treatment |
 |-----------|-----------|
 | Scheme, host, port, path | Preserved. The URL is reparsed, so a logged line may be normalized (host lowercased, default port dropped) relative to what the workflow supplied. |
 | Query parameter *names* | Preserved — `sig` and `code` are not themselves secret, and keeping them makes a redacted line diagnosable |
-| Query parameter *values* | Replaced with `<redacted>`, except an allowlist of benign parameters (`api-version`, `apiversion`, `comp`, `restype`) |
+| Query parameter *values* | Nonempty values replaced with `<redacted>` |
 | Bare query token with no `=` | Replaced whole — indistinguishable from a name |
 | `userinfo@` | Replaced with `<redacted>@`, keeping the host |
 | Fragment | Replaced whole |
@@ -371,19 +371,21 @@ is applied before any URL reaches a log line or an error string.
 Parsing uses the `url` crate, so IPv6 authorities, percent-encoding, default
 ports and userinfo follow the spec rather than ad-hoc string splitting.
 
-The same redaction is applied to the HTTP client's own error text, which
-interpolates the request URL into messages such as
-`error sending request for url (...)`. This matters because activity errors are
-persisted to `df.nodes.error` and recorded in durable execution history, not
-just written to the log.
+The HTTP client's attached request URL is removed before formatting its errors,
+including response-body read failures. Explicitly reported request URLs are
+redacted as above. This matters because failed nodes store their error in
+`df.nodes.result` and durable execution history, not just in the log.
 
-Request headers and bodies are never logged.
+Do not put credentials in paths or parameter names: those remain visible.
+Request headers and bodies are not directly included in request traces, but an
+endpoint can echo them in its response.
 
-> **Not covered:** the response body. A workflow's final result is traced on
-> completion, and the full response envelope is stored in `df.nodes.result`. A
-> request whose *response* is a credential — reading a secret from Key Vault, or
-> an OAuth token endpoint — still persists that value. Response-side redaction
-> is tracked separately.
+> **Not covered:** stored request inputs, response headers and response bodies.
+> A workflow's final result is logged, and response-body previews appear in 5xx
+> errors. A response containing a credential, including an echoed request URL or
+> a token returned by an endpoint, can still expose it in logs and stored results.
+> URL redaction does not make `df.vars` secret storage; see
+> [Variables and secrets](../USER_GUIDE.md#variables-and-secrets).
 
 ---
 
@@ -394,7 +396,7 @@ Request headers and bodies are never logged.
 | No EXECUTE privilege on df.http() | `Blocked: role '{role}' does not have EXECUTE privilege on df.http(). Grant EXECUTE ON FUNCTION df.http(text,text,text,jsonb,integer) TO {role} to allow HTTP requests.` |
 | HTTP disabled (no feature) | `Blocked: outbound HTTP requests are disabled. Rebuild with the 'http-allow-azure-domains' Cargo feature to enable them.` |
 | Plaintext HTTP in a restricted build | `Blocked: plaintext HTTP is not permitted in restricted builds. HTTPS is required.` |
-| Unsupported scheme | `Blocked: unsupported URL scheme '{scheme}'. Only {allowed} is allowed.` where `{allowed}` is `https` in restricted builds or `http and https` with `http-allow-all` |
+| Unsupported scheme | `Blocked: unsupported URL scheme. Only {allowed} is allowed.` where `{allowed}` is `https` in restricted builds or `http and https` with `http-allow-all` |
 | Bare IP address | `Blocked: requests to bare IP addresses are not permitted. Use an approved Azure service hostname instead.` |
 | Non-allowed domain | `Blocked: '{host}' is not in the allowed endpoint list. Only requests to approved Azure service domains are permitted.` |
 | Blocked IP (literal or DNS) | `Blocked: the resolved IP address for '{host}' is in a restricted range. df.http() cannot access private or internal network addresses.` |

--- a/docs/http-security.md
+++ b/docs/http-security.md
@@ -166,25 +166,22 @@ REVOKE EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) FROM PUBLIC
 ```
 
 When `df.grant_usage(role, include_http => false)` is called and the role still
-has effective HTTP access via the PUBLIC grant (or another inherited grant),
-that grant is left intact — `df.grant_usage()` is purely additive and never
-issues a `REVOKE`. Call `df.revoke_usage()` first to downgrade a role.
+has effective HTTP access via the PUBLIC grant (or another inherited grant), a
+`WARNING` is emitted to signal that the revocation had no net effect.
 
 ### 3.4 Admin function protection
 
 `df.grant_usage()` and `df.revoke_usage()` are admin-only functions.
 `EXECUTE` is revoked from `PUBLIC` at `CREATE EXTENSION` time, so only
-superusers can call them — plus any role an admin delegated to with
-`df.grant_usage(role, with_grant => true)`.
+superusers can call them.
 
-`df.grant_usage()` issues a specific set of grants: `USAGE ON SCHEMA df`,
-column-scoped table privileges, `EXECUTE` on `df.http()` / `df.http_multipart()`
-when `include_http => true`, and `EXECUTE` on `df.grant_usage()`,
-`df.revoke_usage()` and `df.metrics()` when `with_grant => true`. Those five
-functions are the only ones with `PUBLIC` `EXECUTE` revoked at install; every
-other `df.*` function keeps PostgreSQL's default, so **schema `USAGE` is the
-real access gate**. Granting `USAGE ON SCHEMA df` by hand therefore exposes the
-whole DSL surface at once; prefer `df.grant_usage()`.
+> **Caution:** `df.grant_usage()` internally runs
+> `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA df`, which temporarily includes
+> `df.grant_usage()` and `df.revoke_usage()` themselves before the function
+> immediately revokes them from the target role.  If an admin replicates the
+> blanket `GRANT` manually without the matching `REVOKE`s, the target role
+> will gain access to these admin helpers.  Always use `df.grant_usage()`
+> rather than hand-crafting the equivalent `GRANT` statements.
 
 ### 3.5 Feature-flag interaction
 

--- a/src/activities/execute_http.rs
+++ b/src/activities/execute_http.rs
@@ -100,6 +100,12 @@ pub async fn execute(
         .as_deref()
         .ok_or("Blocked: HTTP node has no submitted_by \u{2014} cannot verify privilege")?;
 
+    // Every log line and error below reports this, never `config.url`: an Azure
+    // SAS token lives entirely in the query string, and both sinks outlive the
+    // instance (the server log has no retention bound; errors are persisted to
+    // df.nodes.error and into duroxide history).
+    let safe_url = crate::redact::redact_url(&config.url);
+
     // Validation chain — order is security-critical:
     //   0. Privilege: submitted_by must hold EXECUTE on df.http(). Closes the
     //                 bypass path where a user crafts raw Durofut JSON and passes
@@ -121,8 +127,7 @@ pub async fn execute(
         .await
         .inspect_err(|_| {
             ctx.trace_info(format!(
-                "HTTP BLOCKED (privilege) url={} submitted_by={audit_user}",
-                config.url
+                "HTTP BLOCKED (privilege) url={safe_url} submitted_by={audit_user}"
             ));
         })?;
 
@@ -136,23 +141,21 @@ pub async fn execute(
     // --- Scheme validation (always enforced, regardless of feature flag) ---
     crate::ssrf::validate_scheme(&request_url).inspect_err(|_| {
         ctx.trace_info(format!(
-            "HTTP BLOCKED (scheme) url={} submitted_by={audit_user}",
-            config.url
+            "HTTP BLOCKED (scheme) url={safe_url} submitted_by={audit_user}"
         ));
     })?;
 
     // --- Azure endpoint allow-list (blocks all bare IPs + non-Azure domains) ---
     crate::ssrf::validate_allowlist(&request_url).inspect_err(|_| {
         ctx.trace_info(format!(
-            "HTTP BLOCKED (allowlist) url={} submitted_by={audit_user}",
-            config.url
+            "HTTP BLOCKED (allowlist) url={safe_url} submitted_by={audit_user}"
         ));
     })?;
 
     let start = std::time::Instant::now();
     ctx.trace_info(format!(
-        "HTTP {} {} submitted_by={audit_user}",
-        config.method, config.url
+        "HTTP {} {safe_url} submitted_by={audit_user}",
+        config.method
     ));
 
     // Build client with SSRF-safe resolver (when feature enabled) and timeout
@@ -192,10 +195,9 @@ pub async fn execute(
         // a structured audit log (mirrors the scheme-block log above).
         if crate::ssrf::is_ssrf_block_error(&err_string) {
             ctx.trace_info(format!(
-                "HTTP BLOCKED (ip) url={} submitted_by={audit_user}",
-                config.url
+                "HTTP BLOCKED (ip) url={safe_url} submitted_by={audit_user}"
             ));
-            return err_string;
+            return crate::redact::redact_urls_in(&err_string);
         }
 
         // Try to extract status code from error if available
@@ -204,21 +206,22 @@ pub async fn execute(
             .map(|s| format!(" (HTTP {})", s.as_u16()))
             .unwrap_or_default();
 
+        // reqwest's Display interpolates the request URL, so the error text is
+        // scrubbed as well as the URL we format ourselves.
+        let detail = crate::redact::redact_urls_in(&err_string);
+
         if e.is_timeout() {
             format!(
                 "HTTP timeout after {}s{}: {}",
-                config.timeout_seconds, status_info, config.url
+                config.timeout_seconds, status_info, safe_url
             )
         } else if e.is_connect() {
-            format!(
-                "HTTP connection failed{}: {} - {}",
-                status_info, config.url, e
-            )
+            format!("HTTP connection failed{status_info}: {safe_url} - {detail}")
         } else if e.is_status() {
             // Error due to HTTP status code
-            format!("HTTP request failed{}: {} - {}", status_info, config.url, e)
+            format!("HTTP request failed{status_info}: {safe_url} - {detail}")
         } else {
-            format!("HTTP request failed{}: {} - {}", status_info, config.url, e)
+            format!("HTTP request failed{status_info}: {safe_url} - {detail}")
         }
     })?;
 
@@ -251,9 +254,8 @@ pub async fn execute(
     // Fail on 5xx server errors (transient, should retry)
     if status.is_server_error() {
         return Err(format!(
-            "HTTP {} {} returned {}: {}",
+            "HTTP {} {safe_url} returned {}: {}",
             config.method,
-            config.url,
             status_code,
             response_body.error_preview()
         ));

--- a/src/activities/execute_http.rs
+++ b/src/activities/execute_http.rs
@@ -103,7 +103,7 @@ pub async fn execute(
     // Every log line and error below reports this, never `config.url`: an Azure
     // SAS token lives entirely in the query string, and both sinks outlive the
     // instance (the server log has no retention bound; errors are persisted to
-    // df.nodes.error and into duroxide history).
+    // df.nodes.result and into duroxide history).
     let safe_url = crate::redact::redact_url(&config.url);
 
     // Validation chain — order is security-critical:
@@ -133,8 +133,7 @@ pub async fn execute(
 
     let request_url = crate::ssrf::parse_request_url(&config.url).inspect_err(|_| {
         ctx.trace_info(format!(
-            "HTTP BLOCKED (malformed) url={} submitted_by={audit_user}",
-            config.url
+            "HTTP BLOCKED (malformed) url={safe_url} submitted_by={audit_user}"
         ));
     })?;
 
@@ -189,6 +188,7 @@ pub async fn execute(
 
     // Execute request
     let response = request.send().await.map_err(|e| {
+        let e = e.without_url();
         let err_string = e.to_string();
 
         // Detect SSRF IP-blocklist rejections from the resolver and emit
@@ -197,7 +197,7 @@ pub async fn execute(
             ctx.trace_info(format!(
                 "HTTP BLOCKED (ip) url={safe_url} submitted_by={audit_user}"
             ));
-            return crate::redact::redact_urls_in(&err_string);
+            return err_string;
         }
 
         // Try to extract status code from error if available
@@ -206,22 +206,15 @@ pub async fn execute(
             .map(|s| format!(" (HTTP {})", s.as_u16()))
             .unwrap_or_default();
 
-        // reqwest's Display interpolates the request URL, so the error text is
-        // scrubbed as well as the URL we format ourselves.
-        let detail = crate::redact::redact_urls_in(&err_string);
-
         if e.is_timeout() {
             format!(
                 "HTTP timeout after {}s{}: {}",
                 config.timeout_seconds, status_info, safe_url
             )
         } else if e.is_connect() {
-            format!("HTTP connection failed{status_info}: {safe_url} - {detail}")
-        } else if e.is_status() {
-            // Error due to HTTP status code
-            format!("HTTP request failed{status_info}: {safe_url} - {detail}")
+            format!("HTTP connection failed{status_info}: {safe_url} - {err_string}")
         } else {
-            format!("HTTP request failed{status_info}: {safe_url} - {detail}")
+            format!("HTTP request failed{status_info}: {safe_url} - {err_string}")
         }
     })?;
 

--- a/src/activities/execute_multipart.rs
+++ b/src/activities/execute_multipart.rs
@@ -91,6 +91,9 @@ pub async fn execute(
         "Blocked: HTTP_MULTIPART node has no submitted_by \u{2014} cannot verify privilege",
     )?;
 
+    // See execute_http: never log or return `config.url` itself.
+    let safe_url = crate::redact::redact_url(&config.url);
+
     // Validation chain — order is security-critical and mirrors execute_http:
     //   0. Privilege: submitted_by must hold EXECUTE on df.http_multipart().
     //   1. Scheme:    blocks file://, gopher://, etc.
@@ -103,8 +106,7 @@ pub async fn execute(
         .await
         .inspect_err(|_| {
             ctx.trace_info(format!(
-                "HTTP_MULTIPART BLOCKED (privilege) url={} submitted_by={audit_user}",
-                config.url
+                "HTTP_MULTIPART BLOCKED (privilege) url={safe_url} submitted_by={audit_user}"
             ));
         })?;
 
@@ -118,24 +120,21 @@ pub async fn execute(
     // --- Scheme validation (always enforced) ---
     crate::ssrf::validate_scheme(&request_url).inspect_err(|_| {
         ctx.trace_info(format!(
-            "HTTP_MULTIPART BLOCKED (scheme) url={} submitted_by={audit_user}",
-            config.url
+            "HTTP_MULTIPART BLOCKED (scheme) url={safe_url} submitted_by={audit_user}"
         ));
     })?;
 
     // --- Azure endpoint allow-list ---
     crate::ssrf::validate_allowlist(&request_url).inspect_err(|_| {
         ctx.trace_info(format!(
-            "HTTP_MULTIPART BLOCKED (allowlist) url={} submitted_by={audit_user}",
-            config.url
+            "HTTP_MULTIPART BLOCKED (allowlist) url={safe_url} submitted_by={audit_user}"
         ));
     })?;
 
     let start = std::time::Instant::now();
     ctx.trace_info(format!(
-        "HTTP_MULTIPART {} {} ({} parts) submitted_by={audit_user}",
+        "HTTP_MULTIPART {} {safe_url} ({} parts) submitted_by={audit_user}",
         config.method,
-        config.url,
         config.parts.len()
     ));
 
@@ -198,10 +197,9 @@ pub async fn execute(
         // Detect SSRF IP-blocklist rejections from the resolver.
         if crate::ssrf::is_ssrf_block_error(&err_string) {
             ctx.trace_info(format!(
-                "HTTP_MULTIPART BLOCKED (ip) url={} submitted_by={audit_user}",
-                config.url
+                "HTTP_MULTIPART BLOCKED (ip) url={safe_url} submitted_by={audit_user}"
             ));
-            return err_string;
+            return crate::redact::redact_urls_in(&err_string);
         }
 
         let status_info = e
@@ -209,18 +207,18 @@ pub async fn execute(
             .map(|s| format!(" (HTTP {})", s.as_u16()))
             .unwrap_or_default();
 
+        // reqwest's Display interpolates the request URL — scrub it too.
+        let detail = crate::redact::redact_urls_in(&err_string);
+
         if e.is_timeout() {
             format!(
                 "HTTP timeout after {}s{}: {}",
-                config.timeout_seconds, status_info, config.url
+                config.timeout_seconds, status_info, safe_url
             )
         } else if e.is_connect() {
-            format!(
-                "HTTP connection failed{}: {} - {}",
-                status_info, config.url, e
-            )
+            format!("HTTP connection failed{status_info}: {safe_url} - {detail}")
         } else {
-            format!("HTTP request failed{}: {} - {}", status_info, config.url, e)
+            format!("HTTP request failed{status_info}: {safe_url} - {detail}")
         }
     })?;
 
@@ -253,9 +251,8 @@ pub async fn execute(
     // Fail on 5xx server errors (transient, should retry)
     if status.is_server_error() {
         return Err(format!(
-            "HTTP_MULTIPART {} {} returned {}: {}",
+            "HTTP_MULTIPART {} {safe_url} returned {}: {}",
             config.method,
-            config.url,
             status_code,
             response_body.error_preview()
         ));

--- a/src/activities/execute_multipart.rs
+++ b/src/activities/execute_multipart.rs
@@ -112,8 +112,7 @@ pub async fn execute(
 
     let request_url = crate::ssrf::parse_request_url(&config.url).inspect_err(|_| {
         ctx.trace_info(format!(
-            "HTTP_MULTIPART BLOCKED (malformed) url={} submitted_by={audit_user}",
-            config.url
+            "HTTP_MULTIPART BLOCKED (malformed) url={safe_url} submitted_by={audit_user}"
         ));
     })?;
 
@@ -192,6 +191,7 @@ pub async fn execute(
 
     // Execute request
     let response = request.multipart(form).send().await.map_err(|e| {
+        let e = e.without_url();
         let err_string = e.to_string();
 
         // Detect SSRF IP-blocklist rejections from the resolver.
@@ -199,7 +199,7 @@ pub async fn execute(
             ctx.trace_info(format!(
                 "HTTP_MULTIPART BLOCKED (ip) url={safe_url} submitted_by={audit_user}"
             ));
-            return crate::redact::redact_urls_in(&err_string);
+            return err_string;
         }
 
         let status_info = e
@@ -207,18 +207,15 @@ pub async fn execute(
             .map(|s| format!(" (HTTP {})", s.as_u16()))
             .unwrap_or_default();
 
-        // reqwest's Display interpolates the request URL — scrub it too.
-        let detail = crate::redact::redact_urls_in(&err_string);
-
         if e.is_timeout() {
             format!(
                 "HTTP timeout after {}s{}: {}",
                 config.timeout_seconds, status_info, safe_url
             )
         } else if e.is_connect() {
-            format!("HTTP connection failed{status_info}: {safe_url} - {detail}")
+            format!("HTTP connection failed{status_info}: {safe_url} - {err_string}")
         } else {
-            format!("HTTP request failed{status_info}: {safe_url} - {detail}")
+            format!("HTTP request failed{status_info}: {safe_url} - {err_string}")
         }
     })?;
 

--- a/src/activities/execute_sql.rs
+++ b/src/activities/execute_sql.rs
@@ -193,14 +193,18 @@ pub async fn execute(
         serde_json::from_str(&input_json).map_err(|e| format!("Invalid execute_sql input: {e}"))?;
 
     ctx.trace_info(format!(
-        "Executing SQL as '{}'{}: {}",
+        "Executing SQL as '{}'{}{}",
         input.submitted_by,
         input
             .database
             .as_ref()
             .map(|db| format!(" in database '{db}'"))
             .unwrap_or_default(),
-        input.query
+        if crate::types::log_workflow_sql_enabled() {
+            format!(": {}", input.query)
+        } else {
+            String::new()
+        }
     ));
 
     // Acquire a permit from the user-connection semaphore. The permit is held

--- a/src/activities/http_response.rs
+++ b/src/activities/http_response.rs
@@ -261,7 +261,10 @@ mod tests {
                 .unwrap();
             let error = read_body(response).await.err().unwrap();
             server.join().unwrap();
-            assert!(error.starts_with("Failed to read response body:"), "{error}");
+            assert!(
+                error.starts_with("Failed to read response body:"),
+                "{error}"
+            );
             assert!(error.contains("error decoding response body"), "{error}");
             assert!(!error.contains("FIRST"), "{error}");
             assert!(!error.contains("SEKRIT"), "{error}");

--- a/src/activities/http_response.rs
+++ b/src/activities/http_response.rs
@@ -172,14 +172,14 @@ pub async fn read_body(response: reqwest::Response) -> Result<ResponseBody, Stri
         let text = response
             .text()
             .await
-            .map_err(|e| format!("Failed to read response body: {e}"))?;
+            .map_err(|e| format!("Failed to read response body: {}", e.without_url()))?;
         return Ok(ResponseBody::text(text));
     }
 
     let bytes = response
         .bytes()
         .await
-        .map_err(|e| format!("Failed to read response body: {e}"))?;
+        .map_err(|e| format!("Failed to read response body: {}", e.without_url()))?;
     Ok(match text_from_bytes(&bytes) {
         Some(text) => ResponseBody::text(text),
         None => ResponseBody::base64(&bytes),
@@ -221,6 +221,52 @@ pub fn build_envelope(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn response_read_errors_omit_credentials() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::net::TcpListener;
+        use std::time::Duration;
+
+        for content_type in ["text/plain", "application/octet-stream"] {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let address = listener.local_addr().unwrap();
+            let server = std::thread::spawn(move || {
+                let (connection, _) = listener.accept().unwrap();
+                connection
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                let mut connection = BufReader::new(connection);
+                loop {
+                    let mut line = String::new();
+                    if connection.read_line(&mut line).unwrap() == 0 || line == "\r\n" {
+                        break;
+                    }
+                }
+                write!(
+                    connection.get_mut(),
+                    "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: 100\r\nConnection: close\r\n\r\nshort"
+                )
+                .unwrap();
+            });
+
+            let response = reqwest::Client::builder()
+                .no_proxy()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .unwrap()
+                .get(format!("http://{address}/?sig=FIRST,(LAST)#SEKRIT"))
+                .send()
+                .await
+                .unwrap();
+            let error = read_body(response).await.err().unwrap();
+            server.join().unwrap();
+            assert_eq!(
+                error,
+                "Failed to read response body: error decoding response body"
+            );
+        }
+    }
 
     #[test]
     fn classifies_text_types_as_textual() {

--- a/src/activities/http_response.rs
+++ b/src/activities/http_response.rs
@@ -261,10 +261,10 @@ mod tests {
                 .unwrap();
             let error = read_body(response).await.err().unwrap();
             server.join().unwrap();
-            assert_eq!(
-                error,
-                "Failed to read response body: error decoding response body"
-            );
+            assert!(error.starts_with("Failed to read response body:"), "{error}");
+            assert!(error.contains("error decoding response body"), "{error}");
+            assert!(!error.contains("FIRST"), "{error}");
+            assert!(!error.contains("SEKRIT"), "{error}");
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,15 @@ pub static RETENTION_DAYS: GucSetting<i32> = GucSetting::<i32>::new(30);
 /// terminal instances and reclaims orphaned engine records. `0` disables it.
 pub static RECONCILE_INTERVAL: GucSetting<i32> = GucSetting::<i32>::new(3600);
 
+/// When `false`, the worker log omits the SQL text of executed workflow nodes.
+/// The text is logged fully substituted, so a `{var}` holding a credential is
+/// written to the server log in cleartext. Unlike a query string, SQL cannot be
+/// redacted heuristically, so this is on/off rather than a masking rule.
+///
+/// Postmaster context: it is read in the background worker, which never calls
+/// `ProcessConfigFile`, so a reload would not reach it.
+pub static LOG_WORKFLOW_SQL: GucSetting<bool> = GucSetting::<bool>::new(true);
+
 // Module declarations
 pub mod activities;
 pub mod client;
@@ -61,6 +70,7 @@ pub mod explain;
 pub mod monitoring;
 pub mod node_status;
 pub mod orchestrations;
+pub mod redact;
 pub mod registry;
 pub mod ssrf;
 pub mod types;
@@ -226,6 +236,15 @@ pub extern "C-unwind" fn _PG_init() {
         &RECONCILE_INTERVAL,
         0,
         86400,
+        GucContext::Postmaster,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"pg_durable.log_workflow_sql",
+        c"Log the SQL text of executed workflow nodes to the worker log",
+        c"The SQL is logged after variable substitution, so any credential held in a df.vars variable and spliced into a query is written to the PostgreSQL server log in cleartext. Set to off in environments where the server log is less protected than the database. Turning this off also removes the primary forensic record of what workflows executed. Requires server restart to change.",
+        &LOG_WORKFLOW_SQL,
         GucContext::Postmaster,
         GucFlags::default(),
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ pub extern "C-unwind" fn _PG_init() {
     GucRegistry::define_bool_guc(
         c"pg_durable.log_workflow_sql",
         c"Log the SQL text of executed workflow nodes to the worker log",
-        c"The SQL is logged after variable substitution, so any credential held in a df.vars variable and spliced into a query is written to the PostgreSQL server log in cleartext. Set to off in environments where the server log is less protected than the database. Turning this off also removes the primary forensic record of what workflows executed. Requires server restart to change.",
+        c"SQL is logged after variable substitution. Turning this off omits statement text from worker execution traces, but does not suppress errors, results, or PostgreSQL statement logging. Requires server restart to change.",
         &LOG_WORKFLOW_SQL,
         GucContext::Postmaster,
         GucFlags::default(),

--- a/src/orchestrations/execute_function_graph.rs
+++ b/src/orchestrations/execute_function_graph.rs
@@ -468,6 +468,8 @@ pub async fn execute(ctx: OrchestrationContext, input_json: String) -> Result<St
 
     match &function_result {
         Ok(result) => {
+            // FIXME: This might be tracing sensitive data. Should it be fixed?
+            // It's a larger behavioral change than the rest of this work.
             ctx.trace_info(format!("Function completed with result: {result}"));
             finalize_instance_status(&ctx, &input.instance_id, "completed").await;
         }
@@ -777,7 +779,10 @@ async fn execute_sql_node(
         .ok_or_else(|| format!("SQL node {node_id} has no query"))?;
 
     let final_query = substitute_all(query, results, &exec_ctx.vars, sys_vars)?;
-    ctx.trace_info(format!("Executing SQL: {final_query}"));
+    // The substituted text is not traced here: the execute_sql activity logs it
+    // under pg_durable.log_workflow_sql, and an orchestration must not read a
+    // GUC to decide what to emit.
+    ctx.trace_info(format!("Executing SQL node {node_id}"));
 
     let input = serde_json::json!({
         "query": final_query,
@@ -1751,7 +1756,12 @@ async fn execute_http_node(
     let final_config = config.to_string();
     let url = config["url"].as_str().unwrap_or("?");
     let method = config["method"].as_str().unwrap_or("POST");
-    ctx.trace_info(format!("Executing HTTP {method} {url}"));
+    // Substitution has already run, so `url` may carry a SAS token or api-key.
+    // redact_url is pure, so tracing it stays replay-deterministic.
+    ctx.trace_info(format!(
+        "Executing HTTP {method} {}",
+        crate::redact::redact_url(url)
+    ));
 
     let result = ctx
         .schedule_activity(activities::execute_http::NAME, final_config)
@@ -1850,7 +1860,10 @@ async fn execute_http_multipart_node(
     let final_config = config.to_string();
     let url = config["url"].as_str().unwrap_or("?");
     let method = config["method"].as_str().unwrap_or("POST");
-    ctx.trace_info(format!("Executing HTTP_MULTIPART {method} {url}"));
+    ctx.trace_info(format!(
+        "Executing HTTP_MULTIPART {method} {}",
+        crate::redact::redact_url(url)
+    ));
 
     let result = ctx
         .schedule_activity(activities::execute_multipart::NAME, final_config)

--- a/src/orchestrations/execute_function_graph.rs
+++ b/src/orchestrations/execute_function_graph.rs
@@ -468,8 +468,7 @@ pub async fn execute(ctx: OrchestrationContext, input_json: String) -> Result<St
 
     match &function_result {
         Ok(result) => {
-            // FIXME: This might be tracing sensitive data. Should it be fixed?
-            // It's a larger behavioral change than the rest of this work.
+            // Logs the final return value (may contain sensitive data; see USER_GUIDE.md#what-reaches-the-server-log).
             ctx.trace_info(format!("Function completed with result: {result}"));
             finalize_instance_status(&ctx, &input.instance_id, "completed").await;
         }

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -1,0 +1,315 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the PostgreSQL License.
+
+//! Redaction of credential-bearing text before it reaches a log or an error.
+//!
+//! A URL is a credential carrier: Azure SAS tokens live entirely in the query
+//! string, and `?api-key=`/`?code=` are common elsewhere. The worker's tracing
+//! subscriber writes at `info` by default (see `worker::init_tracing`), so an
+//! unredacted URL lands in the PostgreSQL server log in cleartext — a sink with
+//! no RLS, no `pg_durable.retention_days`, and often a different backup path
+//! than the database itself. Error strings are worse still: they are persisted
+//! to `df.nodes.error` and into duroxide history.
+//!
+//! Redaction is deliberately lossy and fails closed: anything that cannot be
+//! parsed as a URL is replaced wholesale rather than echoed back.
+
+/// Stand-in for any elided value. Deliberately not a fixed-width mask, so the
+/// length of the original is not disclosed.
+pub const REDACTED: &str = "<redacted>";
+
+/// Query parameters whose values carry no credential and are worth keeping for
+/// diagnosis. Matched case-insensitively against the parameter name.
+const SAFE_QUERY_PARAMS: &[&str] = &["api-version", "apiversion", "comp", "restype"];
+
+/// Characters that cannot appear inside a URL, used to find where an embedded
+/// URL ends when scanning free-form text.
+///
+/// `{` and `}` are deliberately absent: `${secret:name}` markers and `{var}`
+/// placeholders appear in unsubstituted URLs and are not credentials, so
+/// keeping them intact makes the redacted output far easier to read.
+const URL_TERMINATORS: &[char] = &['"', '\'', '<', '>', '\\', '^', '`', '|', '(', ')', ','];
+
+fn is_safe_query_param(name: &str) -> bool {
+    SAFE_QUERY_PARAMS
+        .iter()
+        .any(|safe| name.eq_ignore_ascii_case(safe))
+}
+
+/// Redact the credential-bearing parts of a single URL.
+///
+/// Preserved: scheme, host, port, path. Elided: userinfo, every query-parameter
+/// value except [`SAFE_QUERY_PARAMS`], and the fragment.
+///
+/// Parameter *names* are preserved — `sig`, `code` and friends are not secret,
+/// and keeping them makes a redacted log line diagnosable. A bare parameter with
+/// no `=` is elided whole, because a lone token is indistinguishable from a name.
+pub fn redact_url(url: &str) -> String {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        // Not a URL shape we recognise — never echo it back.
+        return REDACTED.to_string();
+    };
+
+    // The authority ends at the first '/', '?' or '#'. Splitting on all three
+    // matters: `https://host?x=1` and `https://host#f` have no path at all.
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    let after_authority = &rest[authority_end..];
+
+    let mut out = String::with_capacity(url.len());
+    out.push_str(scheme);
+    out.push_str("://");
+
+    // userinfo may be `user:password`; keep only the fact that one was present.
+    // rfind, not find: a password may itself contain an encoded '@'.
+    match authority.rfind('@') {
+        Some(at) => {
+            out.push_str(REDACTED);
+            out.push('@');
+            out.push_str(&authority[at + 1..]);
+        }
+        None => out.push_str(authority),
+    }
+
+    let path_end = after_authority
+        .find(['?', '#'])
+        .unwrap_or(after_authority.len());
+    out.push_str(&after_authority[..path_end]);
+
+    let tail = &after_authority[path_end..];
+    let mut query = "";
+    let mut has_fragment = false;
+    if let Some(after_question) = tail.strip_prefix('?') {
+        match after_question.find('#') {
+            Some(hash) => {
+                query = &after_question[..hash];
+                has_fragment = true;
+            }
+            None => query = after_question,
+        }
+    } else if tail.starts_with('#') {
+        has_fragment = true;
+    }
+
+    if !query.is_empty() {
+        out.push('?');
+        for (i, pair) in query.split('&').enumerate() {
+            if i > 0 {
+                out.push('&');
+            }
+            match pair.split_once('=') {
+                // An empty value has nothing to elide, and leaving it alone is
+                // what makes redaction idempotent: re-redacting `sig=<redacted>`
+                // must not append a second marker.
+                Some((_, "")) => out.push_str(pair),
+                Some((name, _)) if is_safe_query_param(name) => out.push_str(pair),
+                Some((name, _)) => {
+                    out.push_str(name);
+                    out.push('=');
+                    out.push_str(REDACTED);
+                }
+                None => out.push_str(REDACTED),
+            }
+        }
+    }
+
+    if has_fragment {
+        out.push('#');
+        out.push_str(REDACTED);
+    }
+
+    out
+}
+
+/// Redact every URL embedded in free-form text.
+///
+/// Needed because `reqwest::Error`'s `Display` interpolates the request URL, so
+/// wrapping a transport error without scrubbing it would reintroduce the very
+/// query string [`redact_url`] was applied to remove.
+pub fn redact_urls_in(text: &str) -> String {
+    if !text.contains("://") {
+        return text.to_string();
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+
+    while let Some(sep) = rest.find("://") {
+        // Walk back over the scheme, which must be alphanumeric with `+-.`.
+        let scheme_start = rest[..sep]
+            .rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.'))
+            .map_or(0, |i| i + 1);
+
+        if scheme_start == sep {
+            // `://` with no scheme in front of it — not a URL.
+            out.push_str(&rest[..sep + 3]);
+            rest = &rest[sep + 3..];
+            continue;
+        }
+
+        out.push_str(&rest[..scheme_start]);
+
+        let candidate = &rest[scheme_start..];
+        let end = candidate
+            .find(|c: char| c.is_whitespace() || URL_TERMINATORS.contains(&c))
+            .unwrap_or(candidate.len());
+
+        out.push_str(&redact_url(&candidate[..end]));
+        rest = &candidate[end..];
+    }
+
+    out.push_str(rest);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_sas_token_query_string() {
+        let redacted = redact_url(
+            "https://acct.blob.core.windows.net/c/b?sv=2022-11-02&ss=b&sig=abc%2Fdef%3D",
+        );
+        assert_eq!(
+            redacted,
+            "https://acct.blob.core.windows.net/c/b?sv=<redacted>&ss=<redacted>&sig=<redacted>"
+        );
+        assert!(!redacted.contains("abc"));
+    }
+
+    #[test]
+    fn keeps_safe_query_params() {
+        assert_eq!(
+            redact_url("https://v.vault.azure.net/secrets/s?api-version=7.4&code=SEKRIT"),
+            "https://v.vault.azure.net/secrets/s?api-version=7.4&code=<redacted>"
+        );
+    }
+
+    #[test]
+    fn safe_query_param_match_is_case_insensitive() {
+        assert_eq!(
+            redact_url("https://h/p?API-Version=7.4"),
+            "https://h/p?API-Version=7.4"
+        );
+    }
+
+    #[test]
+    fn preserves_scheme_host_port_and_path() {
+        assert_eq!(
+            redact_url("https://host.example.com:8443/a/b/c"),
+            "https://host.example.com:8443/a/b/c"
+        );
+    }
+
+    #[test]
+    fn redacts_userinfo_but_keeps_host() {
+        assert_eq!(
+            redact_url("https://user:pa%40ss@host.example.com/p"),
+            "https://<redacted>@host.example.com/p"
+        );
+    }
+
+    #[test]
+    fn redacts_fragment() {
+        assert_eq!(
+            redact_url("https://h/p#access_token=SEKRIT"),
+            "https://h/p#<redacted>"
+        );
+        assert_eq!(
+            redact_url("https://h/p?a=1#access_token=SEKRIT"),
+            "https://h/p?a=<redacted>#<redacted>"
+        );
+    }
+
+    #[test]
+    fn redacts_bare_query_token_whole() {
+        assert_eq!(redact_url("https://h/p?SEKRIT"), "https://h/p?<redacted>");
+    }
+
+    #[test]
+    fn handles_bracketed_ipv6_authority() {
+        assert_eq!(
+            redact_url("http://[2001:db8::1]:8080/p?k=v"),
+            "http://[2001:db8::1]:8080/p?k=<redacted>"
+        );
+    }
+
+    #[test]
+    fn handles_authority_only_urls() {
+        assert_eq!(redact_url("https://host"), "https://host");
+        assert_eq!(redact_url("https://host?k=v"), "https://host?k=<redacted>");
+        assert_eq!(redact_url("https://host#f"), "https://host#<redacted>");
+        assert_eq!(redact_url("https://host/"), "https://host/");
+    }
+
+    #[test]
+    fn empty_query_does_not_emit_question_mark() {
+        assert_eq!(redact_url("https://h/p?"), "https://h/p");
+    }
+
+    #[test]
+    fn empty_parameter_value_is_left_alone() {
+        assert_eq!(
+            redact_url("https://h/p?a=&b=SEKRIT"),
+            "https://h/p?a=&b=<redacted>"
+        );
+    }
+
+    #[test]
+    fn fails_closed_on_non_url_input() {
+        assert_eq!(redact_url(""), REDACTED);
+        assert_eq!(redact_url("not a url"), REDACTED);
+        assert_eq!(redact_url("/relative/path?sig=SEKRIT"), REDACTED);
+    }
+
+    #[test]
+    fn leaves_placeholders_readable() {
+        assert_eq!(
+            redact_url("https://{kv_host}/secrets/{name}?api-version=7.4"),
+            "https://{kv_host}/secrets/{name}?api-version=7.4"
+        );
+    }
+
+    #[test]
+    fn redacts_url_embedded_in_error_text() {
+        let scrubbed = redact_urls_in(
+            "error sending request for url (https://h/p?sig=SEKRIT): connection closed",
+        );
+        assert_eq!(
+            scrubbed,
+            "error sending request for url (https://h/p?sig=<redacted>): connection closed"
+        );
+        assert!(!scrubbed.contains("SEKRIT"));
+    }
+
+    #[test]
+    fn redacts_every_url_in_text() {
+        let scrubbed = redact_urls_in("from https://a/x?k=S1 to https://b/y?k=S2 failed");
+        assert!(!scrubbed.contains("S1"));
+        assert!(!scrubbed.contains("S2"));
+        assert_eq!(
+            scrubbed,
+            "from https://a/x?k=<redacted> to https://b/y?k=<redacted> failed"
+        );
+    }
+
+    #[test]
+    fn leaves_text_without_urls_untouched() {
+        assert_eq!(redact_urls_in("plain error, no url"), "plain error, no url");
+        assert_eq!(redact_urls_in(""), "");
+    }
+
+    #[test]
+    fn tolerates_bare_scheme_separator() {
+        assert_eq!(redact_urls_in("weird :// text"), "weird :// text");
+    }
+
+    #[test]
+    fn redaction_is_idempotent() {
+        let once = redact_url("https://h/p?sig=SEKRIT");
+        assert_eq!(redact_url(&once), once);
+        let once_in_text = redact_urls_in("url (https://h/p?sig=SEKRIT)");
+        assert_eq!(redact_urls_in(&once_in_text), once_in_text);
+    }
+}

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -14,6 +14,8 @@
 //! Redaction is deliberately lossy and fails closed: anything that cannot be
 //! parsed as a URL is replaced wholesale rather than echoed back.
 
+use url::Url;
+
 /// Stand-in for any elided value. Deliberately not a fixed-width mask, so the
 /// length of the original is not disclosed.
 pub const REDACTED: &str = "<redacted>";
@@ -25,9 +27,8 @@ const SAFE_QUERY_PARAMS: &[&str] = &["api-version", "apiversion", "comp", "resty
 /// Characters that cannot appear inside a URL, used to find where an embedded
 /// URL ends when scanning free-form text.
 ///
-/// `{` and `}` are deliberately absent: `${secret:name}` markers and `{var}`
-/// placeholders appear in unsubstituted URLs and are not credentials, so
-/// keeping them intact makes the redacted output far easier to read.
+/// `{` and `}` are deliberately absent so that a URL still carrying a `{var}`
+/// placeholder is scanned as a single token rather than being cut in half.
 const URL_TERMINATORS: &[char] = &['"', '\'', '<', '>', '\\', '^', '`', '|', '(', ')', ','];
 
 fn is_safe_query_param(name: &str) -> bool {
@@ -36,84 +37,78 @@ fn is_safe_query_param(name: &str) -> bool {
         .any(|safe| name.eq_ignore_ascii_case(safe))
 }
 
+/// Redact the values in a raw query string, preserving parameter names.
+///
+/// This splits on `&` and `=` rather than using [`Url::query_pairs`], because
+/// `query_pairs` follows the form-urlencoded rules and reports a bare token
+/// (`?SEKRIT`, no `=`) as the *name* of a valueless parameter. Emitting that
+/// would publish the token verbatim. Here a bare token is elided whole, since a
+/// lone token is indistinguishable from a name.
+fn redact_query(query: &str) -> String {
+    let mut out = String::with_capacity(query.len());
+
+    for (i, pair) in query.split('&').enumerate() {
+        if i > 0 {
+            out.push('&');
+        }
+        match pair.split_once('=') {
+            // An empty value has nothing to elide, and leaving it alone is what
+            // makes redaction idempotent: re-redacting `sig=<redacted>` must not
+            // append a second marker.
+            Some((_, "")) => out.push_str(pair),
+            Some((name, _)) if is_safe_query_param(name) => out.push_str(pair),
+            Some((name, _)) => {
+                out.push_str(name);
+                out.push('=');
+                out.push_str(REDACTED);
+            }
+            None => out.push_str(REDACTED),
+        }
+    }
+
+    out
+}
+
 /// Redact the credential-bearing parts of a single URL.
 ///
 /// Preserved: scheme, host, port, path. Elided: userinfo, every query-parameter
 /// value except [`SAFE_QUERY_PARAMS`], and the fragment.
 ///
-/// Parameter *names* are preserved — `sig`, `code` and friends are not secret,
-/// and keeping them makes a redacted log line diagnosable. A bare parameter with
-/// no `=` is elided whole, because a lone token is indistinguishable from a name.
+/// The output is rebuilt from the parsed components rather than by mutating the
+/// [`Url`], because the setters percent-encode `<` and `>` and would turn the
+/// marker into `%3Credacted%3E`.
 pub fn redact_url(url: &str) -> String {
-    let Some((scheme, rest)) = url.split_once("://") else {
-        // Not a URL shape we recognise — never echo it back.
+    let Ok(parsed) = Url::parse(url) else {
+        // Not parseable — never echo it back.
         return REDACTED.to_string();
     };
 
-    // The authority ends at the first '/', '?' or '#'. Splitting on all three
-    // matters: `https://host?x=1` and `https://host#f` have no path at all.
-    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
-    let authority = &rest[..authority_end];
-    let after_authority = &rest[authority_end..];
-
     let mut out = String::with_capacity(url.len());
-    out.push_str(scheme);
+    out.push_str(parsed.scheme());
     out.push_str("://");
 
-    // userinfo may be `user:password`; keep only the fact that one was present.
-    // rfind, not find: a password may itself contain an encoded '@'.
-    match authority.rfind('@') {
-        Some(at) => {
-            out.push_str(REDACTED);
-            out.push('@');
-            out.push_str(&authority[at + 1..]);
-        }
-        None => out.push_str(authority),
+    // Keep only the fact that credentials were present, not which.
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        out.push_str(REDACTED);
+        out.push('@');
     }
 
-    let path_end = after_authority
-        .find(['?', '#'])
-        .unwrap_or(after_authority.len());
-    out.push_str(&after_authority[..path_end]);
-
-    let tail = &after_authority[path_end..];
-    let mut query = "";
-    let mut has_fragment = false;
-    if let Some(after_question) = tail.strip_prefix('?') {
-        match after_question.find('#') {
-            Some(hash) => {
-                query = &after_question[..hash];
-                has_fragment = true;
-            }
-            None => query = after_question,
-        }
-    } else if tail.starts_with('#') {
-        has_fragment = true;
+    if let Some(host) = parsed.host_str() {
+        out.push_str(host);
+    }
+    if let Some(port) = parsed.port() {
+        out.push(':');
+        out.push_str(&port.to_string());
     }
 
-    if !query.is_empty() {
+    out.push_str(parsed.path());
+
+    if let Some(query) = parsed.query().filter(|q| !q.is_empty()) {
         out.push('?');
-        for (i, pair) in query.split('&').enumerate() {
-            if i > 0 {
-                out.push('&');
-            }
-            match pair.split_once('=') {
-                // An empty value has nothing to elide, and leaving it alone is
-                // what makes redaction idempotent: re-redacting `sig=<redacted>`
-                // must not append a second marker.
-                Some((_, "")) => out.push_str(pair),
-                Some((name, _)) if is_safe_query_param(name) => out.push_str(pair),
-                Some((name, _)) => {
-                    out.push_str(name);
-                    out.push('=');
-                    out.push_str(REDACTED);
-                }
-                None => out.push_str(REDACTED),
-            }
-        }
+        out.push_str(&redact_query(query));
     }
 
-    if has_fragment {
+    if parsed.fragment().is_some() {
         out.push('#');
         out.push_str(REDACTED);
     }
@@ -126,6 +121,11 @@ pub fn redact_url(url: &str) -> String {
 /// Needed because `reqwest::Error`'s `Display` interpolates the request URL, so
 /// wrapping a transport error without scrubbing it would reintroduce the very
 /// query string [`redact_url`] was applied to remove.
+///
+/// Locating a URL inside prose is necessarily heuristic — a parser can validate
+/// a candidate but cannot tell you where one ends in surrounding text. So this
+/// only delimits candidates; [`redact_url`] does the parsing, and a candidate it
+/// rejects is replaced wholesale.
 pub fn redact_urls_in(text: &str) -> String {
     if !text.contains("://") {
         return text.to_string();
@@ -237,9 +237,10 @@ mod tests {
 
     #[test]
     fn handles_authority_only_urls() {
-        assert_eq!(redact_url("https://host"), "https://host");
-        assert_eq!(redact_url("https://host?k=v"), "https://host?k=<redacted>");
-        assert_eq!(redact_url("https://host#f"), "https://host#<redacted>");
+        // An empty path normalizes to "/" per the WHATWG URL spec.
+        assert_eq!(redact_url("https://host"), "https://host/");
+        assert_eq!(redact_url("https://host?k=v"), "https://host/?k=<redacted>");
+        assert_eq!(redact_url("https://host#f"), "https://host/#<redacted>");
         assert_eq!(redact_url("https://host/"), "https://host/");
     }
 
@@ -264,11 +265,28 @@ mod tests {
     }
 
     #[test]
-    fn leaves_placeholders_readable() {
+    fn keeps_unsubstituted_placeholders_legible() {
+        // A URL whose {var} placeholders were never substituted still reaches
+        // redaction. Nothing is lost: the host keeps its placeholder verbatim
+        // and the path is percent-encoded, so the mistake is still diagnosable.
         assert_eq!(
             redact_url("https://{kv_host}/secrets/{name}?api-version=7.4"),
-            "https://{kv_host}/secrets/{name}?api-version=7.4"
+            "https://{kv_host}/secrets/%7Bname%7D?api-version=7.4"
         );
+    }
+
+    #[test]
+    fn bare_query_token_is_not_treated_as_a_parameter_name() {
+        // Url::query_pairs follows the form-urlencoded rules and reports a bare
+        // token as the NAME of a valueless parameter. Rebuilding the query from
+        // those pairs would publish the token verbatim, which is why
+        // redact_query splits on '&'/'=' itself. Pin the hazard so a future
+        // refactor to query_pairs fails loudly here.
+        let parsed = Url::parse("https://h/p?SEKRIT").unwrap();
+        let names: Vec<_> = parsed.query_pairs().map(|(k, _)| k.into_owned()).collect();
+        assert_eq!(names, vec!["SEKRIT".to_string()]);
+
+        assert_eq!(redact_url("https://h/p?SEKRIT"), "https://h/p?<redacted>");
     }
 
     #[test]

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -20,13 +20,14 @@ use url::{Position, Url};
 /// length of the original is not disclosed.
 pub const REDACTED: &str = "<redacted>";
 
-/// Redact the values in a raw query string, preserving parameter names.
+/// Redact the values in a raw query string, preserving unambiguous parameter names.
 ///
 /// This splits on `&` and `=` rather than using [`Url::query_pairs`], because
 /// `query_pairs` follows the form-urlencoded rules and reports a bare token
 /// (`?SEKRIT`, no `=`) as the *name* of a valueless parameter. Emitting that
-/// would publish the token verbatim. Here a bare token is elided whole, since a
-/// lone token is indistinguishable from a name.
+/// would publish the token verbatim. Bare tokens and pairs with empty or
+/// padding-only values are elided whole: `token=` and `token==` could be padded
+/// opaque tokens rather than parameters.
 fn redact_query(query: &str) -> String {
     let mut out = String::with_capacity(query.len());
 
@@ -35,13 +36,12 @@ fn redact_query(query: &str) -> String {
             out.push('&');
         }
         match pair.split_once('=') {
-            Some((_, "")) => out.push_str(pair),
-            Some((name, _)) => {
+            Some((name, value)) if !value.trim_end_matches('=').is_empty() => {
                 out.push_str(name);
                 out.push('=');
                 out.push_str(REDACTED);
             }
-            None => out.push_str(REDACTED),
+            _ => out.push_str(REDACTED),
         }
     }
 
@@ -177,11 +177,29 @@ mod tests {
     }
 
     #[test]
-    fn empty_parameter_value_is_left_alone() {
+    fn redacts_empty_valued_query_pairs() {
         assert_eq!(
-            redact_url("https://h/p?a=&b=SEKRIT"),
-            "https://h/p?a=&b=<redacted>"
+            redact_url("https://h/p?a=&b=SEKRIT&="),
+            "https://h/p?<redacted>&b=<redacted>&<redacted>"
         );
+    }
+
+    #[test]
+    fn padded_query_tokens_are_not_treated_as_parameter_names() {
+        for token in ["c2VjcmV0=", "c2VjcmV0MQ=="] {
+            assert_eq!(
+                redact_url(&format!("https://h/p?{token}")),
+                "https://h/p?<redacted>"
+            );
+            assert_eq!(
+                redact_url(&format!("https://h/p?a=1&{token}&b=2")),
+                "https://h/p?a=<redacted>&<redacted>&b=<redacted>"
+            );
+            assert_eq!(
+                redact_url(&format!("https://h/p?token={token}")),
+                "https://h/p?token=<redacted>"
+            );
+        }
     }
 
     #[test]
@@ -252,6 +270,9 @@ mod tests {
             "https://h/p?sig=SEKRIT",
             "https://user:pa%40ss@h/p?sig=SEKRIT#SEKRIT",
             "https://h/p?SEKRIT",
+            "https://h/p?a=&b=SEKRIT&=",
+            "https://h/p?c2VjcmV0=",
+            "https://h/p?c2VjcmV0MQ==",
             "mailto:alice@example.com?body=SEKRIT#SEKRIT",
         ] {
             let once = redact_url(url);

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -9,33 +9,16 @@
 //! unredacted URL lands in the PostgreSQL server log in cleartext — a sink with
 //! no RLS, no `pg_durable.retention_days`, and often a different backup path
 //! than the database itself. Error strings are worse still: they are persisted
-//! to `df.nodes.error` and into duroxide history.
+//! to `df.nodes.result` and into duroxide history.
 //!
 //! Redaction is deliberately lossy and fails closed: anything that cannot be
 //! parsed as a URL is replaced wholesale rather than echoed back.
 
-use url::Url;
+use url::{Position, Url};
 
 /// Stand-in for any elided value. Deliberately not a fixed-width mask, so the
 /// length of the original is not disclosed.
 pub const REDACTED: &str = "<redacted>";
-
-/// Query parameters whose values carry no credential and are worth keeping for
-/// diagnosis. Matched case-insensitively against the parameter name.
-const SAFE_QUERY_PARAMS: &[&str] = &["api-version", "apiversion", "comp", "restype"];
-
-/// Characters that cannot appear inside a URL, used to find where an embedded
-/// URL ends when scanning free-form text.
-///
-/// `{` and `}` are deliberately absent so that a URL still carrying a `{var}`
-/// placeholder is scanned as a single token rather than being cut in half.
-const URL_TERMINATORS: &[char] = &['"', '\'', '<', '>', '\\', '^', '`', '|', '(', ')', ','];
-
-fn is_safe_query_param(name: &str) -> bool {
-    SAFE_QUERY_PARAMS
-        .iter()
-        .any(|safe| name.eq_ignore_ascii_case(safe))
-}
 
 /// Redact the values in a raw query string, preserving parameter names.
 ///
@@ -52,11 +35,7 @@ fn redact_query(query: &str) -> String {
             out.push('&');
         }
         match pair.split_once('=') {
-            // An empty value has nothing to elide, and leaving it alone is what
-            // makes redaction idempotent: re-redacting `sig=<redacted>` must not
-            // append a second marker.
             Some((_, "")) => out.push_str(pair),
-            Some((name, _)) if is_safe_query_param(name) => out.push_str(pair),
             Some((name, _)) => {
                 out.push_str(name);
                 out.push('=');
@@ -72,7 +51,7 @@ fn redact_query(query: &str) -> String {
 /// Redact the credential-bearing parts of a single URL.
 ///
 /// Preserved: scheme, host, port, path. Elided: userinfo, every query-parameter
-/// value except [`SAFE_QUERY_PARAMS`], and the fragment.
+/// value, and the fragment.
 ///
 /// The output is rebuilt from the parsed components rather than by mutating the
 /// [`Url`], because the setters percent-encode `<` and `>` and would turn the
@@ -84,8 +63,7 @@ pub fn redact_url(url: &str) -> String {
     };
 
     let mut out = String::with_capacity(url.len());
-    out.push_str(parsed.scheme());
-    out.push_str("://");
+    out.push_str(&parsed[..Position::BeforeUsername]);
 
     // Keep only the fact that credentials were present, not which.
     if !parsed.username().is_empty() || parsed.password().is_some() {
@@ -93,15 +71,7 @@ pub fn redact_url(url: &str) -> String {
         out.push('@');
     }
 
-    if let Some(host) = parsed.host_str() {
-        out.push_str(host);
-    }
-    if let Some(port) = parsed.port() {
-        out.push(':');
-        out.push_str(&port.to_string());
-    }
-
-    out.push_str(parsed.path());
+    out.push_str(&parsed[Position::BeforeHost..Position::AfterPath]);
 
     if let Some(query) = parsed.query().filter(|q| !q.is_empty()) {
         out.push('?');
@@ -113,52 +83,6 @@ pub fn redact_url(url: &str) -> String {
         out.push_str(REDACTED);
     }
 
-    out
-}
-
-/// Redact every URL embedded in free-form text.
-///
-/// Needed because `reqwest::Error`'s `Display` interpolates the request URL, so
-/// wrapping a transport error without scrubbing it would reintroduce the very
-/// query string [`redact_url`] was applied to remove.
-///
-/// Locating a URL inside prose is necessarily heuristic — a parser can validate
-/// a candidate but cannot tell you where one ends in surrounding text. So this
-/// only delimits candidates; [`redact_url`] does the parsing, and a candidate it
-/// rejects is replaced wholesale.
-pub fn redact_urls_in(text: &str) -> String {
-    if !text.contains("://") {
-        return text.to_string();
-    }
-
-    let mut out = String::with_capacity(text.len());
-    let mut rest = text;
-
-    while let Some(sep) = rest.find("://") {
-        // Walk back over the scheme, which must be alphanumeric with `+-.`.
-        let scheme_start = rest[..sep]
-            .rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.'))
-            .map_or(0, |i| i + 1);
-
-        if scheme_start == sep {
-            // `://` with no scheme in front of it — not a URL.
-            out.push_str(&rest[..sep + 3]);
-            rest = &rest[sep + 3..];
-            continue;
-        }
-
-        out.push_str(&rest[..scheme_start]);
-
-        let candidate = &rest[scheme_start..];
-        let end = candidate
-            .find(|c: char| c.is_whitespace() || URL_TERMINATORS.contains(&c))
-            .unwrap_or(candidate.len());
-
-        out.push_str(&redact_url(&candidate[..end]));
-        rest = &candidate[end..];
-    }
-
-    out.push_str(rest);
     out
 }
 
@@ -179,19 +103,19 @@ mod tests {
     }
 
     #[test]
-    fn keeps_safe_query_params() {
-        assert_eq!(
-            redact_url("https://v.vault.azure.net/secrets/s?api-version=7.4&code=SEKRIT"),
-            "https://v.vault.azure.net/secrets/s?api-version=7.4&code=<redacted>"
-        );
-    }
-
-    #[test]
-    fn safe_query_param_match_is_case_insensitive() {
-        assert_eq!(
-            redact_url("https://h/p?API-Version=7.4"),
-            "https://h/p?API-Version=7.4"
-        );
+    fn redacts_query_values_regardless_of_parameter_name() {
+        for name in [
+            "api-version",
+            "API-Version",
+            "apiversion",
+            "comp",
+            "restype",
+        ] {
+            assert_eq!(
+                redact_url(&format!("https://h/p?{name}=SEKRIT")),
+                format!("https://h/p?{name}=<redacted>")
+            );
+        }
     }
 
     #[test]
@@ -223,8 +147,11 @@ mod tests {
     }
 
     #[test]
-    fn redacts_bare_query_token_whole() {
-        assert_eq!(redact_url("https://h/p?SEKRIT"), "https://h/p?<redacted>");
+    fn preserves_urls_without_authority() {
+        assert_eq!(
+            redact_url("mailto:alice@example.com?body=SEKRIT#SEKRIT"),
+            "mailto:alice@example.com?body=<redacted>#<redacted>"
+        );
     }
 
     #[test]
@@ -271,7 +198,7 @@ mod tests {
         // and the path is percent-encoded, so the mistake is still diagnosable.
         assert_eq!(
             redact_url("https://{kv_host}/secrets/{name}?api-version=7.4"),
-            "https://{kv_host}/secrets/%7Bname%7D?api-version=7.4"
+            "https://{kv_host}/secrets/%7Bname%7D?api-version=<redacted>"
         );
     }
 
@@ -290,44 +217,45 @@ mod tests {
     }
 
     #[test]
-    fn redacts_url_embedded_in_error_text() {
-        let scrubbed = redact_urls_in(
-            "error sending request for url (https://h/p?sig=SEKRIT): connection closed",
-        );
-        assert_eq!(
-            scrubbed,
-            "error sending request for url (https://h/p?sig=<redacted>): connection closed"
-        );
-        assert!(!scrubbed.contains("SEKRIT"));
+    fn redacts_query_values_containing_url_punctuation() {
+        for punctuation in [",", "(", ")", "'", "<", ">", "\\", "^", "`", "|", "\""] {
+            assert_eq!(
+                redact_url(&format!("https://h/p?sig=FIRST{punctuation}LAST")),
+                "https://h/p?sig=<redacted>"
+            );
+        }
     }
 
     #[test]
-    fn redacts_every_url_in_text() {
-        let scrubbed = redact_urls_in("from https://a/x?k=S1 to https://b/y?k=S2 failed");
-        assert!(!scrubbed.contains("S1"));
-        assert!(!scrubbed.contains("S2"));
-        assert_eq!(
-            scrubbed,
-            "from https://a/x?k=<redacted> to https://b/y?k=<redacted> failed"
-        );
-    }
+    fn reqwest_errors_can_remove_sensitive_urls() {
+        let url = Url::parse("https://user:password@h/p?sig=FIRST,(LAST)#SEKRIT").unwrap();
+        let error = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap()
+            .get(url.clone())
+            .header("invalid header name", "value")
+            .build()
+            .unwrap_err()
+            .with_url(url);
+        assert!(error.to_string().contains("FIRST,(LAST)"));
 
-    #[test]
-    fn leaves_text_without_urls_untouched() {
-        assert_eq!(redact_urls_in("plain error, no url"), "plain error, no url");
-        assert_eq!(redact_urls_in(""), "");
-    }
-
-    #[test]
-    fn tolerates_bare_scheme_separator() {
-        assert_eq!(redact_urls_in("weird :// text"), "weird :// text");
+        let error = error.without_url();
+        assert!(error.is_builder());
+        assert!(error.url().is_none());
+        assert_eq!(error.to_string(), "builder error");
     }
 
     #[test]
     fn redaction_is_idempotent() {
-        let once = redact_url("https://h/p?sig=SEKRIT");
-        assert_eq!(redact_url(&once), once);
-        let once_in_text = redact_urls_in("url (https://h/p?sig=SEKRIT)");
-        assert_eq!(redact_urls_in(&once_in_text), once_in_text);
+        for url in [
+            "https://h/p?sig=SEKRIT",
+            "https://user:pa%40ss@h/p?sig=SEKRIT#SEKRIT",
+            "https://h/p?SEKRIT",
+            "mailto:alice@example.com?body=SEKRIT#SEKRIT",
+        ] {
+            let once = redact_url(url);
+            assert_eq!(redact_url(&once), once);
+        }
     }
 }

--- a/src/ssrf.rs
+++ b/src/ssrf.rs
@@ -181,14 +181,14 @@ fn validate_scheme_value(scheme: &str) -> Result<(), String> {
             "Blocked: plaintext HTTP is not permitted in restricted builds. HTTPS is required."
                 .to_string(),
         ),
-        other => {
+        _ => {
             let allowed = if allows_plaintext {
                 "http and https"
             } else {
                 "https"
             };
             Err(format!(
-                "Blocked: unsupported URL scheme '{other}'. Only {allowed} is allowed."
+                "Blocked: unsupported URL scheme. Only {allowed} is allowed."
             ))
         }
     }
@@ -624,6 +624,15 @@ mod tests {
     fn blocks_empty_and_malformed() {
         assert!(precheck_url_scheme("").is_err());
         assert!(precheck_url_scheme("no-scheme").is_err());
+    }
+
+    #[test]
+    fn malformed_scheme_errors_do_not_echo_credentials() {
+        for url in ["https:/h/p?sig=query_token", "invalid?sig=query_token://h"] {
+            let error = precheck_url_scheme(url).unwrap_err();
+            assert!(error.contains("unsupported URL scheme"), "{error}");
+            assert!(!error.contains("query_token"), "{error}");
+        }
     }
 
     // --- Canonical URL parsing ---

--- a/src/types.rs
+++ b/src/types.rs
@@ -87,6 +87,11 @@ pub fn get_reconcile_interval() -> Duration {
     Duration::from_secs(crate::RECONCILE_INTERVAL.get() as u64)
 }
 
+/// Returns `true` when the SQL text of a workflow node may be written to the log.
+pub fn log_workflow_sql_enabled() -> bool {
+    crate::LOG_WORKFLOW_SQL.get()
+}
+
 /// Returns `true` when superuser-submitted instances are permitted.
 pub fn superuser_instances_enabled() -> bool {
     crate::ENABLE_SUPERUSER_INSTANCES.get()

--- a/src/types.rs
+++ b/src/types.rs
@@ -285,7 +285,7 @@ async fn connect_as_user_with_application_name(
     application_name: &str,
 ) -> Result<sqlx::postgres::PgConnection, String> {
     use sqlx::postgres::PgConnectOptions;
-    use sqlx::Connection;
+    use sqlx::{ConnectOptions, Connection};
 
     /// Connection timeout for per-user SQL connections (seconds).
     const CONNECT_TIMEOUT_SECS: u64 = 30;
@@ -301,6 +301,10 @@ async fn connect_as_user_with_application_name(
     let host = get_host();
     if !host.is_empty() {
         options = options.host(&host);
+    }
+
+    if !log_workflow_sql_enabled() {
+        options = options.disable_statement_logging();
     }
 
     let connect_future = sqlx::postgres::PgConnection::connect_with(&options);


### PR DESCRIPTION
Updated version of https://github.com/microsoft/pg_durable/pull/361, now on the correct account.

Does 3 things:

- Adds `pg_durable.log_workflow_sql` postmaster GUC. This controls whether or not the worker will write the fully substituted SQL text of a workflow node to the server log.
- Redacts URLs in logs and errors. Query parameter values, user info, and the fragment are elided. This means that an Azure SAS token, or `?api-key=` won't reach the PG server log, `df.nodes.error`, or durable execution history. Other parts of the URL are preserved. Error text from the HTTP client is scrubbed too, since it interpolates the URL.
- Adds documentation that's honest about `df.vars` and potential exposure to USER_GUIDE.md.

Blocks most of the other work I have for improving `df.http`.