### PR TITLE
Add a `df.with_http_options` combinator

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -701,6 +701,24 @@ df.http(
 ) RETURNS TEXT                    -- JSON response object
 ```
 
+### df.with_http_options() Function
+
+`df.with_http_options(fut TEXT, options JSONB) RETURNS TEXT` is the entry point for
+HTTP modifiers beyond the arguments passed to `df.http` and `df.http_multipart`.
+
+```sql
+df.with_http_options(df.http('https://api.github.com/', 'GET'), '{}'::jsonb)
+    |=> 'response'
+```
+
+In this version, only SQL `NULL` and an empty object (`{}`) are accepted as
+`options`; no option keys are supported yet. Other JSON values, including JSON
+`null`, are rejected. Empty options return the input text byte-for-byte.
+
+The input must be a single `HTTP` or `HTTP_MULTIPART` node, optionally named with
+`|=>`. SQL nodes and compound graphs are rejected, so apply the helper before
+combining nodes. It does not execute a request or change HTTP permissions.
+
 ### Response Format
 
 HTTP calls return a JSON object with full response details:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -367,6 +367,31 @@ Returns the same envelope as `df.http()`.
 
 ---
 
+### df.with_http_options(fut, options)
+
+HTTP-specific modifier entry point. Returns the JSON-encoded TEXT node for use in
+a workflow, not an HTTP response. Neither existing HTTP function changes signature.
+
+| Parameter | Type | Auto-wrap | Description |
+|-----------|------|-----------|-------------|
+| `fut` | TEXT | ❌ Literal | A single `HTTP` or `HTTP_MULTIPART` node, optionally named with `\|=>` |
+| `options` | JSONB | ❌ Literal | SQL `NULL` or an empty object (`'{}'`) only in this version |
+
+```sql
+df.with_http_options(df.http('https://api.github.com/', 'GET'), '{}'::jsonb)
+  |=> 'response'
+```
+
+No option keys are supported yet. Unknown keys, non-object JSON values (including
+JSON `null`), malformed nodes, SQL nodes, and compound graphs raise an error.
+SQL `NULL` and `{}` return the original node text byte-for-byte, preserving its
+config and result name. Apply the helper to each HTTP node before combining nodes.
+It neither resolves secrets nor grants HTTP access; activity-time permission and
+network checks still apply. Existing installations need `ALTER EXTENSION pg_durable
+UPDATE` to use this new helper, but not to keep using the original HTTP functions.
+
+---
+
 ## Control Functions
 
 ### df.start(fut [, label] [, database] [, transaction_mode])

--- a/docs/http-security.md
+++ b/docs/http-security.md
@@ -117,6 +117,12 @@ superusers always return `true`; regular roles return `true` only when an
 explicit `GRANT EXECUTE ON FUNCTION df.http(text, text, text, jsonb, integer) TO <role>` (or a role that
 inherits one) is in effect.
 
+`df.with_http_options(text,jsonb)` is a node modifier, not a network operation.
+Like other combinators, it uses ordinary `df` schema access and default PUBLIC
+`EXECUTE`. Wrapping a hand-crafted HTTP node does not bypass the activity's
+privilege check. No option keys are supported in this version; SQL `NULL` and
+`{}` preserve the original node text.
+
 ### 3.3 Managing access
 
 HTTP access is **opt-in** and separate from general `df` access.

--- a/docs/upgrade-testing.md
+++ b/docs/upgrade-testing.md
@@ -203,7 +203,9 @@ gate, so they never need to be added to the exclude list.
 Each schema-changing PR should add a section here documenting what changed,
 what the upgrade script handles, and any backward compatibility considerations.
 
-### 0.2.8
+### v0.2.7 → v0.2.8
+
+#### Loop failure continuation
 
 - `sql/pg_durable--0.2.7--0.2.8.sql` renames `df.loop(text, text)` to
   `df._loop_legacy(text, text)`, preserving its function OID and dependent
@@ -232,6 +234,12 @@ what the upgrade script handles, and any backward compatibility considerations.
   that recorded the previous terminal-failure path cannot replay under the new
   binary, which continues toward the higher backstop instead. Drain such
   long-running loops before upgrade when continuity is required.
+
+#### Add `df.with_http_options()`
+- **DDL change:** Adds `df.with_http_options(fut text, options jsonb) RETURNS text`. The input must be a single `HTTP` or `HTTP_MULTIPART` node. No option keys are supported yet: SQL `NULL` and `{}` return the original node text byte-for-byte; other values and unsupported keys raise an error.
+- **Upgrade script:** [sql/pg_durable--0.2.7--0.2.8.sql](../sql/pg_durable--0.2.7--0.2.8.sql) adds this helper without replacing the existing HTTP functions. The new helper uses the same schema-access and default PUBLIC `EXECUTE` model as other combinators; it does not grant HTTP access.
+- **Scenario A considerations:** The added function matches pgrx-generated fresh-install SQL, including argument names, null handling and the `with_http_options_wrapper` C symbol.
+- **Scenario B1 considerations:** The new helper remains absent until `ALTER EXTENSION UPDATE`. The new `.so` exports `with_http_options_wrapper`; existing HTTP function signatures, C symbols, OIDs and ACLs are unchanged.
 
 ### v0.2.6 → v0.2.7
 

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -778,6 +778,17 @@ test_b1_conditional_loop() {
     assert_sql_contains "SELECT df.loop('SELECT 1', 'SELECT false');" '"node_type":"LOOP"'
 }
 
+test_b1_http_construction() {
+    assert_sql_contains "SELECT df.http('https://api.github.com/');" '"node_type":"HTTP"' &&
+    assert_sql_equals \
+        "SELECT (df.http('https://api.github.com/', 'GET', NULL, NULL, 7)::jsonb->>'query')::jsonb->>'timeout_seconds';" \
+        "7"
+}
+
+test_b1_http_options_absent() {
+    assert_sql_equals "SELECT to_regprocedure('df.with_http_options(text,jsonb)') IS NULL;" "t"
+}
+
 test_b1_dsl_chain() {
     assert_sql_contains "SELECT df.sql('SELECT 1') ~> df.sql('SELECT 2');" '"node_type":"THEN"'
 }
@@ -909,6 +920,10 @@ else
         run_test "B1 [v${B1_VERSION}]: df.version()" test_b1_version
         run_test "B1 [v${B1_VERSION}]: df.sql() construction" test_b1_dsl_construction
         run_test "B1 [v${B1_VERSION}]: df.loop(body, condition)" test_b1_conditional_loop
+        run_test "B1 [v${B1_VERSION}]: df.http() construction" test_b1_http_construction
+        if ! version_ge "$B1_VERSION" "0.2.8"; then
+            run_test "B1 [v${B1_VERSION}]: new HTTP options helper remains absent" test_b1_http_options_absent
+        fi
         run_test "B1 [v${B1_VERSION}]: DSL chain (~>)" test_b1_dsl_chain
         run_test "B1 [v${B1_VERSION}]: conditional operators (?>/!>)" test_b1_conditional_operators
         run_test "B1 [v${B1_VERSION}]: df.start()/wait_for_completion()" test_b1_start_and_complete
@@ -1030,6 +1045,55 @@ test_b2_grant_usage_after_upgrade() {
     run_sql_capture "DROP OWNED BY ${probe_role}; DROP ROLE IF EXISTS ${probe_role};" >/dev/null 2>&1 || true
 }
 
+test_b2_http_api_after_upgrade() {
+    create_extension_at_version "$PREV_VERSION"
+
+    local output
+    output=$(run_sql_capture "
+        CREATE ROLE durable_b2_http_probe;
+        GRANT EXECUTE ON FUNCTION df.http(text,text,text,jsonb,integer),
+            df.http_multipart(text,text,jsonb,jsonb,integer)
+            TO durable_b2_http_probe WITH GRANT OPTION;
+
+        CREATE TEMP TABLE http_api_before AS
+            SELECT oid, proacl FROM pg_proc
+            WHERE oid IN (
+                'df.http(text,text,text,jsonb,integer)'::regprocedure,
+                'df.http_multipart(text,text,jsonb,jsonb,integer)'::regprocedure
+            );
+        CREATE TEMP VIEW http_calls_before AS
+            SELECT df.http('https://api.github.com/') AS http_node,
+                df.http_multipart('https://api.github.com/',
+                    parts => '[{\"name\":\"field\",\"data_b64\":\"aGk=\"}]'::jsonb) AS multipart_node;
+
+        ALTER EXTENSION pg_durable UPDATE TO '${CURRENT_VERSION}';
+
+        DO \$verify\$
+        BEGIN
+            IF (SELECT count(*) FROM http_api_before) <> 2 OR EXISTS (
+                SELECT 1 FROM http_api_before AS previous
+                LEFT JOIN pg_proc AS current ON current.oid = previous.oid
+                WHERE current.oid IS NULL OR current.proacl IS DISTINCT FROM previous.proacl
+            ) THEN
+                RAISE EXCEPTION 'HTTP function OIDs or ACLs changed during upgrade';
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM http_calls_before
+                WHERE http_node::jsonb->>'node_type' = 'HTTP'
+                  AND multipart_node::jsonb->>'node_type' = 'HTTP_MULTIPART'
+                  AND df.with_http_options(http_node, '{}'::jsonb) = http_node
+                  AND df.with_http_options(multipart_node, NULL) = multipart_node
+            ) THEN
+                RAISE EXCEPTION 'Legacy HTTP calls or the additive helper failed after upgrade';
+            END IF;
+        END
+        \$verify\$;
+
+        DROP OWNED BY durable_b2_http_probe;
+        DROP ROLE durable_b2_http_probe;
+    ") || { echo "$output"; return 1; }
+}
+
 if [ "$HAS_COMPAT_PREV" = true ]; then
     run_test "B2: Pre-upgrade data survives ALTER EXTENSION UPDATE" test_b2_data_survives_upgrade
     run_test "B2: Pre-upgrade instance remains queryable" test_b2_pre_upgrade_instance_after_upgrade
@@ -1037,6 +1101,7 @@ if [ "$HAS_COMPAT_PREV" = true ]; then
     run_test "B2: Loop dependency and unified API survive upgrade" test_b2_loop_dependency_survives_upgrade
     run_test "B2: New data and execution after upgrade" test_b2_new_data_after_upgrade
     run_test "B2: df.grant_usage() works and df.debug_connection() is gone after upgrade" test_b2_grant_usage_after_upgrade
+    run_test "B2: HTTP OIDs, grants and dependent views survive upgrade" test_b2_http_api_after_upgrade
 fi
 
 # ============================================================================

--- a/sql/pg_durable--0.2.7--0.2.8.sql
+++ b/sql/pg_durable--0.2.7--0.2.8.sql
@@ -15,3 +15,11 @@ CREATE FUNCTION df."loop"(
 ) RETURNS TEXT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'loop_with_policy_wrapper';
+
+-- HTTP options are additive; existing function ABIs, OIDs and ACLs stay unchanged.
+CREATE FUNCTION df."with_http_options"(
+    "fut" TEXT,
+    "options" jsonb
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'with_http_options_wrapper';

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -487,6 +487,52 @@ pub fn race(a: &str, b: &str) -> String {
     .to_json()
 }
 
+/// Applies HTTP options to a single HTTP or HTTP_MULTIPART node.
+#[pg_extern(schema = "df")]
+pub fn with_http_options(fut: &str, options: Option<pgrx::JsonB>) -> String {
+    use std::{collections::HashSet, sync::LazyLock};
+    static ALLOWED_KEYS: LazyLock<HashSet<&'static str>> = {
+        LazyLock::new(|| {
+            HashSet::from_iter([
+                // Intentionally empty for now.
+            ])
+        })
+    };
+    let node = Durofut::try_from_json(fut).unwrap_or_else(|_| {
+        pgrx::error!("df.with_http_options(): expected an HTTP or HTTP_MULTIPART node")
+    });
+
+    if !matches!(node.node_type.as_str(), "HTTP" | "HTTP_MULTIPART")
+        || node.left_node.is_some()
+        || node.right_node.is_some()
+        || node.condition_node.is_some()
+        || !node.extra_nodes.is_empty()
+    {
+        pgrx::error!("df.with_http_options(): expected a single HTTP or HTTP_MULTIPART node");
+    }
+
+    let config = node
+        .query
+        .as_deref()
+        .and_then(|query| serde_json::from_str::<serde_json::Value>(query).ok());
+    if !config.as_ref().is_some_and(serde_json::Value::is_object) {
+        pgrx::error!("df.with_http_options(): HTTP node config must be a JSON object");
+    }
+
+    if let Some(options) = options {
+        let Some(map) = options.0.as_object() else {
+            pgrx::error!("df.with_http_options(): options must be a JSON object");
+        };
+        for key in map.keys() {
+            if !ALLOWED_KEYS.contains(key.as_str()) {
+                pgrx::error!("df.with_http_options(): unrecognised option '{key}'.");
+            }
+        }
+    }
+
+    fut.to_string()
+}
+
 /// Creates an HTTP request node.
 /// Makes an HTTP request to the specified URL and returns the response.
 ///

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -511,12 +511,15 @@ pub fn with_http_options(fut: &str, options: Option<pgrx::JsonB>) -> String {
         pgrx::error!("df.with_http_options(): expected a single HTTP or HTTP_MULTIPART node");
     }
 
-    let config = node
-        .query
-        .as_deref()
-        .and_then(|query| serde_json::from_str::<serde_json::Value>(query).ok());
-    if !config.as_ref().is_some_and(serde_json::Value::is_object) {
-        pgrx::error!("df.with_http_options(): HTTP node config must be a JSON object");
+    let valid_config = match (node.node_type.as_str(), node.query.as_deref()) {
+        ("HTTP", Some(query)) => serde_json::from_str::<crate::types::HttpConfig>(query).is_ok(),
+        ("HTTP_MULTIPART", Some(query)) => {
+            serde_json::from_str::<crate::types::MultipartConfig>(query).is_ok()
+        }
+        _ => false,
+    };
+    if !valid_config {
+        pgrx::error!("df.with_http_options(): HTTP node config is malformed");
     }
 
     if let Some(options) = options {

--- a/tests/e2e/sql/69_http_options.sql
+++ b/tests/e2e/sql/69_http_options.sql
@@ -1,0 +1,160 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the PostgreSQL License.
+
+-- Tests: df.with_http_options.
+SELECT df.grant_usage('df_e2e_user', include_http => true);
+SET SESSION AUTHORIZATION df_e2e_user;
+
+DO $$
+DECLARE
+    request_node TEXT;
+    named_node TEXT;
+    option_value JSONB;
+    expected_error TEXT;
+    actual_error TEXT;
+BEGIN
+    FOREACH request_node IN ARRAY ARRAY[
+        df.http('https://httpbingo.org/{path}', 'POST', '$response {value}', '{"Authorization":"${secret:server.token}"}', 15),
+        df.http_multipart('https://httpbingo.org/post', 'POST', '[{"name":"field","data_b64":"$response.body"}]')
+    ] LOOP
+        IF df.with_http_options(request_node, NULL) IS DISTINCT FROM request_node
+           OR df.with_http_options(request_node, '{}') IS DISTINCT FROM request_node
+           OR df.with_http_options(df.with_http_options(request_node, '{}'), '{}') IS DISTINCT FROM request_node THEN
+            RAISE EXCEPTION 'TEST FAILED: empty options changed the node';
+        END IF;
+
+        named_node := df.as(request_node, 'response');
+        IF df.with_http_options(named_node, '{}') IS DISTINCT FROM named_node
+           OR df.as(df.with_http_options(request_node, '{}'), 'response') IS DISTINCT FROM named_node THEN
+            RAISE EXCEPTION 'TEST FAILED: options changed result naming';
+        END IF;
+
+        FOR option_value, expected_error IN
+            SELECT * FROM (VALUES
+                ('{"retry":3}'::jsonb, 'unrecognised option ''retry'''),
+                ('{"response":"metadata"}'::jsonb, 'unrecognised option ''response'''),
+                ('[]'::jsonb, 'options must be a JSON object'),
+                ('null'::jsonb, 'options must be a JSON object'),
+                ('true'::jsonb, 'options must be a JSON object'),
+                ('42'::jsonb, 'options must be a JSON object'),
+                ('"value"'::jsonb, 'options must be a JSON object')
+            ) AS cases(option_value, expected_error)
+        LOOP
+            actual_error := NULL;
+            BEGIN
+                PERFORM df.with_http_options(request_node, option_value);
+            EXCEPTION WHEN others THEN
+                actual_error := SQLERRM;
+            END;
+            IF actual_error IS NULL OR strpos(actual_error, expected_error) = 0 THEN
+                RAISE EXCEPTION 'TEST FAILED: expected %, got %', expected_error, actual_error;
+            END IF;
+        END LOOP;
+    END LOOP;
+
+    request_node := ' { "result_name": "response", "query": "{\"url\":\"https://httpbingo.org/{path}\",\"method\":\"GET\",\"body\":\"$response ${secret:server.token}\"}", "node_type": "HTTP" } ';
+    IF df.with_http_options(request_node, '{}') IS DISTINCT FROM request_node THEN
+        RAISE EXCEPTION 'TEST FAILED: options reserialized the original graph text';
+    END IF;
+
+    FOREACH request_node IN ARRAY ARRAY[
+        'SELECT 1', '{', 'null', '{}', df.sql('SELECT 1'), df.sleep(1),
+        df.http('https://httpbingo.org/get') ~> 'SELECT 1',
+        '{"node_type":"HTTP"}',
+        '{"node_type":"HTTP","query":"not JSON"}',
+        '{"node_type":"HTTP_MULTIPART","query":"[]"}',
+        '{"node_type":"HTTP","query":"{}","left_node":{"node_type":"SQL","query":"SELECT 1"}}'
+    ] LOOP
+        actual_error := NULL;
+        BEGIN
+            PERFORM df.with_http_options(request_node, '{}');
+        EXCEPTION WHEN others THEN
+            actual_error := SQLERRM;
+        END;
+        IF actual_error IS NULL OR actual_error NOT LIKE 'df.with_http_options(): %' THEN
+            RAISE EXCEPTION 'TEST FAILED: expected invalid-node rejection, got %', actual_error;
+        END IF;
+    END LOOP;
+
+    RAISE NOTICE 'TEST PASSED: HTTP options validation and byte preservation';
+END $$;
+
+CREATE TEMP TABLE _test_http_options (instance_id TEXT, node_type TEXT, query TEXT);
+
+INSERT INTO _test_http_options
+SELECT df.start(
+           df.with_http_options(request_node, '{}') |=> 'response'
+           ~> 'SELECT ($response::jsonb->>''status'')::integer as status',
+           'test-http-options'
+       ), request_node::jsonb->>'node_type', request_node::jsonb->>'query'
+FROM (VALUES
+    (df.http('https://httpbingo.org/get', 'GET')),
+    (df.http_multipart('https://httpbingo.org/post', 'POST', '[{"name":"field","data_b64":"aGk="}]'))
+) AS requests(request_node);
+
+DO $$
+DECLARE
+    test_case RECORD;
+    status TEXT;
+BEGIN
+    FOR test_case IN SELECT * FROM _test_http_options LOOP
+        SELECT df.await_instance(test_case.instance_id) INTO status;
+        IF status IS DISTINCT FROM 'completed' THEN
+            RAISE EXCEPTION 'TEST FAILED: % with options ended with %', test_case.node_type, status;
+        END IF;
+        IF NOT EXISTS (
+            SELECT 1 FROM df.nodes AS node
+            WHERE node.instance_id = test_case.instance_id
+              AND node.node_type = test_case.node_type
+              AND node.query = test_case.query
+              AND node.result_name = 'response'
+        ) THEN
+            RAISE EXCEPTION 'TEST FAILED: stored HTTP config or result name changed';
+        END IF;
+    END LOOP;
+END $$;
+
+DROP TABLE _test_http_options;
+RESET SESSION AUTHORIZATION;
+
+DROP ROLE IF EXISTS http_options_denied;
+CREATE ROLE http_options_denied LOGIN;
+SELECT df.grant_usage('http_options_denied');
+SET SESSION AUTHORIZATION http_options_denied;
+
+CREATE TEMP TABLE _test_http_options_denied (instance_id TEXT, node_type TEXT);
+INSERT INTO _test_http_options_denied
+SELECT df.start(df.with_http_options(
+           jsonb_build_object('node_type', node_type, 'query', config)::text, '{}'
+       ), 'test-http-options-denied'), node_type
+FROM (VALUES
+    ('HTTP', '{"url":"https://api.github.com/","method":"GET","timeout_seconds":1}'),
+    ('HTTP_MULTIPART', '{"url":"https://api.github.com/","method":"POST","parts":[{"name":"field","data_b64":"aGk="}],"timeout_seconds":1}')
+) AS requests(node_type, config);
+
+DO $$
+DECLARE
+    test_case RECORD;
+    status TEXT;
+    node_result TEXT;
+BEGIN
+    FOR test_case IN SELECT * FROM _test_http_options_denied LOOP
+        SELECT df.await_instance(test_case.instance_id) INTO status;
+        SELECT node.result::text INTO node_result
+        FROM df.nodes AS node
+        WHERE node.instance_id = test_case.instance_id AND node.node_type = test_case.node_type;
+
+        IF status IS DISTINCT FROM 'failed'
+           OR node_result IS NULL
+           OR node_result NOT LIKE '%does not have EXECUTE privilege%' THEN
+            RAISE EXCEPTION 'TEST FAILED: options bypassed HTTP privilege checks: %, %', status, node_result;
+        END IF;
+    END LOOP;
+END $$;
+
+DROP TABLE _test_http_options_denied;
+RESET SESSION AUTHORIZATION;
+DROP OWNED BY http_options_denied;
+DROP ROLE http_options_denied;
+
+SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
Several of my tasks require passing additional options[^1] to `df.http` and `df.http_multipart`. Unfortunately, adding new parameters to these functions is Hard. The normal approach (for example taken in #377 with the `df.loop`) is to keep the old function around, renamed (but with the same wrapper name). This is fine (and even avoids issues when `ALTER EXTENSION UPDATE` is not run), but `df.http` and `df.http_multipart` are functions that will likely have a bunch of `GRANT`s (and those grants are semantically meaningful to `pg_durable` beyond the user's ability to call the functions).

If we try to capture and re-issue[^2] those grants from an extension, PG will record the grants as coming from the extension update script, and assume it doesn't need to provide them in pg_dump, so then the pg_restore won't have them, meaning logical restore and/or PG upgrades will be broken.

The AI suggested the right approach was some catalog feng shui but that it would take a while to engineer. I asked on the PostgreSQL discord, and one of the PG committers (rhass) told me that this (trying to copy grants from one function to another) was something that you should never do, and to just have users reissue the grants on update.

So... instead of that, we just add a combinator function that manipulates the durofut JSON directly to add the options. For example, you'd use it like:

```sql
df.with_http_options(
    df.http(...),
    '{"options": "here"}'::jsonb
);
```

This admittedly is less ergonomic than adding an `options =>` parameter for `df.http`, but... well, yeah.

If we want, we could make this into an operator, e.g. allowing `df.http(...) <some-operator> '{"options": "here"}'` or something like that? I don't have strong feelings.

Anyway, this does nothing right now (all options are intentionally rejected), but this way I don't have to add it in each case where it's needed. I don't mind waiting on this until the first case where it *is* needed is ready to land though, I suppose.

[^1]: Response/request length caps, separate connect/read/idle/overall timeout values, request-body source and response sink (someday, related to #376, for cases where we want to support huge request bodies).

[^2]: This is ignoring the fact that the permissions may be different now, for example even ignoring the next issue this won't work quite right if a delegator of a grant became a superuser.
