### PR TITLE
Restore shared HTTP grants after extension lifecycle tests

### DIFF
--- a/tests/e2e/sql/12_extension_lifecycle.sql
+++ b/tests/e2e/sql/12_extension_lifecycle.sql
@@ -235,8 +235,8 @@ BEGIN
     RAISE NOTICE 'TEST 3c PASSED: admin helpers are not executable by non-superusers by default';
 END $$;
 
--- Re-grant df privileges to the E2E user
-SELECT df.grant_usage('df_e2e_user');
+-- Restore the shared setup's privileges, including HTTP access for later tests.
+SELECT df.grant_usage('df_e2e_user', include_http => true);
 
 -- Test 4: df.grant_usage() does not grant EXECUTE on admin helpers to the target role
 DO $$
@@ -364,6 +364,24 @@ BEGIN
     END IF;
     
     RAISE NOTICE 'Extension restored successfully';
+END $$;
+
+-- Keep the shared setup's HTTP privileges intact for subsequent tests.
+DO $$
+BEGIN
+    IF NOT has_function_privilege(
+        'df_e2e_user', 'df.http(text, text, text, jsonb, integer)', 'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION 'TEST SETUP FAILED: df.http() privilege not restored for df_e2e_user';
+    END IF;
+
+    IF NOT has_function_privilege(
+        'df_e2e_user', 'df.http_multipart(text, text, jsonb, jsonb, integer)', 'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION 'TEST SETUP FAILED: df.http_multipart() privilege not restored for df_e2e_user';
+    END IF;
+
+    RAISE NOTICE 'Shared E2E HTTP privileges restored successfully';
 END $$;
 
 SELECT 'TEST PASSED' AS result;


### PR DESCRIPTION
`12_extension_lifecycle.sql` can pass while leaving `df_e2e_user` unable to use HTTP. The shared setup grants HTTP access, but the lifecycle test drops/recreates the extension and restores privileges with the default `include_http => false`. A later HTTP test then depends on whether setup has run again.

Restore the same HTTP access as `00_setup_playground.sql` in the final re-grant. Add end-of-test assertions for both `df.http()` and `df.http_multipart()` privileges. The existing checks that administrative helpers remain inaccessible still run.

Related to #381. This addresses one reproduced instance of shared state leakage; it does not provide general per-test database isolation.

### Validation

Tested in disposable Docker containers on Linux arm64, using source-built pg_durable v0.2.8 with `http-allow-test-domains`:

| Check | PostgreSQL 17.11 | PostgreSQL 18.6 |
| --- | --- | --- |
| New regression before the grant fix | Fails at the HTTP privilege assertion | Fails at the HTTP privilege assertion |
| `00_setup_playground.sql` and `01_core_primitives.sql` | Pass | Pass |
| Updated `12_extension_lifecycle.sql`, twice in the same database | Pass both times | Pass both times |
| Non-superuser `df.http()` constructor after each lifecycle run, without repairing grants | Pass both times | Pass both times |

SQL files were run with `docker exec "$container" psql -X -U postgres -v ON_ERROR_STOP=1 -f /repo/tests/e2e/sql/<file>`. The constructor probe used `SET SESSION AUTHORIZATION df_e2e_user; SELECT df.http('https://httpbingo.org/get', 'GET');` in a separate connection; it makes no network request.

`cargo fmt -p pg_durable -- --check` and `git diff --check` passed. This changes only the E2E SQL file; the full suite was not run. The local Docker builds used two Cargo jobs, thin LTO, and eight release codegen units.

AI assistance: implemented and validated with Codex.
